### PR TITLE
Clear focus after picking item from pickerview on Android

### DIFF
--- a/src/UraniumUI.Material/Controls/PickerField.cs
+++ b/src/UraniumUI.Material/Controls/PickerField.cs
@@ -58,6 +58,20 @@ public class PickerField : InputField
 		PickerView.SetBinding(PickerView.SelectedIndexProperty, new Binding(nameof(SelectedIndex), source: this));
 		PickerView.SetBinding(PickerView.IsEnabledProperty, new Binding(nameof(IsEnabled), source: this));
 
+		// TODO: Move platform specific codes into separate files.
+#if ANDROID
+		PickerView.HandlerChanged += (s, e) =>
+		{
+			if (PickerView.Handler != null)
+			{
+				var editText = PickerView.Handler.PlatformView as AndroidX.AppCompat.Widget.AppCompatEditText;
+				editText.AfterTextChanged += (_, args) =>
+				{
+					editText.ClearFocus();
+				};
+			}
+		};
+#endif
 #if WINDOWS
 		rootGrid.Add(labelSelectedItem, column: 1);
 #endif


### PR DESCRIPTION
Closes https://github.com/enisn/UraniumUI/issues/83

This seems isn't a proper solution but it's best hiding way to the problem:
![pickerfield-workaround](https://user-images.githubusercontent.com/23705418/200657959-13ea31c8-ae81-4a42-b916-8b64e26bb1fe.gif)
