### PR TITLE
Introduce XML namespaces

### DIFF
--- a/demo/UraniumApp/MainPage.xaml
+++ b/demo/UraniumApp/MainPage.xaml
@@ -2,14 +2,8 @@
 <uranium:UraniumContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
              xmlns:m="clr-namespace:UraniumUI.Icons.MaterialIcons;assembly=UraniumUI.Icons.MaterialIcons"
-             xmlns:uranium="clr-namespace:UraniumUI.Pages;assembly=UraniumUI"
-             xmlns:validation="clr-namespace:InputKit.Shared.Validations;assembly=InputKit.Maui"
-             xmlns:material="clr-namespace:UraniumUI.Material.Attachments;assembly=UraniumUI.Material"
-             xmlns:controls="clr-namespace:UraniumUI.Material.Controls;assembly=UraniumUI.Material"
-             xmlns:input="clr-namespace:InputKit.Shared.Controls;assembly=InputKit.Maui"
-             xmlns:views="clr-namespace:UraniumUI.Views;assembly=UraniumUI"
-             xmlns:t="clr-namespace:UraniumUI.Theming;assembly=UraniumUI"
-             xmlns:u="clr-namespace:UraniumUI;assembly=UraniumUI"
+             xmlns:uranium="http://schemas.microsoft.com/dotnet/2022/maui/uraniumui"
+             xmlns:material="http://schemas.microsoft.com/dotnet/2022/maui/uraniumui/material"
              xmlns:plain="clr-namespace:Plainer.Maui.Controls;assembly=Plainer.Maui"
              x:Class="UraniumApp.MainPage">
 
@@ -19,9 +13,9 @@
             Padding="30"
             VerticalOptions="Center">
 
-            <controls:ButtonView HorizontalOptions="Center">
+            <material:ButtonView HorizontalOptions="Center">
                 <Label Text="Hello, Uranium ☢️" />
-            </controls:ButtonView>
+            </material:ButtonView>
 
         </VerticalStackLayout>
     </ScrollView>

--- a/demo/UraniumApp/Pages/Backdrops/SimpleBackdropPage.xaml
+++ b/demo/UraniumApp/Pages/Backdrops/SimpleBackdropPage.xaml
@@ -2,10 +2,9 @@
 <uranium:UraniumContentPage x:Class="UraniumApp.Pages.Backdrops.SimpleBackdropPage"
              xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
-             xmlns:uranium="clr-namespace:UraniumUI.Pages;assembly=UraniumUI"
+             xmlns:uranium="http://schemas.microsoft.com/dotnet/2022/maui/uraniumui"
              xmlns:m="clr-namespace:UraniumUI.Icons.MaterialIcons;assembly=UraniumUI.Icons.MaterialIcons"
-             xmlns:attachments="clr-namespace:UraniumUI.Material.Attachments;assembly=UraniumUI.Material"
-             xmlns:material="clr-namespace:UraniumUI.Material.Controls;assembly=UraniumUI.Material"
+             xmlns:material="http://schemas.microsoft.com/dotnet/2022/maui/uraniumui/material"
              xmlns:input="clr-namespace:InputKit.Shared.Controls;assembly=InputKit.Maui"
              xmlns:root="clr-namespace:UraniumApp"
              xmlns:local="clr-namespace:UraniumApp.Pages.Backdrops">
@@ -13,11 +12,11 @@
     <root:DemoContent />
 
     <uranium:UraniumContentPage.Attachments>
-        <attachments:BackdropView Title="Filter">
-            <attachments:BackdropView.IconImageSource>
+        <material:BackdropView Title="Filter">
+            <material:BackdropView.IconImageSource>
                 <FontImageSource FontFamily="MaterialRound" Glyph="{x:Static m:MaterialRound.Filter_alt}" Color="{DynamicResource OnPrimary}" />
-            </attachments:BackdropView.IconImageSource>
-            <attachments:BackdropView.Resources>
+            </material:BackdropView.IconImageSource>
+            <material:BackdropView.Resources>
                 <ResourceDictionary>
                     <Style TargetType="Slider" ApplyToDerivedTypes="True">
                         <Setter Property="ThumbColor" Value="{AppThemeBinding Light={StaticResource OnPrimary},Dark= {StaticResource OnBackground}}" />
@@ -27,13 +26,13 @@
                         <Setter Property="BorderColor" Value="{AppThemeBinding Light={StaticResource OnPrimary}, Dark={StaticResource OnPrimaryDark}}" />
                     </Style>
                 </ResourceDictionary>
-            </attachments:BackdropView.Resources>
+            </material:BackdropView.Resources>
             <VerticalStackLayout>
                 <material:CheckBox Text="Include Disabled Items" Type="Filled" />
                 <material:CheckBox Text="Include Deleted Items" Type="Filled" />
                 <material:CheckBox Text="Show all categories" Type="Filled"/>
                 <input:AdvancedSlider Title="Maximum Value" MinValue="0" MaxValue="1200" StepValue="10" MaxValueSuffix="items" />
             </VerticalStackLayout>
-        </attachments:BackdropView>
+        </material:BackdropView>
     </uranium:UraniumContentPage.Attachments>
 </uranium:UraniumContentPage>

--- a/demo/UraniumApp/Pages/BottomSheets/ExpandingBottomSheetPage.xaml
+++ b/demo/UraniumApp/Pages/BottomSheets/ExpandingBottomSheetPage.xaml
@@ -3,8 +3,8 @@
              xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
              xmlns:root="clr-namespace:UraniumApp"
-             xmlns:uranium="clr-namespace:UraniumUI.Pages;assembly=UraniumUI"
-             xmlns:material="clr-namespace:UraniumUI.Material.Attachments;assembly=UraniumUI.Material"
+             xmlns:uranium="http://schemas.microsoft.com/dotnet/2022/maui/uraniumui"
+             xmlns:material="http://schemas.microsoft.com/dotnet/2022/maui/uraniumui/material"
              xmlns:local="clr-namespace:UraniumApp.Pages.BottomSheets">
     <ScrollView>
         <root:DemoContent/>
@@ -20,7 +20,7 @@
                     <Grid.Shadow>
                         <Shadow Brush="Black"
                                 Radius="20"
-                            Opacity="0.2" />
+                                Opacity="0.2" />
                     </Grid.Shadow>
                     <Image Source="tell_it_to_my_heart.jpg" />
 

--- a/demo/UraniumApp/Pages/BottomSheets/RegularBottomSheetPage.xaml
+++ b/demo/UraniumApp/Pages/BottomSheets/RegularBottomSheetPage.xaml
@@ -3,8 +3,8 @@
              xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
              xmlns:root="clr-namespace:UraniumApp"
-             xmlns:uranium="clr-namespace:UraniumUI.Pages;assembly=UraniumUI"
-             xmlns:material="clr-namespace:UraniumUI.Material.Attachments;assembly=UraniumUI.Material"
+             xmlns:uranium="http://schemas.microsoft.com/dotnet/2022/maui/uraniumui"
+             xmlns:material="http://schemas.microsoft.com/dotnet/2022/maui/uraniumui/material"
              xmlns:local="clr-namespace:UraniumApp.Pages.BottomSheets">
     <ScrollView>
         <root:DemoContent />

--- a/demo/UraniumApp/Pages/CheckBoxesPage.xaml
+++ b/demo/UraniumApp/Pages/CheckBoxesPage.xaml
@@ -1,8 +1,8 @@
-<?xml version="1.0" encoding="UTF-8" ?>
+﻿<?xml version="1.0" encoding="UTF-8" ?>
 <ContentPage x:Class="UraniumApp.Pages.CheckBoxesPage"
              xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
-             xmlns:material="clr-namespace:UraniumUI.Material.Controls;assembly=UraniumUI.Material"
+             xmlns:material="http://schemas.microsoft.com/dotnet/2022/maui/uraniumui/material"
              xmlns:local="clr-namespace:UraniumApp.Pages">
     <ContentPage.Content>
         <StackLayout MaximumWidthRequest="400" Margin="20" Spacing="15">

--- a/demo/UraniumApp/Pages/DataGrids/CustomDataGridPage.xaml
+++ b/demo/UraniumApp/Pages/DataGrids/CustomDataGridPage.xaml
@@ -1,10 +1,10 @@
-<?xml version="1.0" encoding="UTF-8" ?>
+﻿<?xml version="1.0" encoding="UTF-8" ?>
 <ContentPage x:Class="UraniumApp.Pages.DataGrids.CustomDataGridPage"
              xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
              xmlns:local="clr-namespace:UraniumApp.Pages.DataGrids"
              xmlns:m="clr-namespace:UraniumUI.Icons.MaterialIcons;assembly=UraniumUI.Icons.MaterialIcons"
-             xmlns:material="clr-namespace:UraniumUI.Material.Controls;assembly=UraniumUI.Material"
+             xmlns:material="http://schemas.microsoft.com/dotnet/2022/maui/uraniumui/material"
              x:Name="page">
     <ContentPage.BindingContext>
         <local:CustomDataGridPageViewModel />

--- a/demo/UraniumApp/Pages/DataGrids/SelectableDataGridPage.xaml
+++ b/demo/UraniumApp/Pages/DataGrids/SelectableDataGridPage.xaml
@@ -4,7 +4,7 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
              xmlns:m="clr-namespace:UraniumUI.Icons.MaterialIcons;assembly=UraniumUI.Icons.MaterialIcons"
              xmlns:local="clr-namespace:UraniumApp.Pages.DataGrids"
-             xmlns:material="clr-namespace:UraniumUI.Material.Controls;assembly=UraniumUI.Material">
+             xmlns:material="http://schemas.microsoft.com/dotnet/2022/maui/uraniumui/material">
     <ContentPage.BindingContext>
         <local:SelectableDataGridPageViewModel />
     </ContentPage.BindingContext>

--- a/demo/UraniumApp/Pages/DataGrids/SimpleCustomTitleDataGridPage.xaml
+++ b/demo/UraniumApp/Pages/DataGrids/SimpleCustomTitleDataGridPage.xaml
@@ -1,9 +1,9 @@
-<?xml version="1.0" encoding="UTF-8" ?>
+﻿<?xml version="1.0" encoding="UTF-8" ?>
 <ContentPage x:Class="UraniumApp.Pages.DataGrids.SimpleCustomTitleDataGridPage"
              xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
              xmlns:m="clr-namespace:UraniumUI.Icons.MaterialIcons;assembly=UraniumUI.Icons.MaterialIcons"
-             xmlns:material="clr-namespace:UraniumUI.Material.Controls;assembly=UraniumUI.Material"
+             xmlns:material="http://schemas.microsoft.com/dotnet/2022/maui/uraniumui/material"
              xmlns:local="clr-namespace:UraniumApp.Pages.DataGrids">
     <ContentPage.BindingContext>
         <local:SimpleDataGridPageViewModel />

--- a/demo/UraniumApp/Pages/DataGrids/SimpleDataGridPage.xaml
+++ b/demo/UraniumApp/Pages/DataGrids/SimpleDataGridPage.xaml
@@ -1,8 +1,8 @@
-<?xml version="1.0" encoding="UTF-8" ?>
+﻿<?xml version="1.0" encoding="UTF-8" ?>
 <ContentPage x:Class="UraniumApp.Pages.DataGrids.SimpleDataGridPage"
              xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
-             xmlns:material="clr-namespace:UraniumUI.Material.Controls;assembly=UraniumUI.Material"
+             xmlns:material="http://schemas.microsoft.com/dotnet/2022/maui/uraniumui/material"
              xmlns:local="clr-namespace:UraniumApp.Pages.DataGrids">
     <ContentPage.BindingContext>
         <local:SimpleDataGridPageViewModel />

--- a/demo/UraniumApp/Pages/DialogsPage.xaml
+++ b/demo/UraniumApp/Pages/DialogsPage.xaml
@@ -3,7 +3,7 @@
              xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
              xmlns:input="clr-namespace:InputKit.Shared.Controls;assembly=InputKit.Maui"
-             xmlns:material="clr-namespace:UraniumUI.Material.Controls;assembly=UraniumUI.Material"
+             xmlns:material="http://schemas.microsoft.com/dotnet/2022/maui/uraniumui/material"
              xmlns:local="clr-namespace:UraniumApp.Pages">
     <ContentPage.Resources>
         <Style TargetType="Entry">

--- a/demo/UraniumApp/Pages/InputFieldsPage.xaml
+++ b/demo/UraniumApp/Pages/InputFieldsPage.xaml
@@ -1,10 +1,10 @@
-<?xml version="1.0" encoding="UTF-8" ?>
+﻿<?xml version="1.0" encoding="UTF-8" ?>
 <ContentPage x:Class="UraniumApp.Pages.InputFieldsPage"
              xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
              xmlns:input="clr-namespace:InputKit.Shared.Controls;assembly=InputKit.Maui"
              xmlns:validation="clr-namespace:InputKit.Shared.Validations;assembly=InputKit.Maui"
-             xmlns:material="clr-namespace:UraniumUI.Material.Controls;assembly=UraniumUI.Material"
+             xmlns:material="http://schemas.microsoft.com/dotnet/2022/maui/uraniumui/material"
              xmlns:m="clr-namespace:UraniumUI.Icons.MaterialIcons;assembly=UraniumUI.Icons.MaterialIcons"
              xmlns:local="clr-namespace:UraniumApp.Pages">
     <ContentPage.Content>

--- a/demo/UraniumApp/Pages/RadioButtonsPage.xaml
+++ b/demo/UraniumApp/Pages/RadioButtonsPage.xaml
@@ -1,8 +1,8 @@
-<?xml version="1.0" encoding="UTF-8" ?>
+﻿<?xml version="1.0" encoding="UTF-8" ?>
 <ContentPage x:Class="UraniumApp.Pages.RadioButtonsPage"
              xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
-             xmlns:material="clr-namespace:UraniumUI.Material.Controls;assembly=UraniumUI.Material"
+             xmlns:material="http://schemas.microsoft.com/dotnet/2022/maui/uraniumui/material"
              xmlns:local="clr-namespace:UraniumApp.Pages">
     <ContentPage.Content>
         <StackLayout MaximumWidthRequest="400" Margin="20">

--- a/demo/UraniumApp/Pages/TabViews/CustomTabItemTabView.xaml
+++ b/demo/UraniumApp/Pages/TabViews/CustomTabItemTabView.xaml
@@ -3,7 +3,7 @@
              xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
              xmlns:m="clr-namespace:UraniumUI.Icons.MaterialIcons;assembly=UraniumUI.Icons.MaterialIcons"
-             xmlns:material="clr-namespace:UraniumUI.Material.Controls;assembly=UraniumUI.Material"
+             xmlns:material="http://schemas.microsoft.com/dotnet/2022/maui/uraniumui/material"
              xmlns:root="clr-namespace:UraniumApp"
              xmlns:local="clr-namespace:UraniumApp.Pages.TabViews">
     <ContentPage.Resources>

--- a/demo/UraniumApp/Pages/TabViews/TabViewPage.xaml
+++ b/demo/UraniumApp/Pages/TabViews/TabViewPage.xaml
@@ -2,7 +2,7 @@
 <ContentPage x:Class="UraniumApp.Pages.TabViews.TabViewPage"
              xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
-             xmlns:material="clr-namespace:UraniumUI.Material.Controls;assembly=UraniumUI.Material"
+             xmlns:material="http://schemas.microsoft.com/dotnet/2022/maui/uraniumui/material"
              xmlns:input="clr-namespace:InputKit.Shared.Controls;assembly=InputKit.Maui"
              xmlns:m="clr-namespace:UraniumUI.Icons.MaterialIcons;assembly=UraniumUI.Icons.MaterialIcons"
              xmlns:root="clr-namespace:UraniumApp"

--- a/demo/UraniumApp/Pages/TabViews/WebTabViewPage.xaml
+++ b/demo/UraniumApp/Pages/TabViews/WebTabViewPage.xaml
@@ -1,9 +1,9 @@
-<?xml version="1.0" encoding="UTF-8" ?>
+﻿<?xml version="1.0" encoding="UTF-8" ?>
 <ContentPage x:Class="UraniumApp.Pages.TabViews.WebTabViewPage"
              xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
              xmlns:vm="clr-namespace:UraniumApp.ViewModels.TabViews"
-             xmlns:material="clr-namespace:UraniumUI.Material.Controls;assembly=UraniumUI.Material"
+             xmlns:material="http://schemas.microsoft.com/dotnet/2022/maui/uraniumui/material"
              xmlns:local="clr-namespace:UraniumApp.Pages.TabViews">
 
     <ContentPage.BindingContext>

--- a/demo/UraniumApp/Pages/TreeViews/TreeViewFileSystemPage.xaml
+++ b/demo/UraniumApp/Pages/TreeViews/TreeViewFileSystemPage.xaml
@@ -1,8 +1,8 @@
-<?xml version="1.0" encoding="UTF-8" ?>
+﻿<?xml version="1.0" encoding="UTF-8" ?>
 <ContentPage x:Class="UraniumApp.Pages.TreeViews.TreeViewFileSystemPage"
              xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
-             xmlns:material="clr-namespace:UraniumUI.Material.Controls;assembly=UraniumUI.Material"
+             xmlns:material="http://schemas.microsoft.com/dotnet/2022/maui/uraniumui/material"
              xmlns:m="clr-namespace:UraniumUI.Icons.MaterialIcons;assembly=UraniumUI.Icons.MaterialIcons"
              xmlns:vm="clr-namespace:UraniumApp.ViewModels"
              xmlns:local="clr-namespace:UraniumApp.Pages.TreeViews">

--- a/demo/UraniumApp/Pages/TreeViews/TreeViewPage.xaml
+++ b/demo/UraniumApp/Pages/TreeViews/TreeViewPage.xaml
@@ -1,8 +1,8 @@
-<?xml version="1.0" encoding="UTF-8" ?>
+﻿<?xml version="1.0" encoding="UTF-8" ?>
 <ContentPage x:Class="UraniumApp.Pages.TreeViews.TreeViewPage"
              xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
-             xmlns:material="clr-namespace:UraniumUI.Material.Controls;assembly=UraniumUI.Material"
+             xmlns:material="http://schemas.microsoft.com/dotnet/2022/maui/uraniumui/material"
              xmlns:vm="clr-namespace:UraniumApp.ViewModels"
              xmlns:m="clr-namespace:UraniumUI.Icons.MaterialIcons;assembly=UraniumUI.Icons.MaterialIcons"
              xmlns:root="clr-namespace:UraniumApp"

--- a/demo/UraniumApp/Pages/ValidationsPage.xaml
+++ b/demo/UraniumApp/Pages/ValidationsPage.xaml
@@ -1,8 +1,8 @@
-<?xml version="1.0" encoding="UTF-8" ?>
+﻿<?xml version="1.0" encoding="UTF-8" ?>
 <ContentPage x:Class="UraniumApp.Pages.ValidationsPage"
              xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+             xmlns:material="http://schemas.microsoft.com/dotnet/2022/maui/uraniumui/material"
              xmlns:input="clr-namespace:InputKit.Shared.Controls;assembly=InputKit.Maui"
-             xmlns:material="clr-namespace:UraniumUI.Material.Controls;assembly=UraniumUI.Material"
              xmlns:validation="clr-namespace:InputKit.Shared.Validations;assembly=InputKit.Maui"
              xmlns:v="clr-namespace:UraniumUI.Validations;assembly=UraniumUI.Validations.DataAnnotations"
              xmlns:vm="clr-namespace:UraniumApp.ViewModels"

--- a/docs/en/Getting-Started.md
+++ b/docs/en/Getting-Started.md
@@ -53,14 +53,14 @@ Also, templates has `ide.host.json` implementation that allows to create a new p
 
 
 - Go to `App.xaml` and add `ColorResource` & `StyleResource` of **Material**
-    - Define following xml namespace: `xmlns:material="clr-namespace:UraniumUI.Material.Resources;assembly=UraniumUI.Material"`
+    - Define following xml namespace: `xmlns:material="http://schemas.microsoft.com/dotnet/2022/maui/uraniumui/material`
     - Then define `ColorResource` and `StyleResource` into **MergedDictionaries**
         ```xml
         <?xml version = "1.0" encoding = "UTF-8" ?>
         <Application xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
                     xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
                     xmlns:local="clr-namespace:App1"
-                    xmlns:material="clr-namespace:UraniumUI.Material.Resources;assembly=UraniumUI.Material"
+                    xmlns:material="http://schemas.microsoft.com/dotnet/2022/maui/uraniumui/material"
                     x:Class="App1.App">
             <Application.Resources>
                 <ResourceDictionary>

--- a/docs/en/infrastructure/UraniumContentPage.md
+++ b/docs/en/infrastructure/UraniumContentPage.md
@@ -33,7 +33,7 @@ dotnet new uraniumcontentpage -n MyPage -na MyNamespace
     <uranium:UraniumContentPage x:Class="App1.MainPage"
                 xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
                 xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
-                xmlns:uranium="clr-namespace:UraniumUI.Pages;assembly=UraniumUI"
+                xmlns:uranium="http://schemas.microsoft.com/dotnet/2022/maui/uraniumui"
                 xmlns:local="clr-namespace:App1">
 
         <!-- Content here -->
@@ -62,7 +62,7 @@ Attachments aren't same layer with page content and they will automatically rend
     <uranium:UraniumContentPage x:Class="App1.MainPage"
                 xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
                 xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
-                xmlns:uranium="clr-namespace:UraniumUI.Pages;assembly=UraniumUI"
+                xmlns:uranium="http://schemas.microsoft.com/dotnet/2022/maui/uraniumui"
                 xmlns:local="clr-namespace:App1">
 
         <!-- Content here -->
@@ -118,7 +118,7 @@ public class FAB : ImageButton, IPageAttachment
     <uranium:UraniumContentPage x:Class="App1.MainPage"
                 xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
                 xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
-                xmlns:uranium="clr-namespace:UraniumUI.Pages;assembly=UraniumUI"
+                xmlns:uranium="http://schemas.microsoft.com/dotnet/2022/maui/uraniumui"
                 xmlns:local="clr-namespace:App1">
 
         <!-- Content here -->

--- a/docs/en/themes/material/ButtonView.md
+++ b/docs/en/themes/material/ButtonView.md
@@ -8,7 +8,7 @@ ButtonView included in **Material Theme**.
 `ButtonView` is defined in `UraniumUI.Material.Controls` namespace. You can add it to your XAML like this:
 
 ```xml
-xmlns:material="clr-namespace:UraniumUI.Material.Controls;assembly=UraniumUI.Material"
+xmlns:material="http://schemas.microsoft.com/dotnet/2022/maui/uraniumui/material"
 ```
 
 Then you can use it like this:

--- a/docs/en/themes/material/CheckBox.md
+++ b/docs/en/themes/material/CheckBox.md
@@ -15,7 +15,7 @@ RadioButtons should be grouped together in a RadioButtonGroupView. Otherwise, th
 RadioButton is defined in `UraniumUI.Material.Controls` namespace. You can use it like this:
 
 ```xml
-xmlns:material="clr-namespace:UraniumUI.Material.Controls;assembly=UraniumUI.Material"
+xmlns:material="http://schemas.microsoft.com/dotnet/2022/maui/uraniumui/material"
 ```
 
 ```xml

--- a/docs/en/themes/material/Elevation.md
+++ b/docs/en/themes/material/Elevation.md
@@ -12,7 +12,7 @@ Elevation styles come from `StyleResource` from `UraniumUI.Material.Resources` n
 <Application xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
              xmlns:local="clr-namespace:MyCompany.MyProject"
-             xmlns:material="clr-namespace:UraniumUI.Material.Resources;assembly=UraniumUI.Material"
+             xmlns:material="http://schemas.microsoft.com/dotnet/2022/maui/uraniumui/material
              x:Class="MyCompany.MyProject.App">
     <Application.Resources>
         <ResourceDictionary>

--- a/docs/en/themes/material/RadioButton.md
+++ b/docs/en/themes/material/RadioButton.md
@@ -15,7 +15,7 @@ CheckBox is defined in `UraniumUI.Material.Controls` namespace. You can use it l
 
 
 ```xml
-xmlns:material="clr-namespace:UraniumUI.Material.Controls;assembly=UraniumUI.Material"
+xmlns:material="http://schemas.microsoft.com/dotnet/2022/maui/uraniumui/material"
 ```
 
 ```xml

--- a/docs/en/themes/material/components/Backdrop.md
+++ b/docs/en/themes/material/components/Backdrop.md
@@ -16,7 +16,7 @@ Backdrop is an [attachment](../../../infrastructure/UraniumContentPage.md#attach
 Backdrop is included in `UraniumUI.Material.Attachments` namespace. Before starting to use Backdrop, you should add material namespace to your XAML file.
 
 ```
-xmlns:material="clr-namespace:UraniumUI.Material.Attachments;assembly=UraniumUI.Material"
+xmlns:material="http://schemas.microsoft.com/dotnet/2022/maui/uraniumui/material"
 ```
 
 To use a Backdrop, you should add a `Backdrop` to `UraniumContentPage.Attachments`. B
@@ -27,9 +27,9 @@ Backdrop has `Title` and `IconImageSource` property and one of them should be se
 <uranium:UraniumContentPage x:Class="App1.MainPage"
             xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
-            xmlns:uranium="clr-namespace:UraniumUI.Pages;assembly=UraniumUI"
+            xmlns:uranium="http://schemas.microsoft.com/dotnet/2022/maui/uraniumui"
             xmlns:input="clr-namespace:InputKit.Shared.Controls;assembly=InputKit.Maui"
-            xmlns:material="clr-namespace:UraniumUI.Material.Attachments;assembly=UraniumUI.Material">
+            xmlns:material="http://schemas.microsoft.com/dotnet/2022/maui/uraniumui/material">
 
     <!-- Content here -->
 
@@ -60,8 +60,8 @@ Both of `Title` and `IconImageSource` is used to add a toolbaritem. If you set `
 <uranium:UraniumContentPage x:Class="App1.MainPage"
             xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
-            xmlns:uranium="clr-namespace:UraniumUI.Pages;assembly=UraniumUI"
-            xmlns:material="clr-namespace:UraniumUI.Material.Attachments;assembly=UraniumUI.Material">
+            xmlns:uranium="http://schemas.microsoft.com/dotnet/2022/maui/uraniumui"
+            xmlns:material="http://schemas.microsoft.com/dotnet/2022/maui/uraniumui/material">
 
     <!-- Content here -->
 

--- a/docs/en/themes/material/components/BottomSheet.md
+++ b/docs/en/themes/material/components/BottomSheet.md
@@ -16,7 +16,7 @@ BottomSheet has a default regular anchor that user can pull it up and down. But,
 
 Before starting to use BottomSheet, you should add material namespace to your XAML file.
 
-    `xmlns:material="clr-namespace:UraniumUI.Material.Attachments;assembly=UraniumUI.Material"`
+    `xmlns:material="http://schemas.microsoft.com/dotnet/2022/maui/uraniumui/material"`
 
 To use a regular bottom sheet, you should add a `BottomSheet` to `UraniumContentPage.Attachments`.
 
@@ -24,8 +24,8 @@ To use a regular bottom sheet, you should add a `BottomSheet` to `UraniumContent
 <uranium:UraniumContentPage x:Class="App1.MainPage"
             xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
-            xmlns:uranium="clr-namespace:UraniumUI.Pages;assembly=UraniumUI"
-            xmlns:material="clr-namespace:UraniumUI.Material.Attachments;assembly=UraniumUI.Material">
+            xmlns:uranium="http://schemas.microsoft.com/dotnet/2022/maui/uraniumui"
+            xmlns:material="http://schemas.microsoft.com/dotnet/2022/maui/uraniumui/material>
 
     <!-- Content here -->
 
@@ -61,8 +61,8 @@ To use a custom header bottom sheet, you should add a `BottomSheet` to `UraniumC
 <uranium:UraniumContentPage x:Class="App1.MainPage"
             xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
-            xmlns:uranium="clr-namespace:UraniumUI.Pages;assembly=UraniumUI"
-            xmlns:material="clr-namespace:UraniumUI.Material.Attachments;assembly=UraniumUI.Material">
+            xmlns:uranium="http://schemas.microsoft.com/dotnet/2022/maui/uraniumui"
+            xmlns:material="http://schemas.microsoft.com/dotnet/2022/maui/uraniumui/material">
 
     <!-- Content here -->
 
@@ -86,8 +86,8 @@ To use a custom header bottom sheet, you should add a `BottomSheet` to `UraniumC
 <uranium:UraniumContentPage x:Class="App1.MainPage"
             xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
-            xmlns:uranium="clr-namespace:UraniumUI.Pages;assembly=UraniumUI"
-            xmlns:material="clr-namespace:UraniumUI.Material.Attachments;assembly=UraniumUI.Material">
+            xmlns:uranium="http://schemas.microsoft.com/dotnet/2022/maui/uraniumui"
+            xmlns:material="http://schemas.microsoft.com/dotnet/2022/maui/uraniumui/material">
 
     <!-- Content here -->
     <Button Text="Show" OnClick="ShowBottomSheet" />

--- a/docs/en/themes/material/components/DatePickerField.md
+++ b/docs/en/themes/material/components/DatePickerField.md
@@ -8,7 +8,7 @@ DatePickerField is a control that allows users to select a date. It is a wrapper
 DatePickerField is included in the `UraniumUI.Material.Controls` namespace. You should add it to your XAML like this:
 
 ```xml
-xmlns:material="clr-namespace:UraniumUI.Material.Controls;assembly=UraniumUI.Material"
+xmlns:material="http://schemas.microsoft.com/dotnet/2022/maui/uraniumui/material"
 ```
 
 Then you can use it like this:

--- a/docs/en/themes/material/components/PickerField.md
+++ b/docs/en/themes/material/components/PickerField.md
@@ -5,7 +5,7 @@ PickerField is a control that allows user to select a value from a list of optio
 PickerField is included in the `UraniumUI.Material.Controls` namespace. You should add it to your XAML like this:
 
 ```xml
-xmlns:material="clr-namespace:UraniumUI.Material.Controls;assembly=UraniumUI.Material"
+xmlns:material="http://schemas.microsoft.com/dotnet/2022/maui/uraniumui/material"
 ```
 
 Then you can use it like this:

--- a/docs/en/themes/material/components/TabView.md
+++ b/docs/en/themes/material/components/TabView.md
@@ -8,7 +8,7 @@ TabView is a component that allows you to switch between different views by sele
 `TabView` is defined in `UraniumUI.Material.Controls` namespace. You can add it to your XAML like this:
 
 ```xml
-xmlns:material="clr-namespace:UraniumUI.Material.Controls;assembly=UraniumUI.Material"
+xmlns:material="http://schemas.microsoft.com/dotnet/2022/maui/uraniumui/material"
 ```
 
 Then you can use it like this:

--- a/docs/en/themes/material/components/TextField.md
+++ b/docs/en/themes/material/components/TextField.md
@@ -6,7 +6,7 @@ Text fields let users enter and edit text. It is an abstraction on MAUI Level fo
 TextField is included in the `UraniumUI.Material.Controls` namespace. You should add it to your XAML like this:
 
 ```xml
-xmlns:material="clr-namespace:UraniumUI.Material.Controls;assembly=UraniumUI.Material"
+xmlns:material="http://schemas.microsoft.com/dotnet/2022/maui/uraniumui/material"
 ```
 
 Then you can use it like this:

--- a/docs/en/themes/material/components/TimePickerField.md
+++ b/docs/en/themes/material/components/TimePickerField.md
@@ -8,7 +8,7 @@ TimePickerField is a control that allows users to select a time. It is a wrapper
 TimePickerField is included in the `UraniumUI.Material.Controls` namespace. You should add it to your XAML like this:
 
 ```xml
-xmlns:material="clr-namespace:UraniumUI.Material.Controls;assembly=UraniumUI.Material"
+xmlns:material="http://schemas.microsoft.com/dotnet/2022/maui/uraniumui/material"
 ```
 
 Then you can use it like this:

--- a/docs/en/themes/material/components/TreeView.md
+++ b/docs/en/themes/material/components/TreeView.md
@@ -5,7 +5,7 @@ TreeView is a component that displays a hierarchical list of items. It's a MAUI 
 TreeView is included in the `UraniumUI.Material.Controls` namespace. You should add it to your XAML like this:
 
 ```xml
-xmlns:material="clr-namespace:UraniumUI.Material.Controls;assembly=UraniumUI.Material"
+xmlns:material="http://schemas.microsoft.com/dotnet/2022/maui/uraniumui/material"
 ```
 
 Then you can use it like this:

--- a/docs/en/theming/ColorSystem.md
+++ b/docs/en/theming/ColorSystem.md
@@ -4,7 +4,7 @@ Uranium UI has a color system that allows you to use colors in a more flexible w
 Uranium Core provides a base color palette that can be used in your application. Each theme can provide their own colors. You can also use your own colors.
 
 ## Configuration
-You should configure default Theme resources in your `App.xaml`. Default resources are included in `UraniumUI.Resources` namespace, it can be defined `xmlns:u="clr-namespace:UraniumUI.Resources;assembly=UraniumUI"` as xml namespace.
+You should configure default Theme resources in your `App.xaml`. Default resources are included in `UraniumUI.Resources` namespace, it can be defined `xmlns:u="http://schemas.microsoft.com/dotnet/2022/maui/uraniumui"` as xml namespace.
 
 You can either use only `ColorResource` or you can use `StyleResource` to get all theme resources. 
 
@@ -16,7 +16,7 @@ You can either use only `ColorResource` or you can use `StyleResource` to get al
 <Application xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
              xmlns:local="clr-namespace:App1"
-             xmlns:u="clr-namespace:UraniumUI.Resources;assembly=UraniumUI"
+             xmlns:u="http://schemas.microsoft.com/dotnet/2022/maui/uraniumui"
              x:Class="App1.App">
     <Application.Resources>
         <ResourceDictionary>

--- a/src/UraniumUI.Icons.MaterialIcons/UraniumUI.Icons.MaterialIcons.csproj
+++ b/src/UraniumUI.Icons.MaterialIcons/UraniumUI.Icons.MaterialIcons.csproj
@@ -23,6 +23,9 @@
 		<SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'tizen'">6.5</SupportedOSPlatformVersion>
 	</PropertyGroup>
 
+	<PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|net7.0-ios|AnyCPU'">
+	  <CreatePackage>false</CreatePackage>
+	</PropertyGroup>
   <ItemGroup>
     <EmbeddedResource Include="Resources\Fonts\*" />
   </ItemGroup>

--- a/src/UraniumUI.Material/AssemblyInfo.cs
+++ b/src/UraniumUI.Material/AssemblyInfo.cs
@@ -1,0 +1,13 @@
+﻿[assembly: XmlnsDefinition(Constants.XamlNamespace, Constants.NamespacePrefix + nameof(UraniumUI.Material.Attachments))]
+[assembly: XmlnsDefinition(Constants.XamlNamespace, Constants.NamespacePrefix + nameof(UraniumUI.Material.Controls))]
+[assembly: XmlnsDefinition(Constants.XamlNamespace, Constants.NamespacePrefix + nameof(UraniumUI.Material.Resources))]
+
+[assembly: Microsoft.Maui.Controls.XmlnsPrefix(Constants.XamlNamespace, "material")]
+
+
+class Constants
+{
+    public const string XamlNamespace = "http://schemas.microsoft.com/dotnet/2022/maui/uraniumui/material";
+
+    public const string NamespacePrefix = $"{nameof(UraniumUI)}.{nameof(UraniumUI.Material)}.";
+}

--- a/src/UraniumUI/AssemblyInfo.cs
+++ b/src/UraniumUI/AssemblyInfo.cs
@@ -1,0 +1,17 @@
+﻿using System;
+
+[assembly: XmlnsDefinition(Constants.XamlNamespace, Constants.NamespacePrefix + nameof(UraniumUI.Pages))]
+[assembly: XmlnsDefinition(Constants.XamlNamespace, Constants.NamespacePrefix + nameof(UraniumUI.Resources))]
+[assembly: XmlnsDefinition(Constants.XamlNamespace, Constants.NamespacePrefix + nameof(UraniumUI.Theming))]
+[assembly: XmlnsDefinition(Constants.XamlNamespace, Constants.NamespacePrefix + nameof(UraniumUI.Triggers))]
+[assembly: XmlnsDefinition(Constants.XamlNamespace, Constants.NamespacePrefix + nameof(UraniumUI.Views))]
+
+[assembly: Microsoft.Maui.Controls.XmlnsPrefix(Constants.XamlNamespace, "uranium")]
+
+
+class Constants
+{
+    public const string XamlNamespace = "http://schemas.microsoft.com/dotnet/2022/maui/uraniumui";
+
+    public const string NamespacePrefix = $"{nameof(UraniumUI)}.";
+}


### PR DESCRIPTION
A single namespace declaration is enough for each assembly.

For **UraniumUI** assembly:
```xml
xmlns:uranium="http://schemas.microsoft.com/dotnet/2022/maui/uraniumui"
```

For **UraniumUI.Material** assembly:
```xml
xmlns:material="http://schemas.microsoft.com/dotnet/2022/maui/uraniumui/material"
```