### PR TITLE
Update Getting-Started.md

### DIFF
--- a/docs/en/Getting-Started.md
+++ b/docs/en/Getting-Started.md
@@ -45,14 +45,7 @@ Also, templates has `ide.host.json` implementation that allows to create a new p
     ```csharp
     .UseUraniumUI()
     .UseUraniumUIMaterial() // 👈 Don't forget these two lines.
-    
-    .ConfigureMauiHandlers(handlers =>
-    {
-        handlers.AddUraniumUIHandlers(); // 👈 This line should be added.
-    });
     ```
-
-
 
 
 - Go to `App.xaml` and add `ColorResource` & `StyleResource` of **Material**

--- a/docs/en/Getting-Started.md
+++ b/docs/en/Getting-Started.md
@@ -43,6 +43,9 @@ Also, templates has `ide.host.json` implementation that allows to create a new p
 - Go to `MauiProgram.cs` and add UraniumUI Handlers
 
     ```csharp
+    .UseUraniumUI()
+    .UseUraniumUIMaterial() // 👈 Don't forget these two lines.
+    
     .ConfigureMauiHandlers(handlers =>
     {
         handlers.AddUraniumUIHandlers(); // 👈 This line should be added.


### PR DESCRIPTION
In line 43 of this article, users are reminded to modify the 'MauiProgram.cs' content with two key lines missing. This will cause a subsequent error: material:ColorResource not found in xmlns `http://schemas.enisn-projects.io/dotnet/maui/uraniumui/material`