### PR TITLE
TextField & EditorField `IsReadOnly` fix

### DIFF
--- a/demo/UraniumApp/AppShell.xaml
+++ b/demo/UraniumApp/AppShell.xaml
@@ -110,6 +110,7 @@
 
     <FlyoutItem FlyoutDisplayOptions="AsMultipleItems" Title="InputFields">
         <ShellContent Title="TextField" ContentTemplate="{DataTemplate inputFields:TextFieldPage}" Icon="{FontImageSource Glyph={x:Static m:MaterialOutlined.Short_text}, FontFamily=MaterialOutlined, Color={AppThemeBinding {StaticResource Primary}, Dark={StaticResource PrimaryDark}}}"/>
+        <ShellContent Title="EditorField" ContentTemplate="{DataTemplate inputFields:EditorFieldPage}" Icon="{FontImageSource Glyph={x:Static m:MaterialOutlined.Wrap_text}, FontFamily=MaterialOutlined, Color={AppThemeBinding {StaticResource Primary}, Dark={StaticResource PrimaryDark}}}"/>
         <ShellContent Title="PickerField" ContentTemplate="{DataTemplate inputFields:PickerFieldPage}" Icon="{FontImageSource Glyph={x:Static m:MaterialOutlined.Arrow_drop_down}, FontFamily=MaterialOutlined, Color={AppThemeBinding {StaticResource Primary}, Dark={StaticResource PrimaryDark}}}"/>
         <ShellContent Title="DatePickerField" ContentTemplate="{DataTemplate inputFields:DatePickerFieldPage}" Icon="{FontImageSource Glyph={x:Static m:MaterialOutlined.Calendar_month}, FontFamily=MaterialOutlined, Color={AppThemeBinding {StaticResource Primary}, Dark={StaticResource PrimaryDark}}}"/>
         <ShellContent Title="TimePickerField" ContentTemplate="{DataTemplate inputFields:TimePickerFieldPage}" Icon="{FontImageSource Glyph={x:Static m:MaterialOutlined.Access_alarm}, FontFamily=MaterialOutlined, Color={AppThemeBinding {StaticResource Primary}, Dark={StaticResource PrimaryDark}}}"/>

--- a/demo/UraniumApp/Pages/InputFields/EditorFieldPage.xaml
+++ b/demo/UraniumApp/Pages/InputFields/EditorFieldPage.xaml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             xmlns:uranium="http://schemas.enisn-projects.io/dotnet/maui/uraniumui"
+             xmlns:material="http://schemas.enisn-projects.io/dotnet/maui/uraniumui/material"
+             xmlns:root="clr-namespace:UraniumApp"
+             x:Class="UraniumApp.Pages.InputFields.EditorFieldPage"
+             Title="TextField">
+    <Grid Padding="30" RowDefinitions="Auto,*" RowSpacing="30" MaximumWidthRequest="400">
+
+        <material:EditorField x:Name="ref" Title="Name" Icon="{FontImageSource Glyph={x:Static uranium:MaterialTwoTone.Person_2}, FontFamily=MaterialTwoTone}"/>
+
+
+        <root:PropertyEditorView Grid.Row="1"
+            Hierarchical="True"
+            HierarchyLimitType="{x:Type material:InputField}"
+            Value="{Binding ., Source={x:Reference ref}}" />
+    </Grid>
+</ContentPage>

--- a/demo/UraniumApp/Pages/InputFields/EditorFieldPage.xaml.cs
+++ b/demo/UraniumApp/Pages/InputFields/EditorFieldPage.xaml.cs
@@ -1,0 +1,9 @@
+namespace UraniumApp.Pages.InputFields;
+
+public partial class EditorFieldPage : ContentPage
+{
+	public EditorFieldPage()
+	{
+		InitializeComponent();
+	}
+}

--- a/demo/UraniumApp/UraniumApp.csproj
+++ b/demo/UraniumApp/UraniumApp.csproj
@@ -72,20 +72,5 @@
 	    <Generator>MSBuild:Compile</Generator>
 	  </MauiXaml>
 	</ItemGroup>
-  
-	<ItemGroup>
-	  <Compile Update="Pages\InputFields\AutoCompleteTextFieldPage.xaml.cs">
-	    <DependentUpon>AutoCompleteTextFieldPage.xaml</DependentUpon>
-	  </Compile>
-	  <Compile Update="Pages\InputFields\TimePickerFieldPage.xaml.cs">
-	    <DependentUpon>TimePickerFieldPage.xaml</DependentUpon>
-	  </Compile>
-	  <Compile Update="Pages\InputFields\DatePickerFieldPage.xaml.cs">
-	    <DependentUpon>DatePickerFieldPage.xaml</DependentUpon>
-	  </Compile>
-	  <Compile Update="Pages\InputFields\PickerFieldPage.xaml.cs">
-	    <DependentUpon>PickerFieldPage.xaml</DependentUpon>
-	  </Compile>
-	</ItemGroup>
 
 </Project>

--- a/src/UraniumUI.Material/Controls/EditorField.BindableProperties.cs
+++ b/src/UraniumUI.Material/Controls/EditorField.BindableProperties.cs
@@ -1,10 +1,5 @@
 ﻿using Microsoft.Maui.Converters;
-using System;
-using System.Collections.Generic;
 using System.ComponentModel;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using UraniumUI.Resources;
 
 namespace UraniumUI.Material.Controls;
@@ -94,10 +89,10 @@ public partial class EditorField
         typeof(EditorField),
         propertyChanged: (bindable, oldValue, newValue) => (bindable as EditorField).EditorView.MaxLength = (int)newValue);
     
-    public bool IsReadonly { get => (bool)GetValue(IsReadonlyProperty); set => SetValue(IsReadonlyProperty, value); }
+    public bool IsReadOnly { get => (bool)GetValue(IsReadOnlyProperty); set => SetValue(IsReadOnlyProperty, value); }
 
-    public static readonly BindableProperty IsReadonlyProperty = BindableProperty.Create(
-        nameof(IsReadonly),
+    public static readonly BindableProperty IsReadOnlyProperty = BindableProperty.Create(
+        nameof(IsReadOnly),
         typeof(bool),
         typeof(EditorField),
         false,

--- a/src/UraniumUI.Material/Controls/TextField.BindableProperties.cs
+++ b/src/UraniumUI.Material/Controls/TextField.BindableProperties.cs
@@ -147,10 +147,10 @@ public partial class TextField
         false,
         propertyChanged: (bindable, oldValue, newValue) => (bindable as TextField).OnAllowClearChanged());
 
-    public bool IsReadonly { get => (bool)GetValue(IsReadonlyProperty); set => SetValue(IsReadonlyProperty, value); }
+    public new bool IsReadOnly { get => (bool)GetValue(IsReadOnlyProperty); set => SetValue(IsReadOnlyProperty, value); }
 
-    public static readonly BindableProperty IsReadonlyProperty = BindableProperty.Create(
-        nameof(IsReadonly),
+    public static readonly BindableProperty IsReadOnlyProperty = BindableProperty.Create(
+        nameof(IsReadOnly),
         typeof(bool),
         typeof(TextField),
         false,


### PR DESCRIPTION
Resolves https://github.com/enisn/UraniumUI/issues/233

## Breaking Changes ⚠️
- `IsReadonly` is renamed as `IsReadOnly`.