### PR TITLE
Add backdrop color to mopup dialogs

### DIFF
--- a/src/UraniumUI.Dialogs.Mopups/MopupsDialogExtensions.cs
+++ b/src/UraniumUI.Dialogs.Mopups/MopupsDialogExtensions.cs
@@ -8,12 +8,14 @@ using CheckBox = InputKit.Shared.Controls.CheckBox;
 namespace UraniumUI.Dialogs.Mopups;
 public static class MopupsDialogExtensions
 {
+    static readonly Color backdropColor = Colors.Black.WithAlpha(.6f);
     public static async Task<bool> ConfirmAsync(this Page page, string title, string message, string okText = "OK", string cancelText = "Cancel")
     {
         var tcs = new TaskCompletionSource<bool>();
 
         await MopupService.Instance.PushAsync(new PopupPage
         {
+            BackgroundColor = backdropColor,
             CloseWhenBackgroundIsClicked = false,
             Content = GetFrame(page.Width, new VerticalStackLayout
             {
@@ -103,6 +105,7 @@ public static class MopupsDialogExtensions
 
         await MopupService.Instance.PushAsync(new PopupPage
         {
+            BackgroundColor = backdropColor,
             CloseWhenBackgroundIsClicked = false,
             Content = GetFrame(page.Width, rootGrid)
         });
@@ -169,6 +172,8 @@ public static class MopupsDialogExtensions
 
         await MopupService.Instance.PushAsync(new PopupPage
         {
+            BackgroundColor = backdropColor,
+            CloseWhenBackgroundIsClicked = false,
             Content = GetFrame(page.Width, rootGrid)
         });
 
@@ -217,6 +222,7 @@ public static class MopupsDialogExtensions
 
         await MopupService.Instance.PushAsync(new PopupPage
         {
+            BackgroundColor = backdropColor,
             CloseWhenBackgroundIsClicked = false,
             Content = GetFrame(page.Width, new VerticalStackLayout
             {


### PR DESCRIPTION
Before:
<img width="714" alt="image" src="https://user-images.githubusercontent.com/23705418/220572551-82bd6063-3ca3-4876-bd13-bcfb7e4c4912.png">

After:

<img width="714" alt="image" src="https://user-images.githubusercontent.com/23705418/220572267-ec9aa238-4a38-438f-8883-021051dea509.png">
