### PR TITLE
Dialogs Enhancements

### DIFF
--- a/demo/UraniumApp/Pages/DialogsPage.xaml.cs
+++ b/demo/UraniumApp/Pages/DialogsPage.xaml.cs
@@ -43,11 +43,16 @@ public partial class DialogsPage : ContentPage
         checkBoxResultListView.ItemsSource = result;
     }
 
+    private string lastTextInput = string.Empty;
     private async void AskTextPrompt(object sender, EventArgs e)
     {
-        var result = await DialogService.DisplayTextPromptAsync("Your Name", "What is your name?", placeholder: "Uvuvwevwevwe...Osas");
+        lastTextInput = await DialogService.DisplayTextPromptAsync(
+            "Your Name",
+            "What is your name?",
+            placeholder: "Uvuvwevwevwe...Osas",
+            initialValue: lastTextInput);
 
-        labelTextPrompt.Text = "Result: " + result;
+        labelTextPrompt.Text = "Result: " + lastTextInput;
     }
 
     private async void AskConfirmation(object sender, EventArgs e)

--- a/src/UraniumUI.Dialogs.CommunityToolkit/CommunityToolkitDialogExtensions.cs
+++ b/src/UraniumUI.Dialogs.CommunityToolkit/CommunityToolkitDialogExtensions.cs
@@ -384,15 +384,15 @@ public static class CommunityToolkitDialogExtensions
 
         var footer = GetFooter(
             accept,
-        new Command(() =>
-        {
-            tcs.SetResult(entry.Text);
-            popup.Close();
-        }),
+            new Command(() =>
+            {
+                tcs.SetResult(entry.Text);
+                popup.Close();
+            }),
             cancel,
             new Command(() =>
             {
-                tcs.SetResult(null);
+                tcs.SetResult(initialValue);
                 popup.Close();
             }));
 

--- a/src/UraniumUI.Dialogs.Mopups/MopupsDialogExtensions.cs
+++ b/src/UraniumUI.Dialogs.Mopups/MopupsDialogExtensions.cs
@@ -31,12 +31,12 @@ public static class MopupsDialogExtensions
                     GetFooter(
                         okText, new Command(()=>
                         {
-                            tcs.SetResult(true);
+                            tcs.TrySetResult(true);
                             MopupService.Instance.PopAsync();
                         }),
                         cancelText, new Command(()=>
                         {
-                            tcs.SetResult(false);
+                            tcs.TrySetResult(false);
                             MopupService.Instance.PopAsync();
                         }))
                 }
@@ -93,12 +93,12 @@ public static class MopupsDialogExtensions
         rootGrid.Add(GetFooter(
             accept, new Command(() =>
             {
-                tcs.SetResult(checkBoxGroup.Children.Where(x => x is CheckBox checkbox && checkbox.IsChecked).Select(s => (T)(s as CheckBox).CommandParameter));
+                tcs.TrySetResult(checkBoxGroup.Children.Where(x => x is CheckBox checkbox && checkbox.IsChecked).Select(s => (T)(s as CheckBox).CommandParameter));
                 MopupService.Instance.PopAsync();
             }),
             cancel, new Command(() =>
             {
-                tcs.SetResult(null);
+                tcs.TrySetResult(null);
                 MopupService.Instance.PopAsync();
             })
         ), row: 3);
@@ -160,12 +160,12 @@ public static class MopupsDialogExtensions
         rootGrid.Add(GetFooter(
             accept, new Command(() =>
             {
-                tcs.SetResult((T)rbGroup.SelectedItem);
+                tcs.TrySetResult((T)rbGroup.SelectedItem);
                 MopupService.Instance.PopAsync();
             }),
             cancel, new Command(() =>
             {
-                tcs.SetResult(default);
+                tcs.TrySetResult(default);
                 MopupService.Instance.PopAsync();
             })
         ), row: 3);
@@ -239,12 +239,12 @@ public static class MopupsDialogExtensions
                     GetFooter(
                         accept, new Command(()=>
                         {
-                            tcs.SetResult(entry.Text);
+                            tcs.TrySetResult(entry.Text);
                             MopupService.Instance.PopAsync();
                         }),
                         cancel, new Command(()=>
                         {
-                            tcs.SetResult(null);
+                            tcs.TrySetResult(initialValue);
                             MopupService.Instance.PopAsync();
                         }))
                 }


### PR DESCRIPTION

- While calling `ConfirmAsync` method, the Initial value will be returned instead of null.
- Double click to **OK** or **Cancel** button were crashing the application. This is fixed also.

### Breaking Change
There is a behavioral change in this PR. `.ConfirmAsync` method will return the initial value after this PR instead of null. 