### PR TITLE
Add Star to InputFields that have RequiredValidation set.

### DIFF
--- a/src/UraniumUI.Material/Controls/InputField.cs
+++ b/src/UraniumUI.Material/Controls/InputField.cs
@@ -1,6 +1,8 @@
 ﻿using Microsoft.Maui.Controls.Shapes;
 using UraniumUI.Resources;
 using UraniumUI.Extensions;
+using System.ComponentModel;
+using InputKit.Shared.Validations;
 
 namespace UraniumUI.Material.Controls;
 
@@ -99,6 +101,16 @@ public partial class InputField : Grid
         labelTitle.SetBinding(Label.TextProperty, new Binding(nameof(Title), source: this));
 
         InitializeValidation();
+        // TODO: Not sure if this is the right place/way to listen to the validation changes.
+        Content.PropertyChanged += OnValidationsChanged;
+    }
+
+    private void OnValidationsChanged(object s, PropertyChangedEventArgs e)
+    {
+        if (Validations.Any(v => v is RequiredValidation) && !Title.EndsWith("*"))
+        {
+            Title += "*";
+        }
     }
 
     ~InputField()


### PR DESCRIPTION
Fixes #61 

Please review the TODO in line 104, although this code works I am not sure this is the right place to put this. It was not quite clear to me when this is fully initialized, putting it in the original propertyChanged of the TitleProperty did not work as the Validations are not initialized when this is called.