### PR TITLE
TabView Caching Strategy

### DIFF
--- a/demo/UraniumApp/Pages/TabViews/WebTabViewPage.xaml
+++ b/demo/UraniumApp/Pages/TabViews/WebTabViewPage.xaml
@@ -25,7 +25,8 @@
                 <material:TabView 
                         Grid.Row="1" 
                         ItemsSource="{Binding TabItems}"
-                        CurrentItem="{Binding CurrentTab}">
+                        CurrentItem="{Binding CurrentTab}"
+                        CachingStrategy="CacheOnLayout">
                     <material:TabView.TabHeaderItemTemplate>
                         <DataTemplate>
                             <uranium:StatefulContentView TappedCommand="{Binding Command}" WidthRequest="160">

--- a/src/UraniumUI.Material/Controls/TabView.cs
+++ b/src/UraniumUI.Material/Controls/TabView.cs
@@ -10,7 +10,7 @@ namespace UraniumUI.Material.Controls;
 [ContentProperty(nameof(Items))]
 public partial class TabView : Grid
 {
-    public TabViewPresentationStrategy PresentationStrategy { get; set; }
+    public TabViewCachingStrategy CachingStrategy { get; set; }
 
     public static DataTemplate DefaultTabHeaderItemTemplate => new DataTemplate(() =>
     {
@@ -355,7 +355,7 @@ public partial class TabView : Grid
             item.NotifyIsSelectedChanged();
         }
 
-        if (PresentationStrategy == TabViewPresentationStrategy.CacheOnCodeBehing)
+        if (CachingStrategy == TabViewCachingStrategy.CacheOnCodeBehing)
         {
             if (_contentContainer.Content != null)
             {
@@ -394,7 +394,7 @@ public partial class TabView : Grid
     }
 }
 
-public enum TabViewPresentationStrategy
+public enum TabViewCachingStrategy
 {
     CacheOnCodeBehing,
     CacheOnLayout,


### PR DESCRIPTION
By default, Views are stored in the TabItem object after creation in code-behing. This PR adds an option to keep opened tabs in the layout show much more quickly when required.

**CacheOnCodeBehing**: More optimized memory but slower UI interaction.
**CacheOnLayout**: Uses more memory but faster UI interaction.