### PR TITLE
Apply InputField workaround to iOS & MacCatalyst too

### DIFF
--- a/src/UraniumUI.Material/Controls/InputField.cs
+++ b/src/UraniumUI.Material/Controls/InputField.cs
@@ -46,9 +46,7 @@ public partial class InputField : Grid
 
     protected Grid rootGrid = new Grid
     {
-#if ANDROID || WINDOWS
         HeightRequest = 45 // TODO: Remove this after .NET 8. This is a workaround for https://github.com/dotnet/maui/issues/14645
-#endif
     };
 
     protected Lazy<Image> imageIcon = new Lazy<Image>(() =>


### PR DESCRIPTION
Possible fix for https://github.com/enisn/UraniumUI/issues/296 and #281 