### PR TITLE
Introduce injecting into XAML - Inject Markup Extension

### DIFF
--- a/demo/UraniumApp/Pages/Blurs/BlursPreviewPage.xaml
+++ b/demo/UraniumApp/Pages/Blurs/BlursPreviewPage.xaml
@@ -8,7 +8,7 @@
              xmlns:material="http://schemas.enisn-projects.io/dotnet/maui/uraniumui/material"
              xmlns:input="clr-namespace:InputKit.Shared.Controls;assembly=InputKit.Maui"
              x:DataType="vm:BlursPreviewViewModel"
-             BindingContext="{root:Inject {Type vm:BlursPreviewViewModel}}">
+             BindingContext="{uranium:Inject {Type vm:BlursPreviewViewModel}}">
     <ScrollView>
         <VerticalStackLayout>
 

--- a/demo/UraniumApp/Pages/FontImagesPage.xaml
+++ b/demo/UraniumApp/Pages/FontImagesPage.xaml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             xmlns:uranium="http://schemas.enisn-projects.io/dotnet/maui/uraniumui"
              xmlns:material="http://schemas.enisn-projects.io/dotnet/maui/uraniumui/material"
              xmlns:vm="clr-namespace:UraniumApp.ViewModels"
              xmlns:root="clr-namespace:UraniumApp"

--- a/demo/UraniumApp/Pages/FontImagesPage.xaml
+++ b/demo/UraniumApp/Pages/FontImagesPage.xaml
@@ -6,7 +6,7 @@
              xmlns:root="clr-namespace:UraniumApp"
              x:Class="UraniumApp.Pages.FontImagesPage"
              x:DataType="vm:FontImagesViewModel"
-             BindingContext="{root:Inject {Type vm:FontImagesViewModel}}">
+             BindingContext="{uranium:Inject {Type vm:FontImagesViewModel}}">
     <Grid>
         <material:TabView ItemsSource="{Binding Items}">
             <material:TabView.ItemTemplate>

--- a/demo/UraniumApp/Pages/InputFields/AutoCompleteTextFieldPage.xaml
+++ b/demo/UraniumApp/Pages/InputFields/AutoCompleteTextFieldPage.xaml
@@ -7,7 +7,7 @@
              xmlns:vm="clr-namespace:UraniumApp.ViewModels.InputFields"
              xmlns:root="clr-namespace:UraniumApp"
              x:DataType="vm:AutoCompleteViewModel"
-             BindingContext="{root:Inject {Type vm:AutoCompleteViewModel}}"
+             BindingContext="{uranium:Inject {Type vm:AutoCompleteViewModel}}"
              x:Name="page"
              x:Class="UraniumApp.Pages.InputFields.AutoCompleteTextFieldPage">
     <ContentPage.Resources>

--- a/demo/UraniumApp/Pages/InputFields/DatePickerFieldPage.xaml
+++ b/demo/UraniumApp/Pages/InputFields/DatePickerFieldPage.xaml
@@ -7,7 +7,7 @@
              xmlns:vm="clr-namespace:UraniumApp.ViewModels.InputFields"
              xmlns:root="clr-namespace:UraniumApp"
              x:DataType="vm:DatePickerFieldViewModel"
-             BindingContext="{root:Inject {Type vm:DatePickerFieldViewModel}}"
+             BindingContext="{uranium:Inject {Type vm:DatePickerFieldViewModel}}"
              x:Class="UraniumApp.Pages.InputFields.DatePickerFieldPage">
     <ContentPage.Resources>
         <x:String x:Key="SourceCode">

--- a/demo/UraniumApp/Pages/InputFields/EditorFieldPage.xaml
+++ b/demo/UraniumApp/Pages/InputFields/EditorFieldPage.xaml
@@ -7,7 +7,7 @@
              xmlns:vm="clr-namespace:UraniumApp.ViewModels.InputFields"
              xmlns:root="clr-namespace:UraniumApp"
              x:DataType="vm:EditorFieldViewModel"
-             BindingContext="{root:Inject {x:Type vm:EditorFieldViewModel}}"
+             BindingContext="{uranium:Inject {x:Type vm:EditorFieldViewModel}}"
              x:Class="UraniumApp.Pages.InputFields.EditorFieldPage">
     <ContentPage.Resources>
         <x:String x:Key="SourceCode">

--- a/demo/UraniumApp/Pages/InputFields/MultiplePickerFieldPage.xaml
+++ b/demo/UraniumApp/Pages/InputFields/MultiplePickerFieldPage.xaml
@@ -7,7 +7,7 @@
              xmlns:vm="clr-namespace:UraniumApp.ViewModels.InputFields"
              xmlns:root="clr-namespace:UraniumApp"
              x:DataType="vm:MultiplePickerFieldVideModel"
-             BindingContext="{root:Inject {Type vm:MultiplePickerFieldVideModel}}"
+             BindingContext="{uranium:Inject {Type vm:MultiplePickerFieldVideModel}}"
              x:Class="UraniumApp.Pages.InputFields.MultiplePickerFieldPage">
 
     <ContentPage.Resources>

--- a/demo/UraniumApp/Pages/InputFields/PickerFieldPage.xaml
+++ b/demo/UraniumApp/Pages/InputFields/PickerFieldPage.xaml
@@ -8,7 +8,7 @@
              xmlns:root="clr-namespace:UraniumApp"
              x:Class="UraniumApp.Pages.InputFields.PickerFieldPage"
              x:DataType="vm:PickerFieldViewModel"
-             BindingContext="{root:Inject {Type vm:PickerFieldViewModel}}">
+             BindingContext="{uranium:Inject {Type vm:PickerFieldViewModel}}">
 
     <ContentPage.Resources>
         <x:String x:Key="SourceCode">

--- a/demo/UraniumApp/Pages/InputFields/TimePickerFieldPage.xaml
+++ b/demo/UraniumApp/Pages/InputFields/TimePickerFieldPage.xaml
@@ -6,7 +6,7 @@
              xmlns:m="clr-namespace:UraniumUI.Icons.MaterialIcons;assembly=UraniumUI.Icons.MaterialIcons"
              xmlns:vm="clr-namespace:UraniumApp.ViewModels.InputFields"
              x:DataType="vm:TimePickerFieldViewModel"
-             BindingContext="{root:Inject {Type vm:TimePickerFieldViewModel}}"
+             BindingContext="{uranium:Inject {Type vm:TimePickerFieldViewModel}}"
              xmlns:root="clr-namespace:UraniumApp"
              x:Class="UraniumApp.Pages.InputFields.TimePickerFieldPage"
              >

--- a/src/UraniumUI/ViewExtensions/InjectExtension.cs
+++ b/src/UraniumUI/ViewExtensions/InjectExtension.cs
@@ -1,10 +1,8 @@
-﻿using UraniumUI;
-
-namespace UraniumApp;
+﻿namespace UraniumUI.ViewExtensions;
 
 [ContentProperty(nameof(Type))]
 [AcceptEmptyServiceProvider]
-public class InjectExtension : IMarkupExtension<object>
+public class InjectExtension : IMarkupExtension
 {
     public Type Type { get; set; }
     public object ProvideValue(IServiceProvider serviceProvider)


### PR DESCRIPTION
Now `{uranium:Inject {Type vm:MyViewModel}}` extension can be used for `BindingContext` of a page or any specific `View` in XAML.

```xml
<ContentPage 
    xmlns:vm="App1.ViewModels"
    xmlns:uranium="http://schemas.enisn-projects.io/dotnet/maui/uraniumui"
    BindingContext="{uranium:Inject {Type vm:MainPageViewModel}}"
    x:DataType="vm:MainPageViewModel"
>
```

Or any specific view in a page:

```xml

<VerticalStackLayout>
    <Label Text="Some Title" />
    <Frame BindingContext="{uranium:Inject {vm:ProductsViewModel}}">
         <!--Items property from ProductsViewModel👇-->
          <CollectionView ItemsSource="{Binding Items}">
          </CollectionView>
    </Frame>
</VerticalStackLayout>
```

---

> ⚠️ Don't use thid with custom dependency containers. It works with only `Microsoft.Extensions.DependencyInjection`.
> _It might work with others but not tested_

