### PR TITLE
Fix ItemDisplayBinding of PickerField on Windows

### DIFF
--- a/demo/UraniumApp/Pages/InputFields/PickerFieldPage.xaml
+++ b/demo/UraniumApp/Pages/InputFields/PickerFieldPage.xaml
@@ -53,13 +53,7 @@ public ObservableCollection<string> Items { get; } = new ObservableCollection<st
                         <Label Text="Simple EditorField" FontSize="Subtitle" Margin="20"/>
 
                         <VerticalStackLayout StyleClass="ControlPreview" Spacing="12">
-                            <material:PickerField Title="Pick an option" Icon="{FontImageSource FontFamily=MaterialRegular, Glyph={x:Static m:MaterialRegular.Expand_circle_down}}">
-                                <material:PickerField.Items>
-                                    <x:String>Item 1</x:String>
-                                    <x:String>Item 2</x:String>
-                                    <x:String>Item 3</x:String>
-                                </material:PickerField.Items>
-                            </material:PickerField>
+                            <material:PickerField ItemsSource="{Binding TestModels}" ItemDisplayBinding="{Binding Value}" Title="Pick an option" Icon="{FontImageSource FontFamily=MaterialRegular, Glyph={x:Static m:MaterialRegular.Expand_circle_down}}"/>
                         </VerticalStackLayout>
 
                         <uranium:ExpanderView>

--- a/demo/UraniumApp/ViewModels/InputFields/PickerFieldViewModel.cs
+++ b/demo/UraniumApp/ViewModels/InputFields/PickerFieldViewModel.cs
@@ -1,6 +1,7 @@
 ﻿using DotNurse.Injector.Attributes;
 using System;
 using System.Collections;
+using System.Collections.ObjectModel;
 using System.Xml.Linq;
 using UraniumUI.Material.Controls;
 using UraniumUI.Resources;
@@ -10,6 +11,19 @@ namespace UraniumApp.ViewModels.InputFields;
 [RegisterAs(typeof(PickerFieldViewModel))]
 public class PickerFieldViewModel : SingleControlEditingViewModel<PickerField>
 {
+
+    //Test props
+    private ObservableCollection<TestModel> testModels;
+    public ObservableCollection<TestModel> TestModels { get { return testModels; } }
+
+    public PickerFieldViewModel()
+    {
+        testModels = new ObservableCollection<TestModel>()
+        {
+            new TestModel() {Value = "option1"},
+            new TestModel() {Value = "option2"}
+        };
+    }
     protected override string InitialXDocumentCode => """<ContentPage xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml" xmlns:material="http://schemas.enisn-projects.io/dotnet/maui/uraniumui/material"><material:PickerField /></ContentPage>""";
 
     protected override PickerField InitializeControl()
@@ -47,5 +61,11 @@ public class PickerFieldViewModel : SingleControlEditingViewModel<PickerField>
         }
 
         return base.FormatValue(value);
+    }
+
+    //Test for picker field using object as bindable property
+    public class TestModel
+    {
+        public string Value { get; set; }
     }
 }

--- a/src/UraniumUI.Material/Controls/PickerField.cs
+++ b/src/UraniumUI.Material/Controls/PickerField.cs
@@ -83,11 +83,6 @@ public class PickerField : InputField
 #endif
     }
 
-    private void PickerView_SelectedIndexChanged(object sender, EventArgs e)
-    {
-        throw new NotImplementedException();
-    }
-
 #if WINDOWS
     protected override void OnSizeAllocated(double width, double height)
     {
@@ -119,8 +114,6 @@ public class PickerField : InputField
         {
             iconClear.IsVisible = SelectedItem != null;
         }
-
-        string selectedItem = SelectedItem?.ToString();
 
 #if WINDOWS
         //labelSelectedItem.Text = SelectedItem?.ToString();

--- a/src/UraniumUI.Material/Controls/PickerField.cs
+++ b/src/UraniumUI.Material/Controls/PickerField.cs
@@ -83,6 +83,11 @@ public class PickerField : InputField
 #endif
     }
 
+    private void PickerView_SelectedIndexChanged(object sender, EventArgs e)
+    {
+        throw new NotImplementedException();
+    }
+
 #if WINDOWS
     protected override void OnSizeAllocated(double width, double height)
     {
@@ -115,8 +120,20 @@ public class PickerField : InputField
             iconClear.IsVisible = SelectedItem != null;
         }
 
+        string selectedItem = SelectedItem?.ToString();
+
 #if WINDOWS
-        labelSelectedItem.Text = SelectedItem?.ToString();
+        //labelSelectedItem.Text = SelectedItem?.ToString();
+        if (ItemDisplayBinding != null)
+        {
+            Binding itemDisplayBinding = (Binding)ItemDisplayBinding;
+            string nameOfDisplayProperty = itemDisplayBinding.Path;
+            labelSelectedItem.SetBinding(Label.TextProperty, new Binding(nameof(SelectedItem) + '.' + nameOfDisplayProperty, source: this));
+        }
+        else
+        {
+            labelSelectedItem.Text = SelectedItem?.ToString();
+        }
 #endif
 
         UpdateState();
@@ -152,6 +169,8 @@ public class PickerField : InputField
     }
 
     public IList<string> Items => PickerView.Items;
+
+    #region BindableProperties
 
     public object SelectedItem { get => GetValue(SelectedItemProperty); set => SetValue(SelectedItemProperty, value); }
 
@@ -238,4 +257,6 @@ public class PickerField : InputField
         nameof(SelectedValueChangedCommand),
         typeof(ICommand), typeof(PickerField),
         defaultValue: null);
+
+    #endregion
 }

--- a/src/UraniumUI.Material/Controls/PickerField.cs
+++ b/src/UraniumUI.Material/Controls/PickerField.cs
@@ -116,7 +116,6 @@ public class PickerField : InputField
         }
 
 #if WINDOWS
-        //labelSelectedItem.Text = SelectedItem?.ToString();
         if (ItemDisplayBinding != null)
         {
             Binding itemDisplayBinding = (Binding)ItemDisplayBinding;


### PR DESCRIPTION
Fix for [issue-253](https://github.com/enisn/UraniumUI/issues/253)

I switched the demo picker to use an object as it's ItemSource to demonstrate. 
The fix is based on infomation from microsoft [docs](https://learn.microsoft.com/en-us/dotnet/maui/user-interface/controls/picker?view=net-maui-7.0)
![image](https://github.com/enisn/UraniumUI/assets/45164087/c3a15348-1148-4f27-aaaa-5b459672c444)

Not sure if this is the best way, but it seems to work.