### PR TITLE
‘IsSelected’ is now a property and and binding is 'OneWay'

### DIFF
--- a/src/UraniumUI.Material/Controls/TabView.cs
+++ b/src/UraniumUI.Material/Controls/TabView.cs
@@ -33,7 +33,7 @@ public partial class TabView : Grid
         grid.Add(tabButton, 0, 0);
         grid.Triggers.Add(new DataTrigger(typeof(Grid))
         {
-            Binding = new Binding(nameof(TabItem.IsSelected), BindingMode.TwoWay),
+            Binding = new Binding(nameof(TabItem.IsSelected), BindingMode.OneWay),
             Value = true,
             EnterActions =
             {
@@ -58,7 +58,7 @@ public partial class TabView : Grid
 
         grid.Triggers.Add(new DataTrigger(typeof(Grid))
         {
-            Binding = new Binding(nameof(TabItem.IsSelected), BindingMode.TwoWay),
+            Binding = new Binding(nameof(TabItem.IsSelected), BindingMode.OneWay),
             Value = false,
             EnterActions =
             {
@@ -489,7 +489,7 @@ public class TabItem : UraniumBindableObject
     public DataTemplate HeaderTemplate { get; set; }
     public View Content { get; set; }
     public TabView TabView { get; internal set; }
-    public bool IsSelected => TabView.SelectedTab == this || (TabView.CurrentItem != null && TabView.CurrentItem == Data);
+    public bool IsSelected { get => TabView.SelectedTab == this || (TabView.CurrentItem != null && TabView.CurrentItem == Data); }
     public ICommand Command { get; private set; }
 
     public TabItem()


### PR DESCRIPTION
This is a fix that is related to the issue #250 

Reason for the changes:

- Since the error message specifies that the property 'IsSelected' cannot be found, then what needs to be done is to make this a property instead of a variable. That was done, but this question came up - should the property have a getter and setter or just a getter?
- I have not seen any other place in the code where the 'IsSelected' property would get changed after initially set. The only exception is where the Grid triggers have a TwoWay binding mode. However, in my opinion, a TwoWay binding mode is redundant - this binding should not trigger and send a value back. It should only trigger based on a new value received from the 'TabItem.IsSelected' property changes, which will change once the user clicks on a different tab. That made me decide to make it just a getter property.
- I changed the 'IsSelected' from a variable to a property with just a 'get' keyword. However, the new question is this: where do I put this code: `TabView.SelectedTab == this || (TabView.CurrentItem != null && TabView.CurrentItem == Data);`? Do I initialize the property with that value or have it return that value. Since the value will change frequently, I put the code under the 'get' keyword. That means that every time we try to get the 'IsSelected' value, it will dynamically retrieve the value.

After all this was completed, I tested this with the demo app and confirmed that nothing broke. Additionally, I tested it with my own .NET 8.0 application and did not see any more `Binding: 'IsSelected' property not found on 'UraniumUI.Material.Controls.TabItem', target property: 'Microsoft.Maui.Controls.Grid.Bound'` error messages.