### PR TITLE
fix: Catch error 🥅

### DIFF
--- a/src/UraniumUI.Material/Controls/InputField.cs
+++ b/src/UraniumUI.Material/Controls/InputField.cs
@@ -130,9 +130,16 @@ public partial class InputField : Grid
 
     protected override async void OnSizeAllocated(double width, double height)
     {
-        base.OnSizeAllocated(width, height);
-        await Task.Delay(100);
-        InitializeBorder();
+        try
+        {
+            base.OnSizeAllocated(width, height);
+            await Task.Delay(100);
+            InitializeBorder();
+        }
+        catch (Exception ex)
+        {
+            Console.WriteLine($"Error in {nameof(InputField)} - OnSizeAllocated: {ex}");
+        }
     }
 
 #if !WINDOWS


### PR DESCRIPTION
* Catch error in OnSizeAllocated function in InputField for iOS crash.

Refs: #448