### PR TITLE
Add `EntryBehaviours` to TextField

### DIFF
--- a/src/UraniumUI.Material/Controls/TextField.cs
+++ b/src/UraniumUI.Material/Controls/TextField.cs
@@ -37,13 +37,15 @@ public partial class TextField : InputField
 
     public override bool HasValue { get => !string.IsNullOrEmpty(Text); }
 
+    public IList<Behavior> EntryBehaviors => EntryView?.Behaviors;
+
     public event EventHandler<TextChangedEventArgs> TextChanged;
     public event EventHandler Completed;
 
     public TextField()
     {
         iconClear.TappedCommand = new Command(OnClearTapped);
-
+        
         UpdateClearIconState();
 
         EntryView.SetBinding(Entry.TextProperty, new Binding(nameof(Text), source: this));


### PR DESCRIPTION
Closes https://github.com/enisn/UraniumUI/issues/439

```xml
<material:TextField Title="Masked Input">
    <material:TextField.EntryBehaviors>
        <toolkit:MaskedBehavior Mask="XXXX XXXX XXXX XXXX"/>
    </material:TextField.EntryBehaviors>
</material:TextField>
```

![masked-input](https://github.com/enisn/UraniumUI/assets/23705418/59bc05a6-d607-473b-8ab9-c58bdca34904)
