### PR TITLE
Treeview line selection support (Single-Multiple)

### DIFF
--- a/demo/UraniumApp/Converters/BoolToOpactityConverter.cs
+++ b/demo/UraniumApp/Converters/BoolToOpactityConverter.cs
@@ -1,0 +1,25 @@
+﻿using System.Globalization;
+
+namespace UraniumApp.Converters;
+public class BoolToOpactityConverter : IValueConverter
+{
+    public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+    {
+        if (value is bool b)
+        {
+            return b ? 1 : 0;
+        }
+
+        return value;
+    }
+
+    public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+    {
+        if (value is bool b)
+        {
+            return b ? 1 : 0;
+        }
+
+        return value;
+    }
+}

--- a/demo/UraniumApp/Converters/BooleanInverter.cs
+++ b/demo/UraniumApp/Converters/BooleanInverter.cs
@@ -1,0 +1,25 @@
+﻿using System.Globalization;
+
+namespace UraniumApp.Converters;
+public class BooleanInverter : IValueConverter
+{
+    public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+    {
+        if (value is bool b)
+        {
+            return !b;
+        }
+
+        return value;
+    }
+
+    public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+    {
+        if (value is bool b)
+        {
+            return !b;
+        }
+
+        return value;
+    }
+}

--- a/demo/UraniumApp/MauiProgram.cs
+++ b/demo/UraniumApp/MauiProgram.cs
@@ -2,6 +2,8 @@
 using CommunityToolkit.Maui;
 using DotNurse.Injector;
 using Mopups.Hosting;
+using ReactiveUI;
+using System.Reactive;
 using UraniumUI;
 using UraniumUI.Dialogs;
 
@@ -28,6 +30,13 @@ public static class MauiProgram
                 fonts.AddMaterialIconFonts();
                 fonts.AddFluentIconFonts();
             });
+
+        RxApp.DefaultExceptionHandler = new AnonymousObserver<Exception>(ex =>
+        {
+            App.Current.MainPage.DisplayAlert("Error", ex.Message, "OK");
+
+            // Track the exception here... (e.g. AppCenter, Sentry, etc.)
+        });
 
         var thisAssembly = typeof(MauiProgram).Assembly;
 

--- a/demo/UraniumApp/Pages/TreeViews/TreeViewFileSystemPage.xaml
+++ b/demo/UraniumApp/Pages/TreeViews/TreeViewFileSystemPage.xaml
@@ -15,7 +15,7 @@
 
             <VerticalStackLayout>
 
-                <material:TreeView SelectionMode="Single" x:Name="treeView" ItemsSource="{Binding Nodes}" LoadChildrenCommand="{Binding LoadChildrenCommand}" IsExpandedPropertyName="IsExtended">
+                <material:TreeView SelectionMode="Multiple" x:Name="treeView" ItemsSource="{Binding Nodes}" LoadChildrenCommand="{Binding LoadChildrenCommand}" IsExpandedPropertyName="IsExtended">
                     <material:TreeView.ItemTemplate>
                         <DataTemplate>
                             <HorizontalStackLayout Spacing="5" VerticalOptions="Center">

--- a/demo/UraniumApp/Pages/TreeViews/TreeViewFileSystemPage.xaml
+++ b/demo/UraniumApp/Pages/TreeViews/TreeViewFileSystemPage.xaml
@@ -15,7 +15,7 @@
 
             <VerticalStackLayout>
 
-                <material:TreeView x:Name="treeView" ItemsSource="{Binding Nodes}" LoadChildrenCommand="{Binding LoadChildrenCommand}" IsExpandedPropertyName="IsExtended">
+                <material:TreeView SelectionMode="Single" x:Name="treeView" ItemsSource="{Binding Nodes}" LoadChildrenCommand="{Binding LoadChildrenCommand}" IsExpandedPropertyName="IsExtended">
                     <material:TreeView.ItemTemplate>
                         <DataTemplate>
                             <HorizontalStackLayout Spacing="5" VerticalOptions="Center">

--- a/demo/UraniumApp/Pages/TreeViews/TreeViewPage.xaml
+++ b/demo/UraniumApp/Pages/TreeViews/TreeViewPage.xaml
@@ -115,7 +115,7 @@
                             <material:TreeView ItemsSource="{Binding Nodes}" IsExpandedPropertyName="IsExtended">
                                 <material:TreeView.ItemTemplate>
                                     <DataTemplate>
-                                        <material:CheckBox Text="{Binding Name}">
+                                        <material:CheckBox Text="{Binding Name}" Margin="10">
                                             <material:CheckBox.Behaviors>
                                                 <material:TreeViewHierarchicalSelectBehavior />
                                             </material:CheckBox.Behaviors>

--- a/demo/UraniumApp/Pages/TreeViews/TreeViewPage.xaml
+++ b/demo/UraniumApp/Pages/TreeViews/TreeViewPage.xaml
@@ -28,7 +28,7 @@
                             <material:TreeView ItemsSource="{Binding Nodes}">
                                 <material:TreeView.ItemTemplate>
                                     <DataTemplate>
-                                        <HorizontalStackLayout Margin="0,25" Spacing="5" VerticalOptions="Center">
+                                        <HorizontalStackLayout Margin="0,12" Spacing="5" VerticalOptions="Center">
                                             <Image Source="{FontImageSource FontFamily=MaterialRegular, Glyph={x:Static m:MaterialRegular.Folder}, Color={AppThemeBinding Light={StaticResource Primary}, Dark={StaticResource PrimaryDark}}}" />
                                             <Label Text="{Binding Name}" FontAttributes="Bold" />
                                             <Label Text="{Binding Children.Count, StringFormat='({0})'}" />
@@ -48,7 +48,7 @@
                                     <vm:MyTemplateSelector>
                                         <vm:MyTemplateSelector.TemplateDefault>
                                             <DataTemplate>
-                                                <HorizontalStackLayout Margin="0,25" Spacing="5" VerticalOptions="Center">
+                                                <HorizontalStackLayout Margin="0,8" Spacing="5" VerticalOptions="Center">
                                                     <Image Source="{FontImageSource FontFamily=MaterialRegular, Glyph={x:Static m:MaterialRegular.Folder}, Color={AppThemeBinding Light={StaticResource Primary}, Dark={StaticResource PrimaryDark}}}" />
                                                     <Label Text="{Binding Name}" FontAttributes="Bold" />
                                                     <Label Text="{Binding Children.Count, StringFormat='({0})'}" />
@@ -58,7 +58,7 @@
                                         </vm:MyTemplateSelector.TemplateDefault>
                                         <vm:MyTemplateSelector.TemplateA>
                                             <DataTemplate>
-                                                <HorizontalStackLayout Margin="0,25" Spacing="5" VerticalOptions="Center">
+                                                <HorizontalStackLayout Margin="0,8" Spacing="5" VerticalOptions="Center">
                                                     <Image Source="{FontImageSource FontFamily=MaterialRegular, Glyph={x:Static m:MaterialRegular.Folder}, Color={AppThemeBinding Light={StaticResource Tertiary}, Dark={StaticResource TertiaryDark}}}" />
                                                     <Label Text="{Binding Name}" FontAttributes="Bold" />
                                                     <Label Text="{Binding Children.Count, StringFormat='({0})'}" />
@@ -68,7 +68,7 @@
                                         </vm:MyTemplateSelector.TemplateA>
                                         <vm:MyTemplateSelector.TemplateB>
                                             <DataTemplate>
-                                                <HorizontalStackLayout Margin="0,25" Spacing="5" VerticalOptions="Center">
+                                                <HorizontalStackLayout Margin="0,8" Spacing="5" VerticalOptions="Center">
                                                     <Image Source="{FontImageSource FontFamily=MaterialRegular, Glyph={x:Static m:MaterialRegular.Folder}, Color={AppThemeBinding Light={StaticResource Secondary}, Dark={StaticResource SecondaryDark}}}" />
                                                     <Label Text="{Binding Name}" FontAttributes="Bold" />
                                                     <Label Text="{Binding Children.Count, StringFormat='({0})'}" />
@@ -78,7 +78,7 @@
                                         </vm:MyTemplateSelector.TemplateB>
                                         <vm:MyTemplateSelector.TemplateC>
                                             <DataTemplate>
-                                                <HorizontalStackLayout Margin="0,25" Spacing="5" VerticalOptions="Center">
+                                                <HorizontalStackLayout Margin="0,8" Spacing="5" VerticalOptions="Center">
                                                     <Image Source="{FontImageSource FontFamily=MaterialRegular, Glyph={x:Static m:MaterialRegular.Folder}, Color={AppThemeBinding Light={StaticResource Primary}, Dark={StaticResource PrimaryDark}}}" />
                                                     <Label Text="{Binding Name}" FontAttributes="Bold" />
                                                     <Label Text="{Binding Children.Count, StringFormat='({0})'}" />
@@ -99,7 +99,9 @@
                             <material:TreeView ItemsSource="{Binding Nodes}" IsExpandedPropertyName="IsExtended">
                                 <material:TreeView.ExpanderTemplate>
                                     <DataTemplate>
-                                        <Switch IsToggled="{Binding IsExpanded}" />
+                                        <StackLayout WidthRequest="50">
+                                            <Switch IsToggled="{Binding IsExpanded}" IsVisible="{Binding IsLeaf, Converter={x:Static root:UraniumConverters.BooleanInverter}}" />
+                                        </StackLayout>
                                     </DataTemplate>
                                 </material:TreeView.ExpanderTemplate>
                             </material:TreeView>

--- a/demo/UraniumApp/Pages/TreeViews/TreeViewPage.xaml
+++ b/demo/UraniumApp/Pages/TreeViews/TreeViewPage.xaml
@@ -17,7 +17,7 @@
                 <material:TabItem Title="Simple">
                     <material:TabItem.ContentTemplate>
                         <DataTemplate>
-                            <material:TreeView  LoadChildrenCommand="{Binding LoadChildrenCommand}" ItemsSource="{Binding Nodes}" IsExpandedPropertyName="IsExtended"/>
+                            <material:TreeView SelectionMode="Single" ItemsSource="{Binding Nodes}" IsExpandedPropertyName="IsExtended"/>
                         </DataTemplate>
                     </material:TabItem.ContentTemplate>
                 </material:TabItem>

--- a/demo/UraniumApp/UraniumConverters.cs
+++ b/demo/UraniumApp/UraniumConverters.cs
@@ -1,0 +1,9 @@
+﻿using UraniumApp.Converters;
+
+namespace UraniumApp;
+public static class UraniumConverters
+{
+    public static BooleanInverter BooleanInverter { get; } = new();
+
+    public static BoolToOpactityConverter BoolToOpactityConverter { get; } = new();
+}

--- a/demo/UraniumApp/ViewModels/TreeViewFileSystemViewModel.cs
+++ b/demo/UraniumApp/ViewModels/TreeViewFileSystemViewModel.cs
@@ -46,7 +46,6 @@ public class TreeViewFileSystemViewModel : UraniumBindableObject
         }
         catch (Exception ex)
         {
-
             await App.Current.MainPage.DisplayAlert("Error", ex.Message, "OK");
         }
     }

--- a/demo/UraniumApp/ViewModels/TreeViewPageViewModel.cs
+++ b/demo/UraniumApp/ViewModels/TreeViewPageViewModel.cs
@@ -74,5 +74,6 @@ namespace UraniumApp.ViewModels
         public virtual bool IsExtended { get => isExtended; set => SetProperty(ref isExtended, value); }
         public virtual object Value { get => value; set => SetProperty(ref this.value, value); }
         public virtual IList<MyItem> Children { get; set; } = new ObservableCollection<MyItem>();
+        public bool IsLeaf => Children.Count == 0;
     }
 }

--- a/src/UraniumUI.Material/Controls/TreeView.cs
+++ b/src/UraniumUI.Material/Controls/TreeView.cs
@@ -153,4 +153,11 @@ public partial class TreeView : VerticalStackLayout
     public static readonly BindableProperty ArrowColorProperty = BindableProperty.Create(
         nameof(ArrowColor), typeof(Color), typeof(TreeView), ColorResource.GetColor("OnBackground", "OnBackgroundDark", Colors.DarkGray),
             propertyChanged: (bindable, oldValue, newValue)=> (bindable as TreeView).OnArrowColorChanged());
+
+    public Color SelectionColor { get => (Color)GetValue(SelectionColorProperty); set => SetValue(SelectionColorProperty, value); }
+
+    public static readonly BindableProperty SelectionColorProperty = BindableProperty.Create(
+        nameof(ArrowColor), typeof(Color), typeof(TreeView), ColorResource.GetColor("Secondary", "SecondaryDark", Colors.Pink),
+            propertyChanged: (bindable, oldValue, newValue)=> (bindable as TreeView).OnArrowColorChanged());
+
 }

--- a/src/UraniumUI.Material/Controls/TreeView.cs
+++ b/src/UraniumUI.Material/Controls/TreeView.cs
@@ -98,6 +98,21 @@ public partial class TreeView : VerticalStackLayout
         }
     }
 
+    protected virtual void SelectedItemChanged()
+    {
+        if (SelectionMode == SelectionMode.None)
+        {
+            return;
+        }
+
+        foreach (var childHolder in Children.OfType<TreeViewNodeHolderView>())
+        {
+            childHolder.OnSelectedItemChanged();
+        }
+    }
+
+    public SelectionMode SelectionMode { get; set; }
+
     public bool UseAnimation { get; set; } = true;
 
     /// <summary>
@@ -110,6 +125,11 @@ public partial class TreeView : VerticalStackLayout
     public static readonly BindableProperty ItemsSourceProperty = BindableProperty.Create(
         nameof(ItemsSource), typeof(IList), typeof(TreeView), null,
         propertyChanged: (b, o, v) => (b as TreeView).OnItemsSourceSet());
+
+    public object SelectedItem { get => GetValue(SelectedItemProperty); set => SetValue(SelectedItemProperty, value); }
+
+    public static readonly BindableProperty SelectedItemProperty = BindableProperty.Create(
+        nameof(SelectedItem), typeof(object), typeof(TreeView), default, propertyChanged: (bo, ov, nv)=> (bo as TreeView).SelectedItemChanged());
 
     public DataTemplate ExpanderTemplate { get => (DataTemplate)GetValue(ExpanderTemplateProperty); set => SetValue(ExpanderTemplateProperty, value); }
 

--- a/src/UraniumUI.Material/Controls/TreeView.cs
+++ b/src/UraniumUI.Material/Controls/TreeView.cs
@@ -134,8 +134,6 @@ public partial class TreeView : VerticalStackLayout
             observableCollectionNew.CollectionChanged += SelectedItemsChanged;
         }
 
-        // TODO: Init selected
-
         foreach (var childNode in this.FindManyInChildrenHierarchy<TreeViewNodeHolderView>())
         {
             if (newValue.Contains(childNode.BindingContext) && !childNode.IsSelected)
@@ -219,5 +217,4 @@ public partial class TreeView : VerticalStackLayout
 
     public static readonly BindableProperty SelectionColorProperty = BindableProperty.Create(
         nameof(SelectionColor), typeof(Color), typeof(TreeView), ColorResource.GetColor("Secondary", "SecondaryDark", Colors.Pink));
-
 }

--- a/src/UraniumUI.Material/Controls/TreeView.cs
+++ b/src/UraniumUI.Material/Controls/TreeView.cs
@@ -90,14 +90,6 @@ public partial class TreeView : VerticalStackLayout
         OnItemTemplateChanged();
     }
 
-    protected virtual void OnArrowColorChanged()
-    {
-        foreach (var childHolder in Children.OfType<TreeViewNodeHolderView>())
-        {
-            childHolder.ReFillArrowColor();
-        }
-    }
-
     protected virtual void SelectedItemChanged()
     {
         if (SelectionMode == SelectionMode.None)
@@ -148,16 +140,9 @@ public partial class TreeView : VerticalStackLayout
     public static readonly BindableProperty LoadChildrenCommandProperty = BindableProperty.Create(
         nameof(LoadChildrenCommand), typeof(ICommand), typeof(TreeView), null);
 
-    public Color ArrowColor { get => (Color)GetValue(ArrowColorProperty); set => SetValue(ArrowColorProperty, value); }
-
-    public static readonly BindableProperty ArrowColorProperty = BindableProperty.Create(
-        nameof(ArrowColor), typeof(Color), typeof(TreeView), ColorResource.GetColor("OnBackground", "OnBackgroundDark", Colors.DarkGray),
-            propertyChanged: (bindable, oldValue, newValue)=> (bindable as TreeView).OnArrowColorChanged());
-
     public Color SelectionColor { get => (Color)GetValue(SelectionColorProperty); set => SetValue(SelectionColorProperty, value); }
 
     public static readonly BindableProperty SelectionColorProperty = BindableProperty.Create(
-        nameof(ArrowColor), typeof(Color), typeof(TreeView), ColorResource.GetColor("Secondary", "SecondaryDark", Colors.Pink),
-            propertyChanged: (bindable, oldValue, newValue)=> (bindable as TreeView).OnArrowColorChanged());
+        nameof(SelectionColor), typeof(Color), typeof(TreeView), ColorResource.GetColor("Secondary", "SecondaryDark", Colors.Pink));
 
 }

--- a/src/UraniumUI.Material/Controls/TreeViewHierarchicalSelectBehavior.cs
+++ b/src/UraniumUI.Material/Controls/TreeViewHierarchicalSelectBehavior.cs
@@ -104,12 +104,14 @@ public class TreeViewHierarchicalSelectBehavior : Behavior<CheckBox>
 
     private static CheckBox FindCheckBox(TreeViewNodeHolderView child)
     {
-        if (child.NodeView is Layout layout)
+        if (child.NodeView is CheckBox checkBox)
         {
-            return layout.FindInChildrenHierarchy<CheckBox>();
+            return checkBox;
         }
 
-        return (child.NodeView as CheckBox);
+        return child.FindInChildrenHierarchy<CheckBox>();
+
+        throw new InvalidOperationException("CheckBox isn't in a TreeView ItemTemplate");
     }
 }
 

--- a/src/UraniumUI.Material/Controls/TreeViewNodeHolderView.cs
+++ b/src/UraniumUI.Material/Controls/TreeViewNodeHolderView.cs
@@ -230,11 +230,11 @@ public class TreeViewNodeHolderView : VerticalStackLayout
             {
                 IsSelected = false;
             }
-        }
 
-        foreach (var childHolder in nodeChildren.Children.OfType<TreeViewNodeHolderView>())
-        {
-            childHolder.OnSelectedItemChanged();
+            foreach (var childHolder in nodeChildren.Children.OfType<TreeViewNodeHolderView>())
+            {
+                childHolder.OnSelectedItemChanged();
+            }
         }
     }
 

--- a/src/UraniumUI.Material/Controls/TreeViewNodeHolderView.cs
+++ b/src/UraniumUI.Material/Controls/TreeViewNodeHolderView.cs
@@ -205,7 +205,7 @@ public class TreeViewNodeHolderView : VerticalStackLayout
                 TreeView.SelectedItem = BindingContext;
             }
         }
-        else
+        else if (TreeView.SelectionMode == SelectionMode.Multiple)
         {
             if (TreeView.SelectedItems.Contains(BindingContext))
             {

--- a/src/UraniumUI.Material/Controls/TreeViewNodeHolderView.cs
+++ b/src/UraniumUI.Material/Controls/TreeViewNodeHolderView.cs
@@ -16,8 +16,6 @@ public class TreeViewNodeHolderView : VerticalStackLayout
 
     public TreeView TreeView { get; internal set; }
 
-    public int Indent { get; set; } = 0;
-
     protected ContentView nodeContainer = new ContentView
     {
         HorizontalOptions = LayoutOptions.Fill,
@@ -54,7 +52,7 @@ public class TreeViewNodeHolderView : VerticalStackLayout
 
     private View expanderView;
 
-    public TreeViewNodeHolderView(DataTemplate dataTemplate, TreeView treeView, BindingBase childrenBinding)
+    public TreeViewNodeHolderView(DataTemplate dataTemplate, TreeView treeView, BindingBase childrenBinding, int indentLevel = 0)
     {
         if (treeView is null)
         {
@@ -79,6 +77,7 @@ public class TreeViewNodeHolderView : VerticalStackLayout
         {
             Content = rowStack,
             TappedCommand = new Command(ItemClicked),
+            Padding = new Thickness(indentLevel * 16, 0, 0, 0)
         };
 
         this.Add(button);
@@ -96,7 +95,7 @@ public class TreeViewNodeHolderView : VerticalStackLayout
 
         BindableLayout.SetItemTemplate(nodeChildren, new DataTemplate(() =>
         {
-            var node = new TreeViewNodeHolderView(DataTemplate, TreeView, childrenBinding);
+            var node = new TreeViewNodeHolderView(DataTemplate, TreeView, childrenBinding, indentLevel + 1);
             node.ParentHolderView = this;
             node.TreeView = TreeView;
             return node;
@@ -106,17 +105,6 @@ public class TreeViewNodeHolderView : VerticalStackLayout
 
         nodeChildren.ChildAdded += (s, e) => OnPropertyChanged(nameof(IsLeaf));
         nodeChildren.ChildRemoved += (s, e) => OnPropertyChanged(nameof(IsLeaf));
-    }
-
-    protected override void OnParentSet()
-    {
-        base.OnParentSet();
-        var parent = this.FindInParents<TreeViewNodeHolderView>();
-        if (parent is not null)
-        {
-            Indent = parent.Indent + 16;
-            this.FindInChildrenHierarchy<StatefulContentView>().Padding = new Thickness(Indent, 0, 0, 0);
-        }
     }
 
     protected virtual View InitializeArrowExpander()
@@ -270,12 +258,12 @@ public class TreeViewNodeHolderView : VerticalStackLayout
 
         if (IsSelected)
         {
-            VisualStateManager.GoToState(this, CommonStates.Selected);
+            //VisualStateManager.GoToState(this, CommonStates.Selected);
             button.BackgroundColor = ColorResource.GetColor("Secondary", "Secondary", Colors.Pink);
         }
         else
         {
-            VisualStateManager.GoToState(this, CommonStates.Normal);
+            //VisualStateManager.GoToState(this, CommonStates.Normal);
             button.BackgroundColor = Colors.Transparent;
         }
     }

--- a/src/UraniumUI.Material/Controls/TreeViewNodeHolderView.cs
+++ b/src/UraniumUI.Material/Controls/TreeViewNodeHolderView.cs
@@ -126,8 +126,8 @@ public class TreeViewNodeHolderView : VerticalStackLayout
             Margin = new Thickness(0, 0, 5, 0),
             Content = new Path
             {
+                StyleClass = new[] { "TreeView.Arrow" },
                 Data = UraniumShapes.ArrowRight,
-                Fill = TreeView.ArrowColor,
                 HorizontalOptions = LayoutOptions.Center,
                 VerticalOptions = LayoutOptions.Center,
             }
@@ -192,33 +192,6 @@ public class TreeViewNodeHolderView : VerticalStackLayout
         return iconArrow;
     }
 
-    public virtual void ReFillArrowColor()
-    {
-        Layout expanderLayout = null;
-
-        if (expanderView is ContentView contentView && contentView.Content is Layout)
-        {
-            expanderLayout = contentView.Content as Layout;
-        }
-        else if (expanderView is Layout layout)
-        {
-            expanderLayout = layout;
-        }
-
-        if (expanderLayout is not null)
-        {
-            foreach (var path in expanderLayout.FindManyInChildrenHierarchy<Path>())
-            {
-                path.Fill = TreeView.ArrowColor;
-            }
-        }
-
-        foreach (var childHolder in nodeChildren.Children.OfType<TreeViewNodeHolderView>())
-        {
-            childHolder.ReFillArrowColor();
-        }
-    }
-
     protected virtual void ItemClicked()
     {
         if (TreeView.SelectionMode == SelectionMode.Single)
@@ -262,16 +235,31 @@ public class TreeViewNodeHolderView : VerticalStackLayout
         {
             VisualStateManager.GoToState(this, CommonStates.Selected);
             button.BackgroundColor = TreeView.SelectionColor;
-            AddSelectedResources(button);
+            foreach (var item in button.FindManyInChildrenHierarchy<Path>())
+            {
+                item.StyleClass = new[] { "TreeView.Arrow.Selected" };
+            }
+
+            foreach (var item in button.FindManyInChildrenHierarchy<Label>())
+            {
+                item.StyleClass = new[] { "TreeView.Label.Selected" };
+            }
         }
         else
         {
             VisualStateManager.GoToState(button, CommonStates.Normal);
             button.BackgroundColor = Colors.Transparent;
-            button.Resources.Clear();
 
-            button.Resources.Add(new Style(typeof(Label)));
-            button.Resources.Add(new Style(typeof(Path)));
+
+            foreach (var item in button.FindManyInChildrenHierarchy<Path>())
+            {
+                item.StyleClass = new[] { "TreeView.Arrow" };
+            }
+
+            foreach (var item in button.FindManyInChildrenHierarchy<Label>())
+            {
+                item.StyleClass = new[] { "TreeView.Label" };
+            }
         }
     }
 

--- a/src/UraniumUI.Material/Controls/TreeViewNodeHolderView.cs
+++ b/src/UraniumUI.Material/Controls/TreeViewNodeHolderView.cs
@@ -218,7 +218,7 @@ public class TreeViewNodeHolderView : VerticalStackLayout
         }
     }
 
-    protected virtual void OnSelectedItemChanged()
+    protected internal virtual void OnSelectedItemChanged()
     {
         if (TreeView.SelectionMode == SelectionMode.Single)
         {

--- a/src/UraniumUI.Material/Controls/TreeViewNodeHolderView.cs
+++ b/src/UraniumUI.Material/Controls/TreeViewNodeHolderView.cs
@@ -1,13 +1,14 @@
-﻿using UraniumUI.Extensions;
-using UraniumUI.Handlers;
+﻿using InputKit.Shared.Helpers;
+using UraniumUI.Extensions;
 using UraniumUI.Pages;
-using UraniumUI.Resources;
 using UraniumUI.Triggers;
 using UraniumUI.Views;
 using static Microsoft.Maui.Controls.VisualStateManager;
 using Path = Microsoft.Maui.Controls.Shapes.Path;
 
 namespace UraniumUI.Material.Controls;
+
+[ContentProperty(nameof(NodeView))]
 public class TreeViewNodeHolderView : VerticalStackLayout
 {
     public View NodeView { get => nodeContainer.Content; set => nodeContainer.Content = value; }
@@ -61,10 +62,10 @@ public class TreeViewNodeHolderView : VerticalStackLayout
 
         TreeView = treeView;
         DataTemplate = dataTemplate;
-        
+
         nodeContainer.ItemTemplate = DataTemplate;
         nodeContainer.SetBinding(TreeViewNodeItemContentView.ItemProperty, ".");
-        
+
         expanderView = TreeView.ExpanderTemplate?.CreateContent() as View ?? InitializeArrowExpander();
         expanderView.BindingContext = this;
 
@@ -259,14 +260,49 @@ public class TreeViewNodeHolderView : VerticalStackLayout
 
         if (IsSelected)
         {
-            //VisualStateManager.GoToState(this, CommonStates.Selected);
-            button.BackgroundColor = ColorResource.GetColor("Secondary", "Secondary", Colors.Pink);
+            VisualStateManager.GoToState(this, CommonStates.Selected);
+            button.BackgroundColor = TreeView.SelectionColor;
+            AddSelectedResources(button);
         }
         else
         {
-            //VisualStateManager.GoToState(this, CommonStates.Normal);
+            VisualStateManager.GoToState(button, CommonStates.Normal);
             button.BackgroundColor = Colors.Transparent;
+            button.Resources.Clear();
+
+            button.Resources.Add(new Style(typeof(Label)));
+            button.Resources.Add(new Style(typeof(Path)));
         }
+    }
+
+    protected virtual void AddSelectedResources(StatefulContentView button)
+    {
+        var surfaceColor = TreeView.SelectionColor.ToSurfaceColor();
+
+        button.Resources.Clear();
+        button.Resources.Add(new Style(typeof(Label))
+        {
+            CanCascade = true,
+            Setters =
+                {
+                    new Setter
+                    {
+                        Property = Label.TextColorProperty, Value = surfaceColor
+                    }
+                }
+        });
+
+        button.Resources.Add(new Style(typeof(Path))
+        {
+            CanCascade = true,
+            Setters =
+            {
+                new Setter
+                {
+                    Property = Path.FillProperty, Value = surfaceColor
+                }
+            }
+        });
     }
 
     public virtual void ApplyIsExpandedPropertyBindings()

--- a/src/UraniumUI.Material/Controls/TreeViewNodeHolderView.cs
+++ b/src/UraniumUI.Material/Controls/TreeViewNodeHolderView.cs
@@ -218,7 +218,7 @@ public class TreeViewNodeHolderView : VerticalStackLayout
         }
     }
 
-    internal virtual void OnSelectedItemChanged()
+    protected virtual void OnSelectedItemChanged()
     {
         if (TreeView.SelectionMode == SelectionMode.Single)
         {

--- a/src/UraniumUI.Material/Controls/TreeViewNodeHolderView.cs
+++ b/src/UraniumUI.Material/Controls/TreeViewNodeHolderView.cs
@@ -205,6 +205,17 @@ public class TreeViewNodeHolderView : VerticalStackLayout
                 TreeView.SelectedItem = BindingContext;
             }
         }
+        else
+        {
+            if (TreeView.SelectedItems.Contains(BindingContext))
+            {
+                TreeView.SelectedItems.Remove(BindingContext);
+            }
+            else
+            {
+                TreeView.SelectedItems.Add(BindingContext);
+            }
+        }
     }
 
     internal virtual void OnSelectedItemChanged()
@@ -249,7 +260,6 @@ public class TreeViewNodeHolderView : VerticalStackLayout
         {
             VisualStateManager.GoToState(button, CommonStates.Normal);
             button.BackgroundColor = Colors.Transparent;
-
 
             foreach (var item in button.FindManyInChildrenHierarchy<Path>())
             {

--- a/src/UraniumUI.Material/Resources/StyleResource.xaml
+++ b/src/UraniumUI.Material/Resources/StyleResource.xaml
@@ -447,14 +447,14 @@
             </Style>
 
             <Style TargetType="c:TreeView">
-                <Setter Property="SelectionColor" Value="{AppThemeBinding {StaticResource Secondary}, Dark={StaticResource SecondaryDark}}" />
+                <Setter Property="SelectionColor" Value="{AppThemeBinding {StaticResource Tertiary}, Dark={StaticResource TertiaryDark}}" />
             </Style>
 
             <Style TargetType="Label" Class="TreeView.Label" BaseResourceKey="Microsoft.Maui.Controls.Label">
             </Style>
 
             <Style TargetType="Label" Class="TreeView.Label.Selected" BaseResourceKey="Microsoft.Maui.Controls.Label" >
-                <Setter Property="TextColor" Value="{AppThemeBinding {StaticResource OnSecondary}, Dark={StaticResource OnSecondaryDark}}" />
+                <Setter Property="TextColor" Value="{AppThemeBinding {StaticResource OnTertiary}, Dark={StaticResource OnTertiaryDark}}" />
             </Style>
 
             <Style TargetType="Path" Class="TreeView.Arrow" BaseResourceKey="Microsoft.Maui.Controls.Shapes.Path">
@@ -462,7 +462,7 @@
             </Style>
 
             <Style TargetType="Path" Class="TreeView.Arrow.Selected" BaseResourceKey="Microsoft.Maui.Controls.StyleClass.TreeView.Arrow">
-                <Setter Property="Fill" Value="{AppThemeBinding {StaticResource OnSecondary}, Dark={StaticResource OnSecondaryDark}}" />
+                <Setter Property="Fill" Value="{AppThemeBinding {StaticResource OnTertiary}, Dark={StaticResource OnTertiaryDark}}" />
             </Style>
         </ResourceDictionary>
     </ResourceDictionary.MergedDictionaries>

--- a/src/UraniumUI.Material/Resources/StyleResource.xaml
+++ b/src/UraniumUI.Material/Resources/StyleResource.xaml
@@ -445,6 +445,25 @@
             <Style TargetType="FontImageSource" CanCascade="True">
                 <Setter Property="Color" Value="{AppThemeBinding {StaticResource OnBackground}, Dark={StaticResource OnBackgroundDark}}"></Setter>
             </Style>
+
+            <Style TargetType="c:TreeView">
+                <Setter Property="SelectionColor" Value="{AppThemeBinding {StaticResource Secondary}, Dark={StaticResource SecondaryDark}}" />
+            </Style>
+
+            <Style TargetType="Label" Class="TreeView.Label" BaseResourceKey="Microsoft.Maui.Controls.Label">
+            </Style>
+
+            <Style TargetType="Label" Class="TreeView.Label.Selected" BaseResourceKey="Microsoft.Maui.Controls.Label" >
+                <Setter Property="TextColor" Value="{AppThemeBinding {StaticResource OnSecondary}, Dark={StaticResource OnSecondaryDark}}" />
+            </Style>
+
+            <Style TargetType="Path" Class="TreeView.Arrow" BaseResourceKey="Microsoft.Maui.Controls.Shapes.Path">
+                <Setter Property="Fill" Value="{AppThemeBinding Light={StaticResource OnBackground},Dark={StaticResource OnBackgroundDark}}" />
+            </Style>
+
+            <Style TargetType="Path" Class="TreeView.Arrow.Selected" BaseResourceKey="Microsoft.Maui.Controls.StyleClass.TreeView.Arrow">
+                <Setter Property="Fill" Value="{AppThemeBinding {StaticResource OnSecondary}, Dark={StaticResource OnSecondaryDark}}" />
+            </Style>
         </ResourceDictionary>
     </ResourceDictionary.MergedDictionaries>
 </ResourceDictionary>

--- a/src/UraniumUI/Extensions/ViewExtensions.cs
+++ b/src/UraniumUI/Extensions/ViewExtensions.cs
@@ -62,7 +62,8 @@ public static class ViewExtensions
                 {
                     yield return found;
                 }
-                else if (item is View childView)
+
+                if (item is View childView)
                 {
                     foreach (var child in childView.FindManyInChildrenHierarchy<T>())
                     {

--- a/src/UraniumUI/Extensions/ViewExtensions.cs
+++ b/src/UraniumUI/Extensions/ViewExtensions.cs
@@ -49,6 +49,11 @@ public static class ViewExtensions
     public static IEnumerable<T> FindManyInChildrenHierarchy<T>(this View view)
         where T : View
     {
+        if (view is T itself)
+        {
+            yield return itself;
+        }
+
         if (view is Layout layout)
         {
             foreach (var item in layout.Children)
@@ -57,9 +62,9 @@ public static class ViewExtensions
                 {
                     yield return found;
                 }
-                else if (item is Layout anotherLayout)
+                else if (item is View childView)
                 {
-                    foreach (var child in anotherLayout.FindManyInChildrenHierarchy<T>())
+                    foreach (var child in childView.FindManyInChildrenHierarchy<T>())
                     {
                         yield return child;
                     }
@@ -67,9 +72,9 @@ public static class ViewExtensions
             }
         }
 
-        if (view is ContentView contentView)
+        if (view is IContentView contentView && contentView.Content is View contentViewContent)
         {
-            foreach (var child in contentView.Content.FindManyInChildrenHierarchy<T>())
+            foreach (var child in contentViewContent.FindManyInChildrenHierarchy<T>())
             {
                 yield return child;
             }

--- a/src/UraniumUI/Extensions/ViewExtensions.cs
+++ b/src/UraniumUI/Extensions/ViewExtensions.cs
@@ -1,4 +1,6 @@
-﻿namespace UraniumUI.Extensions;
+﻿using Microsoft.Maui.Controls;
+
+namespace UraniumUI.Extensions;
 public static class ViewExtensions
 {
     public static T FindInParents<T>(this View view)
@@ -18,40 +20,59 @@ public static class ViewExtensions
         return default;
     }
 
-    public static T FindInChildrenHierarchy<T>(this Layout layout)
+    public static T FindInChildrenHierarchy<T>(this View view)
         where T : VisualElement
     {
-        foreach (var item in layout.Children)
+        if (view is Layout layout)
         {
-            if (item is T found)
+            foreach (var item in layout.Children)
             {
-                return found;
+                if (item is T found)
+                {
+                    return found;
+                }
+                else if (item is Layout anotherLayout)
+                {
+                    return anotherLayout.FindInChildrenHierarchy<T>();
+                }
             }
-            else if (item is Layout anotherLayout)
-            {
-                return anotherLayout.FindInChildrenHierarchy<T>();
-            }
+        }
+
+        if (view is ContentView contentView)
+        {
+            return contentView.Content.FindInChildrenHierarchy<T>();
         }
 
         return null;
     }
 
-    public static IEnumerable<T> FindManyInChildrenHierarchy<T>(this Layout layout)
+    public static IEnumerable<T> FindManyInChildrenHierarchy<T>(this View view)
         where T : View
     {
-        foreach (var item in layout.Children)
+        if (view is Layout layout)
         {
-            if (item is T found)
+            foreach (var item in layout.Children)
             {
-                yield return found;
-            }
-            else if (item is Layout anotherLayout)
-            {
-                foreach (var child in anotherLayout.FindManyInChildrenHierarchy<T>())
+                if (item is T found)
                 {
-                    yield return child;
+                    yield return found;
+                }
+                else if (item is Layout anotherLayout)
+                {
+                    foreach (var child in anotherLayout.FindManyInChildrenHierarchy<T>())
+                    {
+                        yield return child;
+                    }
                 }
             }
         }
+
+        if (view is ContentView contentView)
+        {
+            foreach (var child in contentView.Content.FindManyInChildrenHierarchy<T>())
+            {
+                yield return child;
+            }
+        }      
     }
 }


### PR DESCRIPTION
Single & Multiple selection options provided by `SelectedItem` and `SelectedItems` properties.

```xml
<material:TreeView SelectionMode="Single" />
```

![treeview-selection](https://github.com/enisn/UraniumUI/assets/23705418/27e8fdcc-2873-48c1-839d-3518b8e91f8e)


---

### Breaking Changes
- `ArrowColor` property has been removed from TreeView. _(Use styles instead like below)_
- New Styles:
  ```xml
              <Style TargetType="c:TreeView">
                  <Setter Property="SelectionColor" Value="{AppThemeBinding {StaticResource Secondary}, Dark={StaticResource SecondaryDark}}" />
              </Style>
  
              <Style TargetType="Label" Class="TreeView.Label" BaseResourceKey="Microsoft.Maui.Controls.Label">
              </Style>
  
              <Style TargetType="Label" Class="TreeView.Label.Selected" BaseResourceKey="Microsoft.Maui.Controls.Label" >
                  <Setter Property="TextColor" Value="{AppThemeBinding {StaticResource OnSecondary}, Dark={StaticResource OnSecondaryDark}}" />
              </Style>
  
              <Style TargetType="Path" Class="TreeView.Arrow" BaseResourceKey="Microsoft.Maui.Controls.Shapes.Path">
                  <Setter Property="Fill" Value="{AppThemeBinding Light={StaticResource OnBackground},Dark={StaticResource OnBackgroundDark}}" />
              </Style>
  
              <Style TargetType="Path" Class="TreeView.Arrow.Selected" BaseResourceKey="Microsoft.Maui.Controls.StyleClass.TreeView.Arrow">
                  <Setter Property="Fill" Value="{AppThemeBinding {StaticResource OnSecondary}, Dark={StaticResource OnSecondaryDark}}" />
              </Style>
  ```