### PR TITLE
Add sorting algorithm to AutoCompleteView

### DIFF
--- a/src/UraniumUI/Handlers/AutoCompleteViewHandler.Apple.cs
+++ b/src/UraniumUI/Handlers/AutoCompleteViewHandler.Apple.cs
@@ -24,7 +24,7 @@ public partial class AutoCompleteViewHandler : ViewHandler<IAutoCompleteView, UI
         var view = new UIAutoCompleteTextField
         {
             AutoCompleteViewSource = new AutoCompleteDefaultDataSource(),
-            SortingAlgorithm = (d, b) => b,
+            SortingAlgorithm = (d, b) => b.OrderBy(x => x.StartsWith(d, StringComparison.InvariantCultureIgnoreCase) ? 0 : 1).ToArray(),
         };
         view.Text = VirtualView.Text;
         view.TextColor = VirtualView.TextColor.ToPlatform();
@@ -133,7 +133,7 @@ public class UIAutoCompleteTextField : MauiTextField, IUITextFieldDelegate
     private UIViewController _parentViewController;
     private UIScrollView _scrollView;
 
-    public Func<string, ICollection<string>, ICollection<string>> SortingAlgorithm { get; set; } = (t, d) => d;
+    public Func<string, ICollection<string>, ICollection<string>> SortingAlgorithm { get; set; } = (t, d) => d.OrderBy(x => x.Contains(t, StringComparison.InvariantCultureIgnoreCase) ? 0 : 1).ToArray();
 
     public AutoCompleteViewSource AutoCompleteViewSource
     {


### PR DESCRIPTION
Closes https://github.com/enisn/UraniumUI/issues/489

I've updated wrong SortingAlgorithm in AutoCompleteView.


But this method isn't suggested by apple and probably won't be accepted by Apple. They suggest showing suggestions in a table view inside entire page:

<img width="320" src="https://github.com/enisn/UraniumUI/assets/23705418/4b423c1f-b5ef-4f2b-86a1-799547478105" />
