### PR TITLE
MultiplePickerField Binding fix - use same collection always

### DIFF
--- a/src/UraniumUI.Material/Controls/MultipleSelectionField.cs
+++ b/src/UraniumUI.Material/Controls/MultipleSelectionField.cs
@@ -53,6 +53,11 @@ public partial class MultiplePickerField : InputField
 
         _pickSelectionsCommand = new Command(async () =>
         {
+            if (SelectedItems is null)
+            {
+                return;
+            }
+
             IsBusy = true;
             var result = await DialogService.DisplayCheckBoxPromptAsync(
                 this.Title,
@@ -62,7 +67,12 @@ public partial class MultiplePickerField : InputField
 
             if (result != null)
             {
-                SelectedItems = new ObservableCollection<object>(result);
+                SelectedItems.Clear();
+                foreach (var item in result)
+                {
+                    SelectedItems.Add(item);
+                }
+
                 UpdateState();
             }
             IsBusy = false;

--- a/test/UraniumUI.Material.Tests/Controls/MultiplePickerField_Test.cs
+++ b/test/UraniumUI.Material.Tests/Controls/MultiplePickerField_Test.cs
@@ -1,0 +1,40 @@
+﻿using System.Collections.ObjectModel;
+using UraniumUI.Material.Controls;
+using UraniumUI.Tests.Core;
+
+namespace UraniumUI.Material.Tests.Controls;
+
+public class MultiplePickerField_Test
+{
+    public MultiplePickerField_Test()
+    {
+        ApplicationExtensions.CreateAndSetMockApplication();
+    }
+    
+    private string[] GetItemsSource() => new string[] { "Option 1", "Option 2", "Option 3", "Option 4", };
+
+    [Fact]
+    public void Initialize_WithSelectedItems()
+    {
+        var control = AnimationReadyHandler.Prepare(new MultiplePickerField());
+        var viewModel = new TestViewModel();
+        viewModel.SelectedItems.Add(viewModel.ItemsSource[0]);
+        viewModel.SelectedItems.Add(viewModel.ItemsSource[2]);
+
+        control.BindingContext = viewModel;
+        control.ItemsSource = viewModel.ItemsSource;
+
+        control.SetBinding(MultiplePickerField.SelectedItemsProperty, new Binding(nameof(TestViewModel.SelectedItems)));
+
+        // Assert
+        Assert.True(control.SelectedItems.Contains(viewModel.ItemsSource[0]));
+        Assert.True(control.SelectedItems.Contains(viewModel.ItemsSource[2]));
+    }
+
+    public class TestViewModel : UraniumBindableObject
+    {
+        public string[] ItemsSource { get; set; } = new string[] { "Option 1", "Option 2", "Option 3", "Option 4", };
+
+        public ObservableCollection<string> SelectedItems { get; } = new();
+    }
+}


### PR DESCRIPTION
The problem occurs because of creating new collection for each selection. So using the same instance of collection solves the problem

Closes https://github.com/enisn/UraniumUI/issues/374
![multiplepickerfield-fix](https://github.com/enisn/UraniumUI/assets/23705418/db417a41-e432-4f59-bf47-16e6f78ac6dc)
