### PR TITLE
Show validations when unfocused on Windows

### DIFF
--- a/src/UraniumUI.Material/Controls/InputField.cs
+++ b/src/UraniumUI.Material/Controls/InputField.cs
@@ -143,7 +143,6 @@ public partial class InputField : Grid
         }
     }
 
-#if !WINDOWS
     protected override void OnHandlerChanged()
     {
         base.OnHandlerChanged();
@@ -160,9 +159,10 @@ public partial class InputField : Grid
 
     protected virtual void OnFocusChanged(object sender, FocusEventArgs args)
     {
+#if !WINDOWS
         (this as IGridLayout).IsFocused = args.IsFocused;
-    }
 #endif
+    }
 
     // TODO: Remove this member hiding after android unfocus fixed.
     public new void Unfocus()

--- a/src/UraniumUI.Material/Controls/TextField.cs
+++ b/src/UraniumUI.Material/Controls/TextField.cs
@@ -88,10 +88,12 @@ public partial class TextField : InputField
             UpdateState();
         }
 
+#if !WINDOWS // Workaround for https://github.com/enisn/UraniumUI/issues/373
         if (e.NewTextValue != null)
         {
             CheckAndShowValidations();
         }
+#endif
 
         if (AllowClear)
         {
@@ -99,6 +101,18 @@ public partial class TextField : InputField
         }
 
         TextChanged?.Invoke(this, e);
+    }
+
+    protected override void OnFocusChanged(object sender, FocusEventArgs args)
+    {
+        base.OnFocusChanged(sender, args);
+
+#if WINDOWS // Workaround for https://github.com/enisn/UraniumUI/issues/373
+        if (!args.IsFocused)
+        {
+            CheckAndShowValidations();
+        }
+#endif
     }
 
     private void EntryView_Completed(object sender, EventArgs e)


### PR DESCRIPTION
Impementation according to https://github.com/enisn/UraniumUI/issues/373#issuecomment-1890787651

Still not stable, I'll work on it soon