### PR TITLE
Add BorderThichness to InputField border calculations

### DIFF
--- a/src/UraniumUI.Material/Controls/InputField.cs
+++ b/src/UraniumUI.Material/Controls/InputField.cs
@@ -215,7 +215,7 @@ public partial class InputField : Grid
         };
 #endif
 
-        border.StrokeDashArray = new DoubleCollection { calculatedFirstDash * 0.9, space, perimeter, 0 };
+        border.StrokeDashArray = new DoubleCollection { calculatedFirstDash * 0.9 / BorderThickness, space / BorderThickness, perimeter, 0 };
 
 #if WINDOWS
         this.Add(border);


### PR DESCRIPTION
Closes https://github.com/enisn/UraniumUI/issues/571
![inputfield-borderthickness](https://github.com/enisn/UraniumUI/assets/23705418/4515f657-8ea6-49f6-a3fa-0b39ec2a28f3)
