### PR TITLE
DataGrid Column IsVisible & Title binding

### DIFF
--- a/demo/UraniumApp/Pages/DataGrids/SimpleDataGridPage.xaml
+++ b/demo/UraniumApp/Pages/DataGrids/SimpleDataGridPage.xaml
@@ -14,7 +14,7 @@
                 <material:DataGrid ItemsSource="{Binding Items}" UseAutoColumns="True" HorizontalOptions="Center" Margin="30">
                     <material:DataGrid.TitleTemplate>
                         <DataTemplate>
-                            <Label Text="{Binding Value}" FontSize="Subtitle" Margin="10" TextColor="{AppThemeBinding Light={StaticResource Primary}, Dark={StaticResource PrimaryDark}}" />
+                            <Label Text="{Binding Title}" FontSize="Subtitle" Margin="10" TextColor="{AppThemeBinding Light={StaticResource Primary}, Dark={StaticResource PrimaryDark}}" />
                         </DataTemplate>
                     </material:DataGrid.TitleTemplate>
                 </material:DataGrid>

--- a/src/UraniumUI.Material/Controls/DataGrid.cs
+++ b/src/UraniumUI.Material/Controls/DataGrid.cs
@@ -178,10 +178,11 @@ public partial class DataGrid : Border
 
         for (int i = 0; i < Columns.Count; i++)
         {
-            var titleView = Columns[i].TitleView
+            var column = Columns[i];
+            var titleView = column.TitleView
                 ?? TitleTemplate?.CreateContent() as View
-                ?? LabelFactory("Value")
-                ?? CreateLabel("Value");
+                ?? LabelFactory(nameof(DataGridColumn.Title))
+                ?? CreateLabel(nameof(DataGridColumn.Title));
 
             if (titleView is Label label)
             {
@@ -189,10 +190,8 @@ public partial class DataGrid : Border
             }
 
             // TODO: Use an attribute to localize it.
-            titleView.BindingContext = new
-            {
-                Value = Columns[i].Title
-            };
+            titleView.BindingContext = column;
+            titleView.SetBinding(View.IsVisibleProperty, nameof(DataGridColumn.IsVisible));
 
             _rootGrid.Add(titleView, column: i, row);
         }
@@ -206,24 +205,27 @@ public partial class DataGrid : Border
 
         for (int columnNumber = 0; columnNumber < Columns.Count; columnNumber++)
         {
-            var binding = Columns[columnNumber].Binding as Binding;
+            var column = Columns[columnNumber];
+            var binding = column.Binding as Binding;
 
             var path = binding?.Path; // Backward compatibility.
 
-            var created = (View)Columns[columnNumber].CellItemTemplate?.CreateContent()
+            var created = (View)column.CellItemTemplate?.CreateContent()
                 ?? (View)CellItemTemplate?.CreateContent()
                 ?? LabelFactory(path) ?? CreateLabel(path);
 
-            var view = new ContentView
+            var cell = new ContentView
             {
                 Content = created,
                 BindingContext = item,
             };
 
-            SetSelectionVisualStates(view);
+            cell.SetBinding(ContentView.IsVisibleProperty, new Binding(nameof(DataGridColumn.IsVisible), source: column));
+
+            SetSelectionVisualStates(cell);
 
             _rootGrid.RowDefinitions.Add(new RowDefinition(GridLength.Auto));
-            _rootGrid.Add(view, columnNumber, row: actualRow);
+            _rootGrid.Add(cell, columnNumber, row: actualRow);
         }
     }
 

--- a/src/UraniumUI.Material/Controls/DataGridColumn.cs
+++ b/src/UraniumUI.Material/Controls/DataGridColumn.cs
@@ -1,9 +1,22 @@
 ﻿using System.ComponentModel;
 
 namespace UraniumUI.Material.Controls;
-public class DataGridColumn
+
+public class DataGridColumn : BindableObject
 {
-    public string Title { get; set; }
+    public string Title { get => (string)GetValue(TitleProperty); set => SetValue(TitleProperty, value); }
+
+    public static readonly BindableProperty TitleProperty = BindableProperty.Create(
+        nameof(Title),
+        typeof(string),
+        typeof(DataGridColumn),
+        propertyChanged: (bindable, oldValue, newValue) =>
+        {
+            if (bindable is DataGridColumn column)
+            {
+                column.OnPropertyChanged(nameof(Title));
+            }
+        });
 
     public View TitleView { get; set; }
 
@@ -13,4 +26,19 @@ public class DataGridColumn
 
     [TypeConverter(typeof(GridLengthTypeConverter))]
     public GridLength Width { get; set; } = GridLength.Auto;
+
+    public bool IsVisible { get => (bool)GetValue(IsVisibleProperty); set => SetValue(IsVisibleProperty, value); }
+
+    public static readonly BindableProperty IsVisibleProperty = BindableProperty.Create(
+        nameof(IsVisible),
+        typeof(bool),
+        typeof(DataGridColumn),
+        true,
+        propertyChanged: (bindable, oldValue, newValue) =>
+        {
+            if (bindable is DataGridColumn column)
+            {
+                column.OnPropertyChanged(nameof(IsVisible));
+            }
+        });
 }


### PR DESCRIPTION
## Extended Properties

- Now `Title` can be used with `Binding` extension.

```xml
<material:DataGrid>
     <material:DataGrid.Columns>
     <material:DataGridColumn Binding="{Binding Id}" Title="{binding IdTitle}" />
     <material:DataGridColumn Binding="{Binding Name}" Title="{Binding NameTitle}" />
     <material:DataGridColumn Binding="{Binding Age}" Title="{Binding AgeTitle}" />
 </material:DataGrid.Columns>
</material:DataGrid>
```

- `IsVisible` is added can be used with `Binding`, too.

```xml
<material:DataGridColumn Binding="{Binding Id}" IsVisible="{OnIdiom Desktop=True, Phone=False}"/>
<!-- OR -->
<material:DataGridColumn Binding="{Binding Id}" IsVisible="{Binding IsIdColumnVisible}"/>
```

---

## Breaking Changes

- DataGrid header uses directly `DataGridColumn` object as binding context. If you have a custom header template, you have to change `{Binding Value}` to `{Binding Title}` usage:

```xml
 <material:DataGrid ItemsSource="{Binding Items}" UseAutoColumns="True">
      <material:DataGrid.TitleTemplate>
          <DataTemplate>
             <!-- 👇 old ❌ -->
             <!-- <Label Text="{Binding Value}" /> -->

             <!-- 👇 new ✅ -->
              <Label Text="{Binding Title}" />
          </DataTemplate>
      </material:DataGrid.TitleTemplate>
  </material:DataGrid>
```