### PR TITLE
Prevent unfocusing Textfield while showing validations

### DIFF
--- a/src/UraniumUI.Material/Controls/TextField.FocusingWorkaround.cs
+++ b/src/UraniumUI.Material/Controls/TextField.FocusingWorkaround.cs
@@ -24,14 +24,15 @@ public partial class TextField
 
     protected override async void CheckAndShowValidations()
     {
-        base.CheckAndShowValidations();
-
+        /* Disable focus for a short time to prevent unfocusing
+         * while validation adding to the layout */
         canUnfocus = false;
         unfocusCts.Cancel();
         unfocusCts = new CancellationTokenSource();
-        /* Disable focus for a short time to prevent unfocusing
-         * while validation adding to the layout */
-        await EnableFocusAfterAsync(100, unfocusCts.Token);
+
+        base.CheckAndShowValidations();
+
+        await EnableFocusAfterAsync(500, unfocusCts.Token);
     }
 
     async Task EnableFocusAfterAsync(int delayMs, CancellationToken cancellationToken)

--- a/src/UraniumUI.Material/Controls/TextField.FocusingWorkaround.cs
+++ b/src/UraniumUI.Material/Controls/TextField.FocusingWorkaround.cs
@@ -1,0 +1,47 @@
+﻿namespace UraniumUI.Material.Controls;
+public partial class TextField
+{
+#if WINDOWS // Workaround for https://github.com/enisn/UraniumUI/issues/373
+    partial void AfterConstructor()
+    {
+        EntryView.HandlerChanged += (s, e) =>
+        {
+            if (EntryView.Handler.PlatformView is Microsoft.UI.Xaml.Controls.TextBox view)
+            {
+                view.LosingFocus += (s, e) =>
+                {
+                    if (!canUnfocus)
+                    {
+                        e.TryCancel();
+                    }
+                };
+            }
+        };
+    }
+
+    protected bool canUnfocus = true;
+    CancellationTokenSource unfocusCts = new();
+
+    protected override async void CheckAndShowValidations()
+    {
+        base.CheckAndShowValidations();
+
+        canUnfocus = false;
+        unfocusCts.Cancel();
+        unfocusCts = new CancellationTokenSource();
+        /* Disable focus for a short time to prevent unfocusing
+         * while validation adding to the layout */
+        await EnableFocusAfterAsync(100, unfocusCts.Token);
+    }
+
+    async Task EnableFocusAfterAsync(int delayMs, CancellationToken cancellationToken)
+    {
+        await Task.Delay(delayMs);
+        if (cancellationToken.IsCancellationRequested)
+        {
+            return;
+        }
+        canUnfocus = true;
+    }
+#endif
+}

--- a/src/UraniumUI.Material/Controls/TextField.cs
+++ b/src/UraniumUI.Material/Controls/TextField.cs
@@ -45,7 +45,7 @@ public partial class TextField : InputField
     public TextField()
     {
         iconClear.TappedCommand = new Command(OnClearTapped);
-        
+
         UpdateClearIconState();
         EntryView.SetBinding(Entry.TextProperty, new Binding(nameof(Text), source: this));
         EntryView.SetBinding(Entry.ReturnCommandParameterProperty, new Binding(nameof(ReturnCommandParameter), source: this));
@@ -54,7 +54,11 @@ public partial class TextField : InputField
         EntryView.SetBinding(Entry.CursorPositionProperty, new Binding(nameof(CursorPosition), source: this));
         EntryView.SetBinding(Entry.IsEnabledProperty, new Binding(nameof(IsEnabled), source: this));
         EntryView.SetBinding(Entry.IsReadOnlyProperty, new Binding(nameof(IsReadOnly), source: this));
+
+        AfterConstructor();
     }
+
+    partial void AfterConstructor();
 
     protected override void OnHandlerChanged()
     {


### PR DESCRIPTION
Resolves https://github.com/enisn/UraniumUI/issues/373

It's not a good solution but better then current:

![textfield-unfocusing](https://github.com/enisn/UraniumUI/assets/23705418/719271d8-36e3-4654-8de3-59b153221f1e)
