### PR TITLE
#635 Update properties for two way binding to EntryView

### DIFF
--- a/src/UraniumUI.Material/Controls/TextField.BindableProperties.cs
+++ b/src/UraniumUI.Material/Controls/TextField.BindableProperties.cs
@@ -15,10 +15,10 @@ public partial class TextField
         typeof(string),
         typeof(TextField),
         string.Empty,
-        BindingMode.TwoWay, propertyChanging: (bindable, oldValue, newValue) =>
+        BindingMode.TwoWay,
+        propertyChanging: (bindable, oldValue, newValue) =>
         {
-            var textField = (TextField)bindable;
-            textField.UpdateClearIconState();
+            (bindable as TextField).UpdateClearIconState();
         });
 
     public Color TextColor { get => (Color)GetValue(TextColorProperty); set => SetValue(TextColorProperty, value); }
@@ -28,7 +28,10 @@ public partial class TextField
         typeof(Color),
         typeof(TextField),
         ColorResource.GetColor("OnBackground", "OnBackgroundDark", Colors.DarkGray),
-        propertyChanged: (bindable, oldValue, newValue) => (bindable as TextField).EntryView.TextColor = (Color)newValue);
+        propertyChanged: (bindable, oldValue, newValue) =>
+        {
+            (bindable as TextField).EntryView.TextColor = (Color)newValue;
+        });
 
     public string FontFamily { get => (string)GetValue(FontFamilyProperty); set => SetValue(FontFamilyProperty, value); }
 
@@ -52,7 +55,10 @@ public partial class TextField
         typeof(Keyboard),
         typeof(TextField),
         Keyboard.Default,
-        propertyChanged: (bindable, oldValue, newValue) => (bindable as TextField).EntryView.Keyboard = (Keyboard)newValue);
+        propertyChanged: (bindable, oldValue, newValue) =>
+        {
+            (bindable as TextField).EntryView.Keyboard = (Keyboard)newValue;
+        });
 
     public ClearButtonVisibility ClearButtonVisibility { get => (ClearButtonVisibility)GetValue(ClearButtonVisibilityProperty); set => SetValue(ClearButtonVisibilityProperty, value); }
 
@@ -61,7 +67,10 @@ public partial class TextField
         typeof(ClearButtonVisibility),
         typeof(TextField),
         ClearButtonVisibility.WhileEditing,
-        propertyChanged: (bindable, oldValue, newValue) => (bindable as TextField).EntryView.ClearButtonVisibility = (ClearButtonVisibility)newValue);
+        propertyChanged: (bindable, oldValue, newValue) =>
+        {
+            (bindable as TextField).EntryView.ClearButtonVisibility = (ClearButtonVisibility)newValue;
+        });
 
     public bool IsPassword { get => (bool)GetValue(IsPasswordProperty); set => SetValue(IsPasswordProperty, value); }
 
@@ -70,21 +79,26 @@ public partial class TextField
         typeof(bool),
         typeof(TextField),
         false,
-        propertyChanged: (bindable, oldValue, newValue) => (bindable as TextField).EntryView.IsPassword = (bool)newValue);
+        propertyChanged: (bindable, oldValue, newValue) =>
+        {
+            (bindable as TextField).EntryView.IsPassword = (bool)newValue;
+        });
 
     public object ReturnCommandParameter { get => GetValue(ReturnCommandParameterProperty); set => SetValue(ReturnCommandParameterProperty, value); }
 
     public static readonly BindableProperty ReturnCommandParameterProperty = BindableProperty.Create(
         nameof(ReturnCommandParameter),
         typeof(object),
-        typeof(TextField));
+        typeof(TextField),
+        defaultBindingMode: BindingMode.TwoWay);
 
     public ICommand ReturnCommand { get => (ICommand)GetValue(ReturnCommandProperty); set => SetValue(ReturnCommandProperty, value); }
 
     public static readonly BindableProperty ReturnCommandProperty = BindableProperty.Create(
         nameof(ReturnCommand),
         typeof(ICommand),
-        typeof(TextField), defaultBindingMode: BindingMode.TwoWay);
+        typeof(TextField),
+        defaultBindingMode: BindingMode.TwoWay);
 
     public double CharacterSpacing { get => (double)GetValue(CharacterSpacingProperty); set => SetValue(CharacterSpacingProperty, value); }
 
@@ -92,7 +106,10 @@ public partial class TextField
         nameof(CharacterSpacing),
         typeof(double),
         typeof(TextField),
-        propertyChanged: (bindable, oldValue, newValue) => (bindable as TextField).EntryView.CharacterSpacing = (double)newValue);
+        propertyChanged: (bindable, oldValue, newValue) =>
+        {
+            (bindable as TextField).EntryView.CharacterSpacing = (double)newValue;
+        });
 
     public ReturnType ReturnType { get => (ReturnType)GetValue(ReturnTypeProperty); set => SetValue(ReturnTypeProperty, value); }
 
@@ -100,21 +117,26 @@ public partial class TextField
         nameof(ReturnType),
         typeof(ReturnType),
         typeof(TextField),
-        propertyChanged: (bindable, oldValue, newValue) => (bindable as TextField).EntryView.ReturnType = (ReturnType)newValue);
+        propertyChanged: (bindable, oldValue, newValue) =>
+        {
+            (bindable as TextField).EntryView.ReturnType = (ReturnType)newValue;
+        });
 
     public int SelectionLength { get => (int)GetValue(SelectionLengthProperty); set => SetValue(SelectionLengthProperty, value); }
 
     public static readonly BindableProperty SelectionLengthProperty = BindableProperty.Create(
         nameof(SelectionLength),
         typeof(int),
-        typeof(TextField));
+        typeof(TextField),
+        defaultBindingMode: BindingMode.TwoWay);
 
     public int CursorPosition { get => (int)GetValue(CursorPositionProperty); set => SetValue(CursorPositionProperty, value); }
 
     public static readonly BindableProperty CursorPositionProperty = BindableProperty.Create(
         nameof(CursorPosition),
         typeof(int),
-        typeof(TextField));
+        typeof(TextField),
+        defaultBindingMode: BindingMode.TwoWay);
 
     public bool IsTextPredictionEnabled { get => (bool)GetValue(IsTextPredictionEnabledProperty); set => SetValue(IsTextPredictionEnabledProperty, value); }
 
@@ -122,7 +144,10 @@ public partial class TextField
         nameof(IsTextPredictionEnabled),
         typeof(bool),
         typeof(TextField),
-        propertyChanged: (bindable, oldValue, newValue) => (bindable as TextField).EntryView.IsTextPredictionEnabled = (bool)newValue);
+        propertyChanged: (bindable, oldValue, newValue) =>
+        {
+            (bindable as TextField).EntryView.IsTextPredictionEnabled = (bool)newValue;
+        });
 
     public int MaxLength { get => (int)GetValue(MaxLengthProperty); set => SetValue(MaxLengthProperty, value); }
 
@@ -130,7 +155,10 @@ public partial class TextField
         nameof(MaxLength),
         typeof(int),
         typeof(TextField),
-        propertyChanged: (bindable, oldValue, newValue) => (bindable as TextField).EntryView.MaxLength = (int)newValue);
+        propertyChanged: (bindable, oldValue, newValue) =>
+        {
+            (bindable as TextField).EntryView.MaxLength = (int)newValue;
+        });
 
     public bool AllowClear { get => (bool)GetValue(AllowClearProperty); set => SetValue(AllowClearProperty, value); }
 
@@ -156,8 +184,10 @@ public partial class TextField
         typeof(double),
         typeof(InputField),
         defaultValue: Label.FontSizeProperty.DefaultValue,
-        propertyChanged: (bindable, oldValue, newValue) => (bindable as TextField).EntryView.FontSize = (double)newValue
-        );
+        propertyChanged: (bindable, oldValue, newValue) =>
+        {
+            (bindable as TextField).EntryView.FontSize = (double)newValue;
+        });
 
     public FontAttributes FontAttributes { get => (FontAttributes)GetValue(FontAttributesProperty); set => SetValue(FontAttributesProperty, value); }
 
@@ -166,8 +196,10 @@ public partial class TextField
         typeof(FontAttributes),
         typeof(TextField),
         defaultValue: Entry.FontAttributesProperty.DefaultValue,
-        propertyChanged: (bindable, oldValue, newValue) => (bindable as TextField).EntryView.FontAttributes = (FontAttributes)newValue
-        );
+        propertyChanged: (bindable, oldValue, newValue) =>
+        {
+            (bindable as TextField).EntryView.FontAttributes = (FontAttributes)newValue;
+        });
 
     public TextAlignment HorizontalTextAlignment { get => (TextAlignment)GetValue(HorizontalTextAlignmentProperty); set => SetValue(HorizontalTextAlignmentProperty, value); }
 
@@ -176,8 +208,10 @@ public partial class TextField
         typeof(TextAlignment),
         typeof(TextField),
         defaultValue: Entry.HorizontalTextAlignmentProperty.DefaultValue,
-        propertyChanged: (bindable, oldValue, newValue) => (bindable as TextField).EntryView.HorizontalTextAlignment = (TextAlignment)newValue
-        );
+        propertyChanged: (bindable, oldValue, newValue) =>
+        {
+            (bindable as TextField).EntryView.HorizontalTextAlignment = (TextAlignment)newValue;
+        });
 
     public Color SelectionHighlightColor { get => (Color)GetValue(SelectionHighlightColorProperty); set => SetValue(SelectionHighlightColorProperty, value); }
 
@@ -186,6 +220,8 @@ public partial class TextField
         typeof(Color),
         typeof(TextField),
         defaultValue: EntryProperties.SelectionHighlightColorProperty.DefaultValue,
-        propertyChanged: (bindable, oldValue, newValue) => EntryProperties.SetSelectionHighlightColor(bindable, (Color)newValue)
-        );
+        propertyChanged: (bindable, oldValue, newValue) =>
+        {
+            EntryProperties.SetSelectionHighlightColor(bindable, (Color)newValue);
+        });
 }

--- a/src/UraniumUI.Material/Controls/TextField.cs
+++ b/src/UraniumUI.Material/Controls/TextField.cs
@@ -46,13 +46,14 @@ public partial class TextField : InputField
         iconClear.TappedCommand = new Command(OnClearTapped);
 
         UpdateClearIconState();
-        EntryView.SetBinding(Entry.TextProperty, new Binding(nameof(Text), source: this));
-        EntryView.SetBinding(Entry.ReturnCommandParameterProperty, new Binding(nameof(ReturnCommandParameter), source: this));
-        EntryView.SetBinding(Entry.ReturnCommandProperty, new Binding(nameof(ReturnCommand), source: this));
-        EntryView.SetBinding(Entry.SelectionLengthProperty, new Binding(nameof(SelectionLength), source: this));
-        EntryView.SetBinding(Entry.CursorPositionProperty, new Binding(nameof(CursorPosition), source: this));
-        EntryView.SetBinding(Entry.IsEnabledProperty, new Binding(nameof(IsEnabled), source: this));
-        EntryView.SetBinding(Entry.IsReadOnlyProperty, new Binding(nameof(IsReadOnly), source: this));
+
+        EntryView.SetBinding(Entry.TextProperty, new Binding(nameof(Text), BindingMode.TwoWay, source: this));
+        EntryView.SetBinding(Entry.ReturnCommandParameterProperty, new Binding(nameof(ReturnCommandParameter), BindingMode.TwoWay, source: this));
+        EntryView.SetBinding(Entry.ReturnCommandProperty, new Binding(nameof(ReturnCommand), BindingMode.TwoWay, source: this));
+        EntryView.SetBinding(Entry.SelectionLengthProperty, new Binding(nameof(SelectionLength), BindingMode.TwoWay, source: this));
+        EntryView.SetBinding(Entry.CursorPositionProperty, new Binding(nameof(CursorPosition), BindingMode.TwoWay, source: this));
+        EntryView.SetBinding(Entry.IsEnabledProperty, new Binding(nameof(IsEnabled), BindingMode.TwoWay, source: this));
+        EntryView.SetBinding(Entry.IsReadOnlyProperty, new Binding(nameof(IsReadOnly), BindingMode.TwoWay, source: this));
 
         AfterConstructor();
     }

--- a/test/UraniumUI.Material.Tests/Controls/TextField_Test.cs
+++ b/test/UraniumUI.Material.Tests/Controls/TextField_Test.cs
@@ -72,6 +72,26 @@ public class TextField_Test
     }
 
     [Fact]
+    public void TextProperty_Parent_ShouldTwoWayBind_Child()
+    {
+        var control = AnimationReadyHandler.Prepare(new TextField());
+
+        //Test Child->Parent
+        // Act
+        control.EntryView.Text = "Test 1";
+
+        // Assert
+        control.Text.ShouldBe(control.EntryView.Text);
+
+        //Test Parent->Child
+        // Act
+        control.Text = "Test 2";
+
+        // Assert
+        control.Text.ShouldBe(control.EntryView.Text);
+    }
+
+    [Fact]
     public void SelectionLength_ShouldBeSent_ToViewModel()
     {
         var control = AnimationReadyHandler.Prepare(new TextField());
@@ -84,6 +104,46 @@ public class TextField_Test
 
         // Assert
         viewModel.SelectionLength.ShouldBe(control.SelectionLength);
+    }
+
+    [Fact]
+    public void SelectionLengthProperty_Parent_ShouldTwoWayBind_Child ()
+    {
+        var control = AnimationReadyHandler.Prepare(new TextField());
+
+        //Test Child->Parent
+        // Act
+        control.EntryView.SelectionLength = 5;
+
+        // Assert
+        control.SelectionLength.ShouldBe(control.EntryView.SelectionLength);
+
+        //Test Parent->Child
+        // Act
+        control.SelectionLength = 10;
+
+        // Assert
+        control.SelectionLength.ShouldBe(control.EntryView.SelectionLength);
+    }
+
+    [Fact]
+    public void CursorPositionProperty_Parent_ShouldTwoWayBind_Child()
+    {
+        var control = AnimationReadyHandler.Prepare(new TextField());
+
+        //Test Child->Parent
+        // Act
+        control.EntryView.CursorPosition = 5;
+
+        // Assert
+        control.CursorPosition.ShouldBe(control.EntryView.CursorPosition);
+
+        //Test Parent->Child
+        // Act
+        control.CursorPosition = 10;
+
+        // Assert
+        control.CursorPosition.ShouldBe(control.EntryView.CursorPosition);
     }
 
     [Fact]
@@ -186,8 +246,11 @@ public class TextField_Test
         // Act
         control.SetBinding(TextField.ReturnCommandParameterProperty, new Binding(nameof(TestViewModel.CommandParameter)));
 
-        // Assert
+        // Assert child
         control.EntryView.ReturnCommandParameter.ShouldBe(viewModel.CommandParameter);
+
+        // Assert parent
+        control.ReturnCommandParameter.ShouldBe(viewModel.CommandParameter);
     }
 
     [Fact]


### PR DESCRIPTION
Updates issues with setting properties not applying to EntryView child

Formats bindable properties to a standard format