### PR TITLE
Expanding Pickerfield

### DIFF
--- a/src/UraniumUI.Material/Controls/PickerField.cs
+++ b/src/UraniumUI.Material/Controls/PickerField.cs
@@ -86,7 +86,7 @@ public class PickerField : InputField
     protected override void OnSizeAllocated(double width, double height)
     {
         base.OnSizeAllocated(width, height);
-        PickerView.WidthRequest = (width * .96f) - (AllowClear ? iconClear.Width : 0) - (imageIcon.IsValueCreated ? imageIcon.Value.Width : 0); // TODO:Make this value dynamic later.
+        PickerView.MinimumWidthRequest = (width * .96f) - (AllowClear ? iconClear.Width : 0) - (imageIcon.IsValueCreated ? imageIcon.Value.Width : 0);
     }
 #endif
 

--- a/src/UraniumUI.Material/Controls/PickerField.cs
+++ b/src/UraniumUI.Material/Controls/PickerField.cs
@@ -18,7 +18,6 @@ public class PickerField : InputField
     public override View Content { get; set; } = new PickerView
     {
         VerticalOptions = LayoutOptions.Center,
-        HorizontalOptions = LayoutOptions.Fill,
         Margin = new Thickness(15, 0),
 #if WINDOWS
         Opacity = 0,
@@ -87,7 +86,7 @@ public class PickerField : InputField
     protected override void OnSizeAllocated(double width, double height)
     {
         base.OnSizeAllocated(width, height);
-        PickerView.WidthRequest = width * .5; // TODO:Make this value dynamic later.
+        PickerView.WidthRequest = (width * .96f) - (AllowClear ? iconClear.Width : 0) - (imageIcon.IsValueCreated ? imageIcon.Value.Width : 0); // TODO:Make this value dynamic later.
     }
 #endif
 


### PR DESCRIPTION
Here;

**HorizontalOptions="Center"**

When content is longer and layout allows more width, it'll expand:
![pickerfield-expand](https://github.com/enisn/UraniumUI/assets/23705418/b0f522b0-6e82-452f-9b4f-dab6f9cc9b81)

Otherwise, If the Layout limits the space it'll be wrapped.
![image](https://github.com/enisn/UraniumUI/assets/23705418/6537e54f-2aae-4367-9c2c-5255bf0c80bc)
