### PR TITLE
Fixed missing notification

### DIFF
--- a/src/UraniumUI.Material/Controls/InputField.Validation.cs
+++ b/src/UraniumUI.Material/Controls/InputField.Validation.cs
@@ -55,7 +55,8 @@ public partial class InputField : IValidatable
             {
                 endIconsContainer.Remove(iconValidation.Value);
                 this.Remove(labelValidation.Value);
-            }
+                OnPropertyChanged(nameof(IsValid));
+			}
         }
         else
         {
@@ -66,7 +67,8 @@ public partial class InputField : IValidatable
             {
                 endIconsContainer.Add(iconValidation.Value);
                 this.Add(labelValidation.Value, row: 1);
-            }
+                OnPropertyChanged(nameof(IsValid));
+			}
         }
     }
 


### PR DESCRIPTION
Fixed problems when resetting the InputKit FormView. It seems that only a notification of IsValid property is missing.
I looked at InputKit.Shared.Controls.AdvancedEntry.CheckAndDisplayValidations() and copied the missing code from there.