### PR TITLE
Allow binding to HeaderTemplate and ContentTemplate of material:TabItem

### DIFF
--- a/src/UraniumUI.Material/Controls/TabItem.cs
+++ b/src/UraniumUI.Material/Controls/TabItem.cs
@@ -9,11 +9,17 @@ public class TabItem : UraniumBindableObject
 
     public static readonly BindableProperty TitleProperty = BindableProperty.Create(nameof(Title), typeof(string), typeof(TabItem));
 
-    public object Data { get; set; }
-    public DataTemplate ContentTemplate { get; set; }
-    public DataTemplate HeaderTemplate { get; set; }
+    public DataTemplate HeaderTemplate { get => (DataTemplate)GetValue(HeaderTemplateProperty); set => SetValue(HeaderTemplateProperty, value); }
+
+    public static readonly BindableProperty HeaderTemplateProperty = BindableProperty.Create(nameof(HeaderTemplate), typeof(DataTemplate), typeof(TabItem), defaultBindingMode: BindingMode.TwoWay);
+
+    public DataTemplate ContentTemplate { get => (DataTemplate)GetValue(ContentTemplateProperty); set => SetValue(ContentTemplateProperty, value); }
+
+    public static readonly BindableProperty ContentTemplateProperty = BindableProperty.Create(nameof(ContentTemplate), typeof(DataTemplate), typeof(TabItem), defaultBindingMode: BindingMode.TwoWay);
+
     public View Content { get; set; }
     public View Header { get; set; }
+    public object Data { get; set; }
     public TabView TabView { get; internal set; }
     public bool IsSelected { get => TabView.SelectedTab == this || (TabView.CurrentItem != null && TabView.CurrentItem == Data); }
 


### PR DESCRIPTION
In our code, we wanted to reuse a named DataTemplate that was  defined in our Styles.xaml:

```xaml
<DataTemplate x:Key="TabHeaderTemplate" x:DataType="material:TabItem">
        <Label
            Padding="0,0,0,5"
            HorizontalOptions="Center"
            VerticalOptions="Center"
            LineBreakMode="MiddleTruncation"
            Text="{Binding Title}">
            <Label.Triggers>
                <DataTrigger Binding="{Binding IsSelected}" TargetType="Label" Value="True">
                    <Setter Property="TextColor" Value="{StaticResource Primary}" />
                    <Setter Property="Scale" Value="1.2" />
                </DataTrigger>
                <DataTrigger Binding="{Binding IsSelected}" TargetType="Label" Value="False">
                    <Setter Property="TextColor" Value="Gray" />
                    <Setter Property="Scale" Value="1" />
                </DataTrigger>
            </Label.Triggers>
        </Label>
    </DataTemplate>
```

 and apply as an implicit style it as a default to all `TabItem` s like so:

```xaml
<Style TargetType="material:TabItem">
  <Setter Property="HeaderTemplate" Value="{StaticResource TabHeaderTemplate}" />
</Style>
```

Currently, this is not possible, since [TabItem.cs](https://github.com/enisn/UraniumUI/blob/develop/src/UraniumUI.Material/Controls/TabItem.cs) does not expose its properties `DataTemplate` and `ContentTemplate` as [BindableProperties](https://learn.microsoft.com/en-us/dotnet/maui/fundamentals/bindable-properties?view=net-maui-8.0).

This Pull Request enables this possibility.