### PR TITLE
fix I18N bug

### DIFF
--- a/src/UraniumUI/Options/AutoFormViewOptions.cs
+++ b/src/UraniumUI/Options/AutoFormViewOptions.cs
@@ -20,7 +20,7 @@ public sealed class AutoFormViewOptions
         var attribute = property.GetCustomAttribute<DisplayAttribute>();
         if (attribute != null)
         {
-            return attribute.Name;
+            return attribute.GetName();
         }
 
         return property.Name;


### PR DESCRIPTION
use `GetName()` instead of the original name key