### PR TITLE
Update CommunityToolkitDialogService.cs

### DIFF
--- a/src/UraniumUI.Dialogs.CommunityToolkit/CommunityToolkitDialogService.cs
+++ b/src/UraniumUI.Dialogs.CommunityToolkit/CommunityToolkitDialogService.cs
@@ -51,7 +51,10 @@ public class CommunityToolkitDialogService : IDialogService
         {
             return tabbed.CurrentPage;
         }
-
+        if (Application.Current.MainPage is FlyoutPage page)
+        {
+	        return page.Flyout;
+        }
         return Application.Current.MainPage;
     }
 }


### PR DESCRIPTION
Fix. The DialogService fix does not work in an application when the main Flyout page.