### PR TITLE
Use same instance of ItemsSource of AutoCompleteView

### DIFF
--- a/src/UraniumUI/Controls/AutoCompleteView.cs
+++ b/src/UraniumUI/Controls/AutoCompleteView.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections;
 using System.Windows.Input;
 
 namespace UraniumUI.Controls;
@@ -56,7 +57,7 @@ public class AutoCompleteView : View, IAutoCompleteView
         typeof(AutoCompleteView),
         Colors.DarkGray);
 
-    public IList<string> ItemsSource { get => (IList<string>)GetValue(ItemsSourceProperty); set => SetValue(ItemsSourceProperty, value); }
+    public IList ItemsSource { get => (IList)GetValue(ItemsSourceProperty); set => SetValue(ItemsSourceProperty, value); }
 
     public static readonly BindableProperty ItemsSourceProperty = BindableProperty.Create(nameof(ItemsSource),
             typeof(IList<string>),

--- a/src/UraniumUI/Controls/IAutoCompleteView.cs
+++ b/src/UraniumUI/Controls/IAutoCompleteView.cs
@@ -1,11 +1,13 @@
-﻿namespace UraniumUI.Controls;
+﻿using System.Collections;
+
+namespace UraniumUI.Controls;
 
 public interface IAutoCompleteView : IView
 {
     string Text { get; set; }
     string SelectedText { get; set; }
     Color TextColor { get; set; }
-    IList<string> ItemsSource { get; set; }
+    IList ItemsSource { get; set; }
     int Threshold { get; set; }
 
     void Completed();

--- a/src/UraniumUI/Handlers/AutoCompleteViewHandler.Android.cs
+++ b/src/UraniumUI/Handlers/AutoCompleteViewHandler.Android.cs
@@ -8,6 +8,7 @@ using AndroidX.AppCompat.Widget;
 using Microsoft.Maui.Controls.Compatibility.Platform.Android;
 using Microsoft.Maui.Controls.Platform;
 using Microsoft.Maui.Handlers;
+using System.Collections;
 using UraniumUI.Controls;
 
 namespace UraniumUI.Handlers;
@@ -98,7 +99,7 @@ public partial class AutoCompleteViewHandler : ViewHandler<IAutoCompleteView, Ap
     {
         var adapter = new BoxArrayAdapter(Context,
             Android.Resource.Layout.SimpleDropDownItem1Line,
-            VirtualView.ItemsSource.ToList());
+            VirtualView.ItemsSource);
 
         PlatformView.Adapter = adapter;
 
@@ -129,12 +130,12 @@ public partial class AutoCompleteViewHandler : ViewHandler<IAutoCompleteView, Ap
 
 internal class BoxArrayAdapter : ArrayAdapter
 {
-    private readonly IList<string> _objects;
+    private readonly IList _objects;
 
     public BoxArrayAdapter(
         Context context,
         int textViewResourceId,
-        List<string> objects) : base(context, textViewResourceId, objects)
+        IList objects) : base(context, textViewResourceId, objects)
     {
         _objects = objects;
     }

--- a/src/UraniumUI/Handlers/AutoCompleteViewHandler.Windows.cs
+++ b/src/UraniumUI/Handlers/AutoCompleteViewHandler.Windows.cs
@@ -44,12 +44,10 @@ public partial class AutoCompleteViewHandler : ViewHandler<IAutoCompleteView, Au
             VirtualView.Text = sender.Text;
         }
 
-        if (VirtualView.ItemsSource != null && !string.IsNullOrEmpty(sender.Text))
+        if (args.Reason == AutoSuggestionBoxTextChangeReason.UserInput && VirtualView.ItemsSource != null && !string.IsNullOrEmpty(sender.Text) && VirtualView.ItemsSource is IEnumerable<object> suggestions)
         {
-            PlatformView.ItemsSource = VirtualView.ItemsSource.Where(x => x.Contains(sender.Text));
+            PlatformView.ItemsSource = suggestions.Where(x => x != null && x.ToString().Contains(sender.Text, StringComparison.InvariantCultureIgnoreCase));
         }
-
-        PlatformView.IsSuggestionListOpen = sender.Text.Length < VirtualView.Threshold;
     }
 
     private void PlatformView_GotFocus(object sender, Microsoft.UI.Xaml.RoutedEventArgs e)


### PR DESCRIPTION
This PR converts AutoCompleteView ItemsSource to `IList` and starts using always the same instance instead creating new collections while filtering.

---

Resolves https://github.com/enisn/UraniumUI/issues/654