### PR TITLE
Memory usage optimizations

### DIFF
--- a/demo/UraniumApp/MauiProgram.cs
+++ b/demo/UraniumApp/MauiProgram.cs
@@ -1,6 +1,8 @@
 ﻿//using CommunityToolkit.Maui;
 using CommunityToolkit.Maui;
 using DotNurse.Injector;
+using MemoryToolkit.Maui;
+using Microsoft.Extensions.Logging;
 using Mopups.Hosting;
 using ReactiveUI;
 using System.Reactive;
@@ -32,6 +34,12 @@ public static class MauiProgram
                 fonts.AddMaterialSymbolsFonts();
                 fonts.AddFluentIconFonts();
             });
+
+#if DEBUG
+        builder.Logging.AddDebug();
+
+        builder.UseLeakDetection(target => Console.WriteLine("Leaked: " +target.Name));
+#endif
 
         builder.Services.Configure<AutoFormViewOptions>(options =>
         {

--- a/demo/UraniumApp/UraniumApp.csproj
+++ b/demo/UraniumApp/UraniumApp.csproj
@@ -52,10 +52,12 @@
 	</ItemGroup>
 
 	<ItemGroup>
+		<PackageReference Include="AdamE.MemoryToolkit.Maui" Version="1.0.0" />
 		<PackageReference Include="DotNurse.Injector" Version="2.5.2" />
 		<PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
 		<PackageReference Include="ReactiveUI.Fody" Version="19.5.1" />
 		<PackageReference Include="Bogus" Version="35.4.0" />
+        <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="8.0.0" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/src/UraniumUI.Material/Controls/AutoCompleteTextField.cs
+++ b/src/UraniumUI.Material/Controls/AutoCompleteTextField.cs
@@ -12,6 +12,13 @@ public class AutoCompleteTextField : InputField
 
     public AutoCompleteView AutoCompleteView => this.FindByViewQueryIdInVisualTreeDescendants<AutoCompleteView>("AutoCompleteView");
 
+    public override View Content { get; set; } = new AutoCompleteView
+    {
+        Margin = new Thickness(10, 0),
+        BackgroundColor = Colors.Transparent,
+        VerticalOptions = LayoutOptions.Center
+    };
+
     protected ContentView iconClear = new ContentView
     {
         VerticalOptions = LayoutOptions.Center,
@@ -29,12 +36,8 @@ public class AutoCompleteTextField : InputField
     {
         ItemsSource = new List<string>();
 
-        var autoCompleteView = new AutoCompleteView
-        {
-            Margin = new Thickness(10, 0),
-            BackgroundColor = Colors.Transparent,
-            VerticalOptions = LayoutOptions.Center
-        };
+        var autoCompleteView = Content as AutoCompleteView;
+
         autoCompleteView.SetId("AutoCompleteView");
 
         Content = autoCompleteView;

--- a/src/UraniumUI.Material/Controls/AutoCompleteTextField.cs
+++ b/src/UraniumUI.Material/Controls/AutoCompleteTextField.cs
@@ -2,6 +2,7 @@
 using UraniumUI.Controls;
 using UraniumUI.Pages;
 using UraniumUI.Resources;
+using UraniumUI.ViewExtensions;
 using Path = Microsoft.Maui.Controls.Shapes.Path;
 
 namespace UraniumUI.Material.Controls;
@@ -9,14 +10,7 @@ public class AutoCompleteTextField : InputField
 {
     private bool _clearTapped;
 
-    public AutoCompleteView AutoCompleteView => Content as AutoCompleteView;
-
-    public override View Content { get; set; } = new AutoCompleteView
-    {
-        Margin = new Thickness(10, 0),
-        BackgroundColor = Colors.Transparent,
-        VerticalOptions = LayoutOptions.Center
-    };
+    public AutoCompleteView AutoCompleteView => this.FindByViewQueryIdInVisualTreeDescendant<AutoCompleteView>("AutoCompleteView");
 
     protected ContentView iconClear = new ContentView
     {
@@ -35,22 +29,26 @@ public class AutoCompleteTextField : InputField
     {
         ItemsSource = new List<string>();
 
+        var autoCompleteView = new AutoCompleteView
+        {
+            Margin = new Thickness(10, 0),
+            BackgroundColor = Colors.Transparent,
+            VerticalOptions = LayoutOptions.Center
+        };
+        autoCompleteView.SetId("AutoCompleteView");
+
+        Content = autoCompleteView;
+
         iconClear.GestureRecognizers.Add(new TapGestureRecognizer
         {
             Command = new Command(OnClearTapped)
         });
 
-        AutoCompleteView.SetBinding(AutoCompleteView.TextProperty, new Binding(nameof(Text), source: this));
-        AutoCompleteView.SetBinding(AutoCompleteView.SelectedTextProperty, new Binding(nameof(SelectedText), source: this));
-        AutoCompleteView.SetBinding(AutoCompleteView.ItemsSourceProperty, new Binding(nameof(ItemsSource), source: this));
-
-        AutoCompleteView.Focused += AutoCompleteTextField_Focused;
-        this.Focused += AutoCompleteTextField_Focused;
-    }
-
-    private void AutoCompleteTextField_Focused(object sender, FocusEventArgs e)
-    {
-        Console.WriteLine("Focused");
+        autoCompleteView.SetBinding(AutoCompleteView.TextProperty, new Binding(nameof(Text), source: this));
+        autoCompleteView.SetBinding(AutoCompleteView.SelectedTextProperty, new Binding(nameof(SelectedText), source: this));
+        autoCompleteView.SetBinding(AutoCompleteView.ItemsSourceProperty, new Binding(nameof(ItemsSource), source: this));
+        autoCompleteView.SetBinding(AutoCompleteView.TextColorProperty, new Binding(nameof(TextColor), source: this));
+        autoCompleteView.SetBinding(AutoCompleteView.ThresholdProperty, new Binding(nameof(Threshold), source: this));
     }
 
     public override bool HasValue => !string.IsNullOrEmpty(Text);
@@ -162,8 +160,7 @@ public class AutoCompleteTextField : InputField
         nameof(TextColor),
         typeof(Color),
         typeof(AutoCompleteView),
-        ColorResource.GetColor("OnBackground", "OnBackgroundDark", Colors.DarkGray),
-        propertyChanged: (bindable, oldValue, newValue) => (bindable as AutoCompleteTextField).AutoCompleteView.TextColor = (Color)newValue);
+        ColorResource.GetColor("OnBackground", "OnBackgroundDark", Colors.DarkGray));
 
     public bool AllowClear { get => (bool)GetValue(AllowClearProperty); set => SetValue(AllowClearProperty, value); }
 

--- a/src/UraniumUI.Material/Controls/AutoCompleteTextField.cs
+++ b/src/UraniumUI.Material/Controls/AutoCompleteTextField.cs
@@ -10,7 +10,7 @@ public class AutoCompleteTextField : InputField
 {
     private bool _clearTapped;
 
-    public AutoCompleteView AutoCompleteView => this.FindByViewQueryIdInVisualTreeDescendant<AutoCompleteView>("AutoCompleteView");
+    public AutoCompleteView AutoCompleteView => this.FindByViewQueryIdInVisualTreeDescendants<AutoCompleteView>("AutoCompleteView");
 
     protected ContentView iconClear = new ContentView
     {

--- a/src/UraniumUI.Material/Controls/CheckBox.cs
+++ b/src/UraniumUI.Material/Controls/CheckBox.cs
@@ -1,11 +1,6 @@
-﻿using Microsoft.Maui.Platform;
-
-namespace UraniumUI.Material.Controls;
+﻿namespace UraniumUI.Material.Controls;
 
 [ContentProperty(nameof(Validations))]
 public partial class CheckBox : InputKit.Shared.Controls.CheckBox
 {
-    public CheckBox()
-    {
-    }
 }

--- a/src/UraniumUI.Material/Controls/InputField.Validation.cs
+++ b/src/UraniumUI.Material/Controls/InputField.Validation.cs
@@ -36,8 +36,7 @@ public partial class InputField : IValidatable
 
     protected virtual void InitializeValidation()
     {
-        //this.AddRowDefinition(new RowDefinition(GridLength.Auto));
-        //this.AddRowDefinition(new RowDefinition(GridLength.Auto));
+        // Keep it for the future requirements
     }
 
     protected virtual void CheckAndShowValidations()

--- a/src/UraniumUI.Material/Controls/InputField.Validation.cs
+++ b/src/UraniumUI.Material/Controls/InputField.Validation.cs
@@ -36,8 +36,8 @@ public partial class InputField : IValidatable
 
     protected virtual void InitializeValidation()
     {
-        this.AddRowDefinition(new RowDefinition(GridLength.Auto));
-        this.AddRowDefinition(new RowDefinition(GridLength.Auto));
+        //this.AddRowDefinition(new RowDefinition(GridLength.Auto));
+        //this.AddRowDefinition(new RowDefinition(GridLength.Auto));
     }
 
     protected virtual void CheckAndShowValidations()
@@ -54,7 +54,7 @@ public partial class InputField : IValidatable
             if (isStateChanged)
             {
                 endIconsContainer.Remove(iconValidation.Value);
-                this.Remove(labelValidation.Value);
+                this.rootGrid.Remove(labelValidation.Value);
                 OnPropertyChanged(nameof(IsValid));
 			}
         }
@@ -66,7 +66,7 @@ public partial class InputField : IValidatable
             if (isStateChanged)
             {
                 endIconsContainer.Add(iconValidation.Value);
-                this.Add(labelValidation.Value, row: 1);
+                this.rootGrid.Add(labelValidation.Value, row: 1);
                 OnPropertyChanged(nameof(IsValid));
 			}
         }
@@ -107,7 +107,7 @@ public partial class InputField : IValidatable
     public virtual void ResetValidation()
     {
         endIconsContainer.Remove(iconValidation.Value);
-        this.Remove(labelValidation.Value);
+        this.rootGrid.Remove(labelValidation.Value);
         lastValidationState = true;
     }
 }

--- a/src/UraniumUI.Material/Controls/InputField.cs
+++ b/src/UraniumUI.Material/Controls/InputField.cs
@@ -37,13 +37,13 @@ public partial class InputField : ContentView
             inputField.OnPropertyChanged(nameof(Content));
         }, defaultBindingMode: BindingMode.TwoWay);
 
-    protected Label labelTitle => this.FindByViewQueryIdInVisualTreeDescendant<Label>("TitleLabel");
+    protected Label labelTitle => this.FindByViewQueryIdInVisualTreeDescendants<Label>("TitleLabel");
 
-    protected Border border => this.FindByViewQueryIdInVisualTreeDescendant<Border>("Border");
+    protected Border border => this.FindByViewQueryIdInVisualTreeDescendants<Border>("Border");
 
-    protected Grid rootGrid => this.FindByViewQueryIdInVisualTreeDescendant<Grid>("RootGrid");
+    protected Grid rootGrid => this.FindByViewQueryIdInVisualTreeDescendants<Grid>("RootGrid");
 
-    protected Grid innerGrid => this.FindByViewQueryIdInVisualTreeDescendant<Grid>("InnerGrid");
+    protected Grid innerGrid => this.FindByViewQueryIdInVisualTreeDescendants<Grid>("InnerGrid");
 
     protected Lazy<Image> imageIcon = new Lazy<Image>(() =>
     {
@@ -58,7 +58,7 @@ public partial class InputField : ContentView
         };
     });
 
-    protected HorizontalStackLayout endIconsContainer => this.FindByViewQueryIdInVisualTreeDescendant<HorizontalStackLayout>("EndIconsContainer");
+    protected HorizontalStackLayout endIconsContainer => this.FindByViewQueryIdInVisualTreeDescendants<HorizontalStackLayout>("EndIconsContainer");
 
     public IList<IView> Attachments => endIconsContainer.Children;
 

--- a/src/UraniumUI.Material/Controls/PickerField.cs
+++ b/src/UraniumUI.Material/Controls/PickerField.cs
@@ -23,18 +23,20 @@ public class PickerField : InputField
 
     public override bool HasValue => SelectedItem != null;
 
+    public override View Content { get; set; } = new PickerView
+    {
+        VerticalOptions = LayoutOptions.Center,
+        Margin = new Thickness(15, 0),
+#if WINDOWS
+        Opacity = 0,
+#endif
+    };
+
     public event EventHandler<object> SelectedValueChanged;
 
     public PickerField()
     {
-        var pickerView = new PickerView
-        {
-            VerticalOptions = LayoutOptions.Center,
-            Margin = new Thickness(15, 0),
-#if WINDOWS
-        Opacity = 0,
-#endif
-        };
+        var pickerView = Content as PickerView;
         pickerView.SetId("PickerView");
 
         Content = pickerView;

--- a/src/UraniumUI.Material/Controls/PickerField.cs
+++ b/src/UraniumUI.Material/Controls/PickerField.cs
@@ -15,10 +15,10 @@ namespace UraniumUI.Material.Controls;
 [ContentProperty(nameof(Validations))]
 public class PickerField : InputField
 {
-    public PickerView PickerView => this.FindByViewQueryIdInVisualTreeDescendant<PickerView>("PickerView");
+    public PickerView PickerView => this.FindByViewQueryIdInVisualTreeDescendants<PickerView>("PickerView");
 
 #if WINDOWS
-    protected Label labelSelectedItem => this.FindByViewQueryIdInVisualTreeDescendant<Label>("LabelSelectedItem");
+    protected Label labelSelectedItem => this.FindByViewQueryIdInVisualTreeDescendants<Label>("LabelSelectedItem");
 #endif
 
     public override bool HasValue => SelectedItem != null;
@@ -143,7 +143,7 @@ public class PickerField : InputField
 
     protected virtual void UpdateClearIconState()
     {
-        var existing = endIconsContainer.FindByViewQueryIdInVisualTreeDescendant<StatefulContentView>("ClearIcon");
+        var existing = endIconsContainer.FindByViewQueryIdInVisualTreeDescendants<StatefulContentView>("ClearIcon");
 
         if (AllowClear)
         {

--- a/src/UraniumUI.Material/Controls/TextField.BindableProperties.cs
+++ b/src/UraniumUI.Material/Controls/TextField.BindableProperties.cs
@@ -27,11 +27,7 @@ public partial class TextField
         nameof(TextColor),
         typeof(Color),
         typeof(TextField),
-        ColorResource.GetColor("OnBackground", "OnBackgroundDark", Colors.DarkGray),
-        propertyChanged: (bindable, oldValue, newValue) =>
-        {
-            (bindable as TextField).EntryView.TextColor = (Color)newValue;
-        });
+        ColorResource.GetColor("OnBackground", "OnBackgroundDark", Colors.DarkGray));
 
     public string FontFamily { get => (string)GetValue(FontFamilyProperty); set => SetValue(FontFamilyProperty, value); }
 
@@ -231,9 +227,5 @@ public partial class TextField
         nameof(DisallowClearButtonFocus),
         typeof(bool),
         typeof(TextField),
-        false,
-        propertyChanged: (bindable, oldValue, newValue) =>
-        {
-            (bindable as TextField).iconClear.IsFocusable = !(bool)newValue;
-        });
+        false);
 }

--- a/src/UraniumUI.Material/Controls/TextField.cs
+++ b/src/UraniumUI.Material/Controls/TextField.cs
@@ -1,7 +1,10 @@
 ﻿using Plainer.Maui.Controls;
+using System.Windows.Input;
+using UraniumUI.Converters;
 using UraniumUI.Material.Extensions;
 using UraniumUI.Pages;
 using UraniumUI.Resources;
+using UraniumUI.ViewExtensions;
 using UraniumUI.Views;
 using Path = Microsoft.Maui.Controls.Shapes.Path;
 
@@ -10,29 +13,7 @@ namespace UraniumUI.Material.Controls;
 [ContentProperty(nameof(Validations))]
 public partial class TextField : InputField
 {
-    public EntryView EntryView => Content as EntryView;
-
-    public override View Content { get; set; } = new EntryView
-    {
-        Margin = new Thickness(10, 0),
-        BackgroundColor = Colors.Transparent,
-        VerticalOptions = LayoutOptions.Center
-    };
-
-    protected StatefulContentView iconClear = new StatefulContentView
-    {
-        VerticalOptions = LayoutOptions.Center,
-        HorizontalOptions = LayoutOptions.End,
-        IsVisible = false,
-        Padding = new Thickness(5, 0),
-        Margin = new Thickness(0, 0, 5, 0),
-        Content = new Path
-        {
-            StyleClass = new[] { "TextField.ClearIcon" },
-            Data = UraniumShapes.X,
-            Fill = ColorResource.GetColor("OnBackground", "OnBackgroundDark", Colors.DarkGray).WithAlpha(.5f),
-        }
-    };
+    public EntryView EntryView => this.FindByViewQueryIdInVisualTreeDescendant<EntryView>("EntryView");
 
     public override bool HasValue { get => !string.IsNullOrEmpty(Text); }
 
@@ -41,27 +22,40 @@ public partial class TextField : InputField
     public event EventHandler<TextChangedEventArgs> TextChanged;
     public event EventHandler Completed;
 
+    public ICommand ClearCommand { get; protected set; }
+
     public TextField()
     {
-        iconClear.TappedCommand = new Command(OnClearTapped);
+        var entryView = new EntryView
+        {
+            Margin = new Thickness(10, 0),
+            BackgroundColor = Colors.Transparent,
+            VerticalOptions = LayoutOptions.Center,
+        };
+
+        Content = entryView;
+        entryView.SetId("EntryView");
 
         UpdateClearIconState();
 
-        EntryView.SetBinding(Entry.TextProperty, new Binding(nameof(Text), BindingMode.TwoWay, source: this));
-        EntryView.SetBinding(Entry.ReturnCommandParameterProperty, new Binding(nameof(ReturnCommandParameter), BindingMode.TwoWay, source: this));
-        EntryView.SetBinding(Entry.ReturnCommandProperty, new Binding(nameof(ReturnCommand), BindingMode.TwoWay, source: this));
-        EntryView.SetBinding(Entry.SelectionLengthProperty, new Binding(nameof(SelectionLength), BindingMode.TwoWay, source: this));
-        EntryView.SetBinding(Entry.CursorPositionProperty, new Binding(nameof(CursorPosition), BindingMode.TwoWay, source: this));
-
-        EntryView.SetBinding(Entry.IsEnabledProperty, new Binding(nameof(IsEnabled), BindingMode.OneWay, source: this));
-        EntryView.SetBinding(Entry.IsReadOnlyProperty, new Binding(nameof(IsReadOnly), BindingMode.OneWay, source: this));
-
-        iconClear.SetBinding(StatefulContentView.IsFocusableProperty, new Binding(nameof(DisallowClearButtonFocus), source: this));
+        entryView.SetBinding(Entry.TextProperty, new Binding(nameof(Text), BindingMode.TwoWay, source: this));
+        entryView.SetBinding(Entry.TextColorProperty, new Binding(nameof(TextColor), BindingMode.OneWay, source: this));
+        entryView.SetBinding(Entry.ReturnCommandParameterProperty, new Binding(nameof(ReturnCommandParameter), BindingMode.TwoWay, source: this));
+        entryView.SetBinding(Entry.ReturnCommandProperty, new Binding(nameof(ReturnCommand), BindingMode.TwoWay, source: this));
+        entryView.SetBinding(Entry.SelectionLengthProperty, new Binding(nameof(SelectionLength), BindingMode.TwoWay, source: this));
+        entryView.SetBinding(Entry.CursorPositionProperty, new Binding(nameof(CursorPosition), BindingMode.TwoWay, source: this));
+        entryView.SetBinding(Entry.IsEnabledProperty, new Binding(nameof(IsEnabled), BindingMode.OneWay, source: this));
+        entryView.SetBinding(Entry.IsReadOnlyProperty, new Binding(nameof(IsReadOnly), BindingMode.OneWay, source: this));
 
         AfterConstructor();
     }
 
     partial void AfterConstructor();
+
+    protected override void OnApplyTemplate()
+    {
+        base.OnApplyTemplate();
+    }
 
     protected override void OnHandlerChanged()
     {
@@ -98,11 +92,6 @@ public partial class TextField : InputField
             CheckAndShowValidations();
         }
 
-        if (AllowClear)
-        {
-            iconClear.IsVisible = !string.IsNullOrEmpty(e.NewTextValue);
-        }
-
         TextChanged?.Invoke(this, e);
     }
 
@@ -136,16 +125,18 @@ public partial class TextField : InputField
 
     protected virtual void UpdateClearIconState()
     {
+        var existing = endIconsContainer.FindByViewQueryIdInVisualTreeDescendant<StatefulContentView>("ClearIcon");
         if (AllowClear)
         {
-            if (!endIconsContainer.Contains(iconClear))
+            if (existing == null)
             {
+                var iconClear = CreateIconClear();
                 endIconsContainer.Add(iconClear);
             }
         }
         else
         {
-            endIconsContainer.Remove(iconClear);
+            endIconsContainer?.Remove(existing);
         }
     }
 
@@ -153,5 +144,28 @@ public partial class TextField : InputField
     {
         EntryView.Text = string.Empty;
         base.ResetValidation();
+    }
+
+    protected virtual View CreateIconClear()
+    {
+        var contentView = new StatefulContentView
+        {
+            VerticalOptions = LayoutOptions.Center,
+            HorizontalOptions = LayoutOptions.End,
+            IsVisible = false,
+            Padding = new Thickness(5, 0),
+            Margin = new Thickness(0, 0, 5, 0),
+            TappedCommand = new Command(OnClearTapped),
+            Content = new Path
+            {
+                StyleClass = new[] { "TextField.ClearIcon" },
+                Data = UraniumShapes.X,
+                Fill = ColorResource.GetColor("OnBackground", "OnBackgroundDark", Colors.DarkGray).WithAlpha(.5f),
+            }
+        };
+        contentView.SetId("ClearIcon");
+        contentView.SetBinding(StatefulContentView.IsFocusableProperty, new Binding(nameof(DisallowClearButtonFocus), source: this));
+        contentView.SetBinding(StatefulContentView.IsVisibleProperty, new Binding(nameof(Text), converter: UraniumConverters.StringIsNotNullOrEmptyConverter, source: this));
+        return contentView;
     }
 }

--- a/src/UraniumUI.Material/Controls/TextField.cs
+++ b/src/UraniumUI.Material/Controls/TextField.cs
@@ -15,6 +15,13 @@ public partial class TextField : InputField
 {
     public EntryView EntryView => this.FindByViewQueryIdInVisualTreeDescendants<EntryView>("EntryView");
 
+    public override View Content { get; set; } = new EntryView
+    {
+        Margin = new Thickness(10, 0),
+        BackgroundColor = Colors.Transparent,
+        VerticalOptions = LayoutOptions.Center,
+    };
+
     public override bool HasValue { get => !string.IsNullOrEmpty(Text); }
 
     public IList<Behavior> EntryBehaviors => EntryView?.Behaviors;
@@ -26,14 +33,8 @@ public partial class TextField : InputField
 
     public TextField()
     {
-        var entryView = new EntryView
-        {
-            Margin = new Thickness(10, 0),
-            BackgroundColor = Colors.Transparent,
-            VerticalOptions = LayoutOptions.Center,
-        };
+        var entryView = Content as EntryView;
 
-        Content = entryView;
         entryView.SetId("EntryView");
 
         UpdateClearIconState();

--- a/src/UraniumUI.Material/Controls/TextField.cs
+++ b/src/UraniumUI.Material/Controls/TextField.cs
@@ -13,7 +13,7 @@ namespace UraniumUI.Material.Controls;
 [ContentProperty(nameof(Validations))]
 public partial class TextField : InputField
 {
-    public EntryView EntryView => this.FindByViewQueryIdInVisualTreeDescendant<EntryView>("EntryView");
+    public EntryView EntryView => this.FindByViewQueryIdInVisualTreeDescendants<EntryView>("EntryView");
 
     public override bool HasValue { get => !string.IsNullOrEmpty(Text); }
 
@@ -125,7 +125,7 @@ public partial class TextField : InputField
 
     protected virtual void UpdateClearIconState()
     {
-        var existing = endIconsContainer.FindByViewQueryIdInVisualTreeDescendant<StatefulContentView>("ClearIcon");
+        var existing = endIconsContainer.FindByViewQueryIdInVisualTreeDescendants<StatefulContentView>("ClearIcon");
         if (AllowClear)
         {
             if (existing == null)

--- a/src/UraniumUI.Material/Extensions/EntryProperties.cs
+++ b/src/UraniumUI.Material/Extensions/EntryProperties.cs
@@ -24,7 +24,7 @@ public static class EntryProperties
         }
 
 #if WINDOWS
-        if (entry.Handler.PlatformView is Microsoft.UI.Xaml.Controls.TextBox textBox)
+        if (entry.Handler?.PlatformView is Microsoft.UI.Xaml.Controls.TextBox textBox)
         {
             textBox.SelectionHighlightColor = new Microsoft.UI.Xaml.Media.SolidColorBrush(color.ToWindowsColor());
             textBox.BorderThickness = new Microsoft.UI.Xaml.Thickness(0);
@@ -32,13 +32,13 @@ public static class EntryProperties
             textBox.Style = null;
         }
 #elif ANDROID
-        if (entry.Handler.PlatformView is AndroidX.AppCompat.Widget.AppCompatEditText editText)
+        if (entry.Handler?.PlatformView is AndroidX.AppCompat.Widget.AppCompatEditText editText)
         {
             editText.SetHighlightColor(color.ToPlatform());
         }
 
 #elif IOS || MACCATALYST
-        if (entry.Handler.PlatformView is UIKit.UITextField textField)
+        if (entry.Handler?.PlatformView is UIKit.UITextField textField)
         {
             textField.TintColor = color.ToPlatform();
         }

--- a/src/UraniumUI.Validations.DataAnnotations/UraniumUI.Validations.DataAnnotations.csproj
+++ b/src/UraniumUI.Validations.DataAnnotations/UraniumUI.Validations.DataAnnotations.csproj
@@ -27,7 +27,7 @@
   </ItemGroup>
 
   <ItemGroup Condition="$(TargetFramework.Contains('net8'))">
-    <PackageReference Include="InputKit.Maui" Version="4.4.4" />
+    <PackageReference Include="InputKit.Maui" Version="4.4.5" />
   </ItemGroup>
 
 </Project>

--- a/src/UraniumUI/Converters/StringIsNotNullOrEmptyConverter.cs
+++ b/src/UraniumUI/Converters/StringIsNotNullOrEmptyConverter.cs
@@ -1,0 +1,20 @@
+﻿using System.Globalization;
+
+namespace UraniumUI.Converters;
+public class StringIsNotNullOrEmptyConverter : IValueConverter
+{
+    public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+    {
+        if (value is not string text)
+        {
+            text = value?.ToString();
+        }
+
+        return !string.IsNullOrEmpty(text);
+    }
+
+    public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+    {
+        throw new NotImplementedException();
+    }
+}

--- a/src/UraniumUI/Converters/UraniumConverters.cs
+++ b/src/UraniumUI/Converters/UraniumConverters.cs
@@ -1,0 +1,7 @@
+﻿using System.Reflection;
+
+namespace UraniumUI.Converters;
+public static class UraniumConverters
+{
+    public static StringIsNotNullOrEmptyConverter StringIsNotNullOrEmptyConverter { get; } = new();
+}

--- a/src/UraniumUI/Pages/UraniumShapes.cs
+++ b/src/UraniumUI/Pages/UraniumShapes.cs
@@ -4,13 +4,13 @@ using Microsoft.Maui.Controls.Shapes;
 namespace UraniumUI.Pages;
 public static class UraniumShapes
 {
-    public static Geometry ArrowRight = GeometryConverter.FromPath(Paths.ArrowRight);
-    public static Geometry ArrowDown = GeometryConverter.FromPath(Paths.ArrowDown);
-    public static Geometry ExclamationCircle = GeometryConverter.FromPath(Paths.ExclamationCircle);
-    public static Geometry X = GeometryConverter.FromPath(Paths.X);
-    public static Geometry XCircle = GeometryConverter.FromPath(Paths.XCircle);
-    public static Geometry Eye = GeometryConverter.FromPath(Paths.Eye);
-    public static Geometry EyeSlash = GeometryConverter.FromPath(Paths.EyeSlash);
+    public static Geometry ArrowRight => GeometryConverter.FromPath(Paths.ArrowRight);
+    public static Geometry ArrowDown => GeometryConverter.FromPath(Paths.ArrowDown);
+    public static Geometry ExclamationCircle => GeometryConverter.FromPath(Paths.ExclamationCircle);
+    public static Geometry X => GeometryConverter.FromPath(Paths.X);
+    public static Geometry XCircle => GeometryConverter.FromPath(Paths.XCircle);
+    public static Geometry Eye => GeometryConverter.FromPath(Paths.Eye);
+    public static Geometry EyeSlash => GeometryConverter.FromPath(Paths.EyeSlash);
 
     public static class Paths
 	{

--- a/src/UraniumUI/UraniumUI.csproj
+++ b/src/UraniumUI/UraniumUI.csproj
@@ -25,7 +25,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Maui.Controls" Version="$(MauiVersion)" />
-    <PackageReference Include="InputKit.Maui" Version="4.4.4" />
+    <PackageReference Include="InputKit.Maui" Version="4.4.5" />
     <PackageReference Include="Plainer.Maui" Version="1.7.1" />
   </ItemGroup>
 </Project>

--- a/src/UraniumUI/ViewExtensions/ViewQuery.cs
+++ b/src/UraniumUI/ViewExtensions/ViewQuery.cs
@@ -31,7 +31,7 @@ public static class ViewQuery
         return view.FindManyInChildrenHierarchy<T>(x => GetId(x) == id);
     }
 
-    public static T FindByViewQueryIdInVisualTreeDescendant<T>(this View view, string id)
+    public static T FindByViewQueryIdInVisualTreeDescendants<T>(this View view, string id)
         where T : VisualElement
     {
         return view.GetVisualTreeDescendants().OfType<T>().FirstOrDefault(x => GetId(x) == id);

--- a/src/UraniumUI/ViewExtensions/ViewQuery.cs
+++ b/src/UraniumUI/ViewExtensions/ViewQuery.cs
@@ -30,4 +30,10 @@ public static class ViewQuery
     {
         return view.FindManyInChildrenHierarchy<T>(x => GetId(x) == id);
     }
+
+    public static T FindByViewQueryIdInVisualTreeDescendant<T>(this View view, string id)
+        where T : VisualElement
+    {
+        return view.GetVisualTreeDescendants().OfType<T>().FirstOrDefault(x => GetId(x) == id);
+    }
 }

--- a/test/UraniumUI.Material.Tests/Controls/TextField_Test.cs
+++ b/test/UraniumUI.Material.Tests/Controls/TextField_Test.cs
@@ -74,6 +74,7 @@ public class TextField_Test
     [Fact]
     public void TextProperty_Parent_ShouldTwoWayBind_Child()
     {
+        
         var control = AnimationReadyHandler.Prepare(new TextField());
 
         //Test Child->Parent

--- a/test/UraniumUI.Material.Tests/Controls/TextField_Test.cs
+++ b/test/UraniumUI.Material.Tests/Controls/TextField_Test.cs
@@ -74,7 +74,6 @@ public class TextField_Test
     [Fact]
     public void TextProperty_Parent_ShouldTwoWayBind_Child()
     {
-        
         var control = AnimationReadyHandler.Prepare(new TextField());
 
         //Test Child->Parent

--- a/test/UraniumUI.Tests.Core/ApplicationExtensions.cs
+++ b/test/UraniumUI.Tests.Core/ApplicationExtensions.cs
@@ -15,6 +15,7 @@ public static class ApplicationExtensions
                                 .UseUraniumUI();
 
         builder?.Invoke(appBuilder);
+        appBuilder.ConfigureDispatching();
 
         var mauiApp = appBuilder.Build();
         var application = mauiApp.Services.GetRequiredService<IApplication>();


### PR DESCRIPTION
Resolves #727 

---

According to #727 some notable changes are made:

- `UraniumShapes` were singleton across application and all the components were using same instance. After this PR, each component will get newly created `Geometry` instances.

- **InputField Ctor initialization**: This is not a memory leak issue but it prevents disposing on **hot-reload** cases. All fields are removed and `ContentTemplate` will be used after this PR.
    - Also inheritors such as `TextField`, `AutoCompleteField`, `PickerField`, etc. are updated.

- Instead of keeping Views in fields, query will be used to access when necessary. 
    _This will reduce memory usage and prevent possible leaks but will increase CPU usage. This is a trade-off. Preventing possible leaks is more important for now._

Thanks to [usefulBeeing](https://github.com/usefulBeeing) for reporting the case

This changes may break some of cases, tests don't cover all the specific scenarios, so it'll be part of the next release `v2.10`