### PR TITLE
Tweaks for MacCatalyst

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -400,3 +400,7 @@ FodyWeavers.xsd
 # DocFx
 _site/
 api/
+
+# Mac resource files
+.DS_Store
+**/.DS_Store

--- a/src/UraniumUI.Material/Controls/InputField.cs
+++ b/src/UraniumUI.Material/Controls/InputField.cs
@@ -197,6 +197,12 @@ public partial class InputField : ContentView
 #if ANDROID
         Loaded += OnLoaded;
 #endif
+#if MACCATALYST
+        if (OperatingSystem.IsIOSVersionAtLeast(15) && Content.Handler.PlatformView is UIKit.UITextField textview)
+        {
+            textview.FocusEffect = null;
+        }
+#endif
 
         Content.Focused += OnFocusChanged;
         Content.Unfocused += OnFocusChanged;

--- a/src/UraniumUI/Handlers/AutoCompleteViewHandler.Apple.cs
+++ b/src/UraniumUI/Handlers/AutoCompleteViewHandler.Apple.cs
@@ -27,7 +27,10 @@ public partial class AutoCompleteViewHandler : ViewHandler<IAutoCompleteView, UI
         view.Text = VirtualView.Text;
         view.TextColor = VirtualView.TextColor.ToPlatform();
         view.ReturnKeyType = UIReturnKeyType.Done;
-        
+        if (OperatingSystem.IsIOSVersionAtLeast(15))
+        {
+            view.FocusEffect = null;
+        }
 
 
         view.AutoCompleteViewSource.Selected += AutoCompleteViewSourceOnSelected;

--- a/src/UraniumUI/Handlers/DropdownHandler.Apple.cs
+++ b/src/UraniumUI/Handlers/DropdownHandler.Apple.cs
@@ -24,6 +24,8 @@ public partial class DropdownHandler : ButtonHandler
         if (UIDevice.CurrentDevice.CheckSystemVersion(15, 0))
         {
             button.ChangesSelectionAsPrimaryAction = true;
+            var configuration = UIButtonConfiguration.PlainButtonConfiguration;
+            button.Configuration = configuration;
         }
 
 


### PR DESCRIPTION
- Remove focus effect from Input and AutoComplete when running on MacCatalyst.
- Set UIButton.Configuration in DropdownHandler to make the OS render it with the drop down arrows.