### PR TITLE
Add icon to DropdownHandler and update InputKit.Maui (#748)

### DIFF
--- a/src/UraniumUI.Validations.DataAnnotations/UraniumUI.Validations.DataAnnotations.csproj
+++ b/src/UraniumUI.Validations.DataAnnotations/UraniumUI.Validations.DataAnnotations.csproj
@@ -27,7 +27,7 @@
   </ItemGroup>
 
   <ItemGroup Condition="$(TargetFramework.Contains('net8'))">
-    <PackageReference Include="InputKit.Maui" Version="4.4.5" />
+    <PackageReference Include="InputKit.Maui" Version="4.4.6" />
   </ItemGroup>
 
 </Project>

--- a/src/UraniumUI/Handlers/DropdownHandler.Windows.cs
+++ b/src/UraniumUI/Handlers/DropdownHandler.Windows.cs
@@ -112,6 +112,19 @@ public partial class DropdownHandler : ButtonHandler
 
     protected void ArrangeText()
     {
+        var selectedIndex = VirtualViewDropdown.ItemsSource?.IndexOf(VirtualViewDropdown.SelectedItem) ?? -1;
+        if (PlatformView.Flyout is Microsoft.UI.Xaml.Controls.MenuFlyout flyout)
+        {
+            for (int i = 0; i < flyout.Items.Count; i++)
+            {
+                var menuItem = flyout.Items[i];
+                if (menuItem is Microsoft.UI.Xaml.Controls.MenuFlyoutItem menuFlyoutItem)
+                {
+                    menuFlyoutItem.Icon = i == selectedIndex ? new FontIcon() { Glyph="\uE73E" } : null;
+                }
+            }
+        }
+
         if (VirtualViewDropdown.SelectedItem is null)
         {
             PlatformView.Content = VirtualViewDropdown.Placeholder;

--- a/src/UraniumUI/UraniumUI.csproj
+++ b/src/UraniumUI/UraniumUI.csproj
@@ -25,7 +25,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Maui.Controls" Version="$(MauiVersion)" />
-    <PackageReference Include="InputKit.Maui" Version="4.4.5" />
+    <PackageReference Include="InputKit.Maui" Version="4.4.6" />
     <PackageReference Include="Plainer.Maui" Version="1.7.1" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Added code to DropdownHandler.Windows.cs to set a FontIcon for the selected item in a MenuFlyout if the Flyout is of type Microsoft.UI.Xaml.Controls.MenuFlyout.

Updated UraniumUI.Validations.DataAnnotations.csproj and UraniumUI.csproj to use InputKit.Maui version 4.4.6 for .NET 8.