### PR TITLE
Include tablets in CalculateSize condition (fixes #750)

### DIFF
--- a/src/UraniumUI.Dialogs.CommunityToolkit/CommunityToolkitDialogExtensions.cs
+++ b/src/UraniumUI.Dialogs.CommunityToolkit/CommunityToolkitDialogExtensions.cs
@@ -651,7 +651,7 @@ public static class CommunityToolkitDialogExtensions
 
     private static Size CalculateSize(Page page)
     {
-        if (DeviceInfo.Current.Idiom == DeviceIdiom.Desktop)
+        if (DeviceInfo.Current.Idiom == DeviceIdiom.Desktop || DeviceInfo.Current.Idiom == DeviceIdiom.Tablet)
         {
             return new Size(400, 400);
         }


### PR DESCRIPTION
The method `CalculateSize` in the `CommunityToolkitDialogExtensions` class has been modified to include tablets in the condition that previously only checked for desktops. This means that the method will now return a size of 400x400 for both desktop and tablet devices.