### PR TITLE
Arrange apple native arrow colors for dropdown

### DIFF
--- a/src/UraniumUI/Handlers/DropdownHandler.Apple.cs
+++ b/src/UraniumUI/Handlers/DropdownHandler.Apple.cs
@@ -5,6 +5,7 @@ using System.Collections.Specialized;
 using UIKit;
 using UraniumUI.Controls;
 using UraniumUI.Extensions;
+using UraniumUI.Resources;
 
 namespace UraniumUI.Handlers;
 
@@ -22,6 +23,7 @@ public partial class DropdownHandler : ButtonHandler
         SetItemsSource(VirtualViewDropdown, button);
 
         button.ShowsMenuAsPrimaryAction = true;
+        button.TintColor = ColorResource.GetColor("Primary", "PrimaryDark", Colors.Azure).ToPlatform();
         if (UIDevice.CurrentDevice.CheckSystemVersion(15, 0))
         {
             button.ChangesSelectionAsPrimaryAction = true;
@@ -117,6 +119,8 @@ public partial class DropdownHandler : ButtonHandler
             VirtualViewDropdown.Text = GetTextForItem(VirtualViewDropdown, VirtualViewDropdown.SelectedItem);
             PlatformView.SetTitleColor(VirtualViewDropdown.TextColor?.ToPlatform() ?? Colors.Black.ToPlatform(), UIControlState.Normal);
         }
+
+        PlatformView.TintColor = ColorResource.GetColor("Primary", "PrimaryDark", Colors.Azure).ToPlatform();
     }
 
     public static void MapPlaceholder(DropdownHandler handler, Dropdown dropdown)


### PR DESCRIPTION
## Before
<img width="288" alt="image" src="https://github.com/user-attachments/assets/220b7055-85e8-4412-98c3-dae498c4a55d">

## After
<img width="275" alt="image" src="https://github.com/user-attachments/assets/28760b95-1c8a-434b-84cf-ce5c7309754e">

It'll use `"Primary"` color from resources, for now it's not possible to customize separately. Since it's a platform-specific feature, I can't add a shared property for that for now

<img width="271" alt="image" src="https://github.com/user-attachments/assets/af4362cd-bb93-4e76-9ff7-a561bc0afbee">

