### PR TITLE
Use behaviour instead custom Binding for DataAnnotations

### DIFF
--- a/demo/UraniumApp/Pages/ValidationsPage.xaml
+++ b/demo/UraniumApp/Pages/ValidationsPage.xaml
@@ -20,16 +20,23 @@
             <StackLayout Padding="25" MaximumWidthRequest="400">
                 <input:FormView SubmitCommand="{Binding SubmitCommand}" Spacing="20">
 
-
                     <material:TextField Title="Email"
-                                        Text="{v:ValidationBinding Email}" 
-                                        Icon="{FontImage FontFamily=MaterialSharp, Glyph={x:Static m:MaterialSharp.Mail}}"/>
+                                        Text="{Binding Email}"
+                                        Icon="{FontImage FontFamily=MaterialSharp, Glyph={x:Static m:MaterialSharp.Mail}}">
+                        <material:TextField.Behaviors>
+                            <v:DataAnnotationsBehavior Binding="{Binding Email}" />
+                        </material:TextField.Behaviors>
+                    </material:TextField>
 
-                    <material:TextField Title="Fullname"
-                                        Text="{v:ValidationBinding FullName}" 
-                                        Icon="{FontImage FontFamily=MaterialSharp, Glyph={x:Static m:MaterialSharp.Person}}"/>
+                    <material:TextField Title="Fullname" 
+                                        Text="{Binding FullName}"
+                                        Icon="{FontImage FontFamily=MaterialSharp, Glyph={x:Static m:MaterialSharp.Person}}">
+                        <material:TextField.Behaviors>
+                            <v:DataAnnotationsBehavior Binding="{Binding FullName}" />
+                        </material:TextField.Behaviors>
+                    </material:TextField>
 
-                    <material:PickerField Title="Gender"
+                    <material:PickerField Title="Gender" AllowClear="True"
                                           SelectedItem="{Binding Gender}"
                                           Icon="{FontImage FontFamily=MaterialSharp, Glyph={x:Static m:MaterialSharp.Agender}}">
                         <material:PickerField.ItemsSource>

--- a/docs/en/docs-nav.json
+++ b/docs/en/docs-nav.json
@@ -240,6 +240,10 @@
         {
           "text": "Migration to v2.7",
           "path": "migration-guides/Migrating-To-2.7.md"
+        },
+        {
+          "text": "Migration to v2.11",
+          "path": "migration-guides/Migrating-To-2.11.md"
         }
       ]
     },

--- a/docs/en/migration-guides/Migrating-To-2.11.md
+++ b/docs/en/migration-guides/Migrating-To-2.11.md
@@ -1,0 +1,27 @@
+# Migration Guide to v2.11
+Version 2.11 comes with some breaking-changes. You should follow this docuemnt to migrate your code to the new version properly.
+
+You can see related PRs with breaking changes [from here](https://github.com/enisn/UraniumUI/pulls?q=is%3Aopen+is%3Apr+milestone%3Av2.11+label%3A%22breaking-change+%F0%9F%92%94%22)
+
+
+## Changes
+
+- `ValidationBinding` is obsolete now. You should use `DataAnnotationsBehavior` instead of `v:ValidationBinding`.
+
+    - Replace `v:ValidationBinding` with the regular `Binding` in XAML.
+    - Add `DataAnnotationsBehavior` to the `TextField.Behaviors` or any other control that you want to validate.
+
+        - **Before:**
+            ```xml
+            <material:TextField Text="{v:ValidationBinding Email}"/>
+            ```
+
+        - **After:**
+
+            ```xml
+            <material:TextField Text="{Binding Email}">
+                <material:TextField.Behaviors>
+                    <v:DataAnnotationsBehavior Binding="{Binding Email}" />
+                </material:TextField.Behaviors>
+            </material:TextField>
+            ```

--- a/docs/en/toc.yml
+++ b/docs/en/toc.yml
@@ -116,6 +116,8 @@
       href: migration-guides/Migrating-To-2.4.md
     - name: Migration to v2.7
       href: migration-guides/Migrating-To-2.7.md
+    - name: Migration to v2.11
+      href: migration-guides/Migrating-To-2.11.md
 - name: Support
   href: Support.md
   items:

--- a/docs/en/validations/DataAnnotations.md
+++ b/docs/en/validations/DataAnnotations.md
@@ -17,7 +17,7 @@ dotnet add package UraniumUI.Validations.DataAnnotations
     xmlns:v="clr-namespace:UraniumUI.Validations;assembly=UraniumUI.Validations.DataAnnotations"
     ```
 
-- Use the `DataAnnotationsBehavior ` method to bind the control with the validation rules.
+- Use the `DataAnnotationsBehavior` method to bind the control with the validation rules.
 
     ```xml
     <input:FormView>

--- a/docs/en/validations/DataAnnotations.md
+++ b/docs/en/validations/DataAnnotations.md
@@ -9,7 +9,7 @@ dotnet add package UraniumUI.Validations.DataAnnotations
 ```
 
 ## Usage
-With the simple `Binding` method, controls can't know the validation rules. You need to use the `ValidationBinding` method to bind the control with the validation rules.
+`DataAnnotationsBehavior` is a behavior that allows you to bind the validations from the ViewModel to the control. It's used with the `FormView` to validate the controls.
 
 - Add xmlns for the `UraniumUI.Validations` namespace.
 
@@ -17,11 +17,15 @@ With the simple `Binding` method, controls can't know the validation rules. You 
     xmlns:v="clr-namespace:UraniumUI.Validations;assembly=UraniumUI.Validations.DataAnnotations"
     ```
 
-- Use the `v:ValidationBinding` method to bind the control with the validation rules.
+- Use the `DataAnnotationsBehavior ` method to bind the control with the validation rules.
 
     ```xml
     <input:FormView>
-          <material:TextField Text="{v:ValidationBinding Email}" />
+        <material:TextField Text="{Binding Email}">
+            <material:TextField.Behaviors>
+                <v:DataAnnotationsBehavior Binding="{Binding Email}" />
+            </material:TextField.Behaviors>
+        </material:TextField>
             <!-- ... -->
     </input:FormView>
     ```

--- a/src/UraniumUI.Validations.DataAnnotations/Validations/DataAnnotationsBehavior.cs
+++ b/src/UraniumUI.Validations.DataAnnotations/Validations/DataAnnotationsBehavior.cs
@@ -1,0 +1,66 @@
+using InputKit.Shared.Abstraction;
+using System.ComponentModel.DataAnnotations;
+using System.Reflection;
+
+namespace UraniumUI.Validations;
+
+public class DataAnnotationsBehavior : Behavior<View>
+{
+    public BindingBase Binding { get; set; }
+
+    protected BindableObject bindable;
+
+    protected override void OnAttachedTo(BindableObject bindable)
+    {
+        base.OnAttachedTo(bindable);
+        this.bindable = bindable;
+        Apply();
+    }
+
+    protected override void OnAttachedTo(View bindable)
+    {
+        base.OnAttachedTo(bindable);
+        Apply();
+
+        bindable.BindingContextChanged -= Bindable_BindingContextChanged;
+        bindable.BindingContextChanged += Bindable_BindingContextChanged;
+    }
+
+    protected override void OnDetachingFrom(View bindable)
+    {
+        base.OnDetachingFrom(bindable);
+        bindable.BindingContextChanged -= Bindable_BindingContextChanged;
+    }
+
+    private void Bindable_BindingContextChanged(object sender, EventArgs e)
+    {
+        Apply();
+    }
+
+    void Apply()
+    {
+        if (bindable is not IValidatable validatable)
+        {
+            return;
+        }
+
+        if (Binding is Binding newBinding)
+        {
+            var source = newBinding.Source ?? bindable.BindingContext;
+
+            if (source is null)
+            {
+                return;
+            }
+
+            var propertyInfo = source.GetType().GetProperty(newBinding.Path);
+            var validationAttributes = propertyInfo.GetCustomAttributes<ValidationAttribute>(true);
+            var displayAttribute = propertyInfo.GetCustomAttribute<DisplayAttribute>(true);
+
+            foreach (var attribute in validationAttributes)
+            {
+                validatable.Validations.Add(new DataAnnotationValidation(attribute, displayAttribute?.GetName() ?? propertyInfo.Name));
+            }
+        }
+    }
+}

--- a/src/UraniumUI.Validations.DataAnnotations/Validations/DataAnotationValidation.cs
+++ b/src/UraniumUI.Validations.DataAnnotations/Validations/DataAnotationValidation.cs
@@ -3,6 +3,7 @@ using System.ComponentModel.DataAnnotations;
 using System.Reflection;
 
 namespace UraniumUI.Validations;
+
 public class DataAnnotationValidation : IValidation
 {
     public string Message { get; protected set; }

--- a/src/UraniumUI.Validations.DataAnnotations/Validations/ValidationBinding.cs
+++ b/src/UraniumUI.Validations.DataAnnotations/Validations/ValidationBinding.cs
@@ -7,6 +7,7 @@ using Microsoft.Maui.Controls.Internals;
 namespace UraniumUI.Validations;
 
 [ContentProperty(nameof(Path))]
+[Obsolete("Use the new DataAnnotationsBehavior instead.")]
 public class ValidationBinding : IMarkupExtension<BindingBase>, IMarkupExtension
 {
     public string Path { get; set; }


### PR DESCRIPTION
Due to https://github.com/dotnet/maui/issues/16881 issue, we can't access the root object to retrieve DataAnnotations with reflection.

So ValidationBinding is obsolete now,
Alternatively `DataAnnotationsBehavior` is introduced in this PR.