### PR TITLE
Workaround for DatePicker and TimePicker controls not being able to set to value present in wrapped MAUI control

### DIFF
--- a/src/UraniumUI.Material/Controls/DatePickerField.cs
+++ b/src/UraniumUI.Material/Controls/DatePickerField.cs
@@ -1,5 +1,6 @@
 ﻿using Plainer.Maui.Controls;
 using System.ComponentModel;
+using UraniumUI.Controls;
 using UraniumUI.Pages;
 using UraniumUI.Resources;
 using UraniumUI.Views;
@@ -10,8 +11,8 @@ namespace UraniumUI.Material.Controls;
 [ContentProperty(nameof(Validations))]
 public class DatePickerField : InputField
 {
-    public DatePickerView DatePickerView => Content as DatePickerView;
-    public override View Content { get; set; } = new DatePickerView
+    public DatePickerWrappedView DatePickerView => Content as DatePickerWrappedView;
+    public override View Content { get; set; } = new DatePickerWrappedView
     {
         VerticalOptions = LayoutOptions.Center,
 #if ANDROID
@@ -44,11 +45,11 @@ public class DatePickerField : InputField
 
         UpdateClearIconState();
 
-        DatePickerView.SetBinding(DatePickerView.DateProperty, new Binding(nameof(Date), source: this));
-        DatePickerView.SetBinding(DatePickerView.IsEnabledProperty, new Binding(nameof(IsEnabled), source: this));
-        DatePickerView.SetBinding(DatePickerView.FontSizeProperty, new Binding(nameof(FontSize), source: this));
-        DatePickerView.SetBinding(DatePickerView.FontAutoScalingEnabledProperty, new Binding(nameof(FontAutoScalingEnabled), source: this));
-        DatePickerView.SetBinding(DatePickerView.FontFamilyProperty, new Binding(nameof(FontFamily), source: this));
+        DatePickerView.SetBinding(DatePicker.DateProperty, new Binding(nameof(Date), source: this));
+        DatePickerView.SetBinding(DatePicker.IsEnabledProperty, new Binding(nameof(IsEnabled), source: this));
+        DatePickerView.SetBinding(DatePicker.FontSizeProperty, new Binding(nameof(FontSize), source: this));
+        DatePickerView.SetBinding(DatePicker.FontAutoScalingEnabledProperty, new Binding(nameof(FontAutoScalingEnabled), source: this));
+        DatePickerView.SetBinding(DatePicker.FontFamilyProperty, new Binding(nameof(FontFamily), source: this));
 
 #if MACCATALYST || IOS
         labelTitle.InputTransparent = true;

--- a/src/UraniumUI.Material/Controls/TimePickerField.cs
+++ b/src/UraniumUI.Material/Controls/TimePickerField.cs
@@ -1,5 +1,6 @@
 ﻿using Plainer.Maui.Controls;
 using System.ComponentModel;
+using UraniumUI.Controls;
 using UraniumUI.Pages;
 using UraniumUI.Resources;
 using UraniumUI.Views;
@@ -10,8 +11,8 @@ namespace UraniumUI.Material.Controls;
 [ContentProperty(nameof(Validations))]
 public class TimePickerField : InputField
 {
-    public TimePickerView TimePickerView => Content as TimePickerView;
-    public override View Content { get; set; } = new TimePickerView
+    public TimePickerWrappedView TimePickerView => Content as TimePickerWrappedView;
+    public override View Content { get; set; } = new TimePickerWrappedView
     {
         VerticalOptions = LayoutOptions.Center,
 #if WINDOWS

--- a/src/UraniumUI/Controls/DatePickerWrappedView.cs
+++ b/src/UraniumUI/Controls/DatePickerWrappedView.cs
@@ -1,0 +1,27 @@
+﻿using Plainer.Maui.Controls;
+
+namespace UraniumUI.Controls;
+
+/// <summary>
+/// TODO Revisit when the underlying dotnet/maui issue is fixed: https://github.com/dotnet/maui/issues/13156
+/// A workaround for abovementioned issue where the DateSelected event is not raised when the date is the same as the current date.
+/// This "manually" raises the PropertyChanged event when the date is the same as the current date by briefly setting it to a different time before applying the actual value.
+/// Alternatively, this workaround could be implemented in Plainer.Maui.Controls.DatePickerView directly.
+/// </summary>
+public class DatePickerWrappedView : DatePickerView, IDatePicker
+{
+    DateTime IDatePicker.Date
+    {
+        get => Date;
+        set
+        {
+            if (value == Date)
+            {
+                Date += TimeSpan.FromDays(1);
+            }
+
+            Date = value;
+            OnPropertyChanged(nameof(Date));
+        }
+    }
+}

--- a/src/UraniumUI/Controls/TimePickerWrappedView.cs
+++ b/src/UraniumUI/Controls/TimePickerWrappedView.cs
@@ -1,0 +1,25 @@
+﻿using Plainer.Maui.Controls;
+
+namespace UraniumUI.Controls;
+
+
+/// <summary>
+/// See explanation in <see cref="DatePickerWrappedView"/>
+/// </summary>
+public class TimePickerWrappedView : TimePickerView, ITimePicker
+{
+    TimeSpan ITimePicker.Time
+    {
+        get => Time;
+        set
+        {
+            if (value == Time)
+            {
+                Time += TimeSpan.FromSeconds(1);
+            }
+
+            Time = value;
+            OnPropertyChanged(nameof(Time));
+        }
+    }
+}


### PR DESCRIPTION
Fixes #84

As indicated in comment in DatePickerWrappedView, could alternatively also be a pull request in [Plainer](https://github.com/enisn/Xamarin.Forms.Plainer), which would remove the necessity of changing UraniumUI code.