### PR TITLE
Change VerticalStack and ScrollView

### DIFF
--- a/src/UraniumUI/Dialogs/DefaultDialogService.cs
+++ b/src/UraniumUI/Dialogs/DefaultDialogService.cs
@@ -424,12 +424,12 @@ public class DefaultDialogService : IDialogService
         var popupPage = new DefaultDialogAnimatedContentPage
         {
             BackgroundColor = GetBackdropColor(),
-            Content = GetFrame(Page.Width, new VerticalStackLayout
+            Content = GetFrame(Page.Width, new ScrollView
             {
                 Children =
                 {
                     GetHeader(title),
-                    new ScrollView { Content = formView },
+                    new VerticalStackLayout { Content = formView },
                     GetDivider(),
                     GetFooter(new Dictionary<string, Command>
                     {


### PR DESCRIPTION
Replace VerticalStackLayout to ScrollView and from ScrollView to VerticalStackLayout.

This change will handle error when AutoFormView is way to long vertically so you can't scroll. Now if ScrollView is parent of VerticalStackLayout you can scroll.