### PR TITLE
Fix for bug 825 - AutoCompleteTextField not closing keyboard area in android

### DIFF
--- a/src/UraniumUI/Handlers/AutoCompleteViewHandler.Android.cs
+++ b/src/UraniumUI/Handlers/AutoCompleteViewHandler.Android.cs
@@ -42,6 +42,7 @@ public partial class AutoCompleteViewHandler : ViewHandler<IAutoCompleteView, Ap
     {
         platformView.TextChanged += PlatformView_TextChanged;
         platformView.FocusChange += PlatformView_FocusChange;
+        platformView.EditorAction += PlatformView_EditorAction;
         platformView.ItemClick += PlatformView_ItemClicked;
     }
 
@@ -49,6 +50,7 @@ public partial class AutoCompleteViewHandler : ViewHandler<IAutoCompleteView, Ap
     {
         platformView.TextChanged -= PlatformView_TextChanged;
         platformView.FocusChange -= PlatformView_FocusChange;
+        platformView.EditorAction -= PlatformView_EditorAction;
         platformView.ItemClick -= PlatformView_ItemClicked;
     }
 
@@ -67,7 +69,28 @@ public partial class AutoCompleteViewHandler : ViewHandler<IAutoCompleteView, Ap
             PlatformView.ShowDropDown();
         }
     }
-   
+
+    private void PlatformView_EditorAction(object sender, TextView.EditorActionEventArgs e)
+    {
+        if (e.ActionId == Android.Views.InputMethods.ImeAction.Done)
+        {
+           VirtualView.Completed();
+           
+          // Cast sender to TextView
+          if (sender is TextView textView)
+          {
+              // Get the InputMethodManager
+              var inputMethodManager = (InputMethodManager)textView.Context.GetSystemService(Context.InputMethodService);
+
+              // Hide the soft keyboard
+              inputMethodManager?.HideSoftInputFromWindow(textView.WindowToken, 0);
+          }
+
+          // Mark the event as handled
+          e.Handled = true;
+        }
+    }
+
     private void PlatformView_ItemClicked(object sender, Android.Widget.AdapterView.ItemClickEventArgs e)
     {
         if (VirtualView.SelectedText != PlatformView.Text)

--- a/src/UraniumUI/Handlers/AutoCompleteViewHandler.Android.cs
+++ b/src/UraniumUI/Handlers/AutoCompleteViewHandler.Android.cs
@@ -42,7 +42,6 @@ public partial class AutoCompleteViewHandler : ViewHandler<IAutoCompleteView, Ap
     {
         platformView.TextChanged += PlatformView_TextChanged;
         platformView.FocusChange += PlatformView_FocusChange;
-        platformView.EditorAction += PlatformView_EditorAction;
         platformView.ItemClick += PlatformView_ItemClicked;
     }
 
@@ -50,7 +49,6 @@ public partial class AutoCompleteViewHandler : ViewHandler<IAutoCompleteView, Ap
     {
         platformView.TextChanged -= PlatformView_TextChanged;
         platformView.FocusChange -= PlatformView_FocusChange;
-        platformView.EditorAction -= PlatformView_EditorAction;
         platformView.ItemClick -= PlatformView_ItemClicked;
     }
 
@@ -69,15 +67,7 @@ public partial class AutoCompleteViewHandler : ViewHandler<IAutoCompleteView, Ap
             PlatformView.ShowDropDown();
         }
     }
-
-    private void PlatformView_EditorAction(object sender, TextView.EditorActionEventArgs e)
-    {
-        if (e.ActionId == Android.Views.InputMethods.ImeAction.Done)
-        {
-            VirtualView.Completed();
-        }
-    }
-
+   
     private void PlatformView_ItemClicked(object sender, Android.Widget.AdapterView.ItemClickEventArgs e)
     {
         if (VirtualView.SelectedText != PlatformView.Text)


### PR DESCRIPTION
Code written in handler of AutompleteTextField, PlatformView.EditorAction event prevents android to close keyboard.
Removing this action on this event works as expected in android.