### PR TITLE
Fix TextField ClearIcon not appearing in latest MAUI version, AllowClear in Style no longer causes crash

### DIFF
--- a/demo/UraniumApp/Pages/InputFields/TextFieldPage.xaml
+++ b/demo/UraniumApp/Pages/InputFields/TextFieldPage.xaml
@@ -67,7 +67,7 @@
                     <Label Text="Simple set of TextFields." FontSize="Subtitle" Margin="20"/>
 
                     <VerticalStackLayout StyleClass="ControlPreview" Spacing="12">
-                        <material:TextField Title="Name" />
+                        <material:TextField Title="Name" AllowClear="True" />
                         <material:TextField Title="Surname" />
                         <material:TextField Title="Age" Keyboard="Numeric" />
                     </VerticalStackLayout>

--- a/demo/UraniumApp/UraniumApp.csproj
+++ b/demo/UraniumApp/UraniumApp.csproj
@@ -57,8 +57,8 @@
 		<PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
 		<PackageReference Include="ReactiveUI.Fody" Version="19.5.1" />
 		<PackageReference Include="Bogus" Version="35.4.0" />
-        <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="9.0.0" />
-        <PackageReference Include="Microsoft.Maui.Controls.Compatibility" Version="$(MauiVersion)" />
+		<PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="9.0.0" />
+		<PackageReference Include="Microsoft.Maui.Controls.Compatibility" Version="9.0.50" />
 	</ItemGroup>
 
 	<ItemGroup>
@@ -81,8 +81,12 @@
 
 	<ItemGroup>
 	  <MauiXaml Update="Resources\Styles\Override.xaml">
-	    <Generator>MSBuild:Compile</Generator>
+		<Generator>MSBuild:Compile</Generator>
 	  </MauiXaml>
+	</ItemGroup>
+
+	<ItemGroup>
+	  <PackageReference Update="Microsoft.Maui.Controls" Version="9.0.50" />
 	</ItemGroup>
 
 </Project>

--- a/demo/UraniumApp/UraniumApp.csproj
+++ b/demo/UraniumApp/UraniumApp.csproj
@@ -57,8 +57,8 @@
 		<PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
 		<PackageReference Include="ReactiveUI.Fody" Version="19.5.1" />
 		<PackageReference Include="Bogus" Version="35.4.0" />
-		<PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="9.0.0" />
-		<PackageReference Include="Microsoft.Maui.Controls.Compatibility" Version="9.0.50" />
+        <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="9.0.0" />
+        <PackageReference Include="Microsoft.Maui.Controls.Compatibility" Version="$(MauiVersion)" />
 	</ItemGroup>
 
 	<ItemGroup>
@@ -81,12 +81,8 @@
 
 	<ItemGroup>
 	  <MauiXaml Update="Resources\Styles\Override.xaml">
-		<Generator>MSBuild:Compile</Generator>
+	    <Generator>MSBuild:Compile</Generator>
 	  </MauiXaml>
-	</ItemGroup>
-
-	<ItemGroup>
-	  <PackageReference Update="Microsoft.Maui.Controls" Version="9.0.50" />
 	</ItemGroup>
 
 </Project>

--- a/src/UraniumUI.Material/Controls/TextField.BindableProperties.cs
+++ b/src/UraniumUI.Material/Controls/TextField.BindableProperties.cs
@@ -16,7 +16,7 @@ public partial class TextField
         typeof(TextField),
         string.Empty,
         BindingMode.TwoWay,
-        propertyChanging: (bindable, oldValue, newValue) =>
+        propertyChanged: (bindable, oldValue, newValue) =>
         {
             (bindable as TextField).UpdateClearIconState();
         });

--- a/src/UraniumUI.Material/Controls/TextField.cs
+++ b/src/UraniumUI.Material/Controls/TextField.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.Extensions.Logging;
+using Microsoft.Maui.Controls;
 using Plainer.Maui.Controls;
 using System.Windows.Input;
 using UraniumUI.Converters;
@@ -167,7 +168,7 @@ public partial class TextField : InputField
         {
             VerticalOptions = LayoutOptions.Center,
             HorizontalOptions = LayoutOptions.End,
-            IsVisible = false,
+            IsVisible = true, // this is important; having initial state of false will have SetBinding have no effect, since it will not receive input events
             Padding = new Thickness(5, 0),
             Margin = new Thickness(0, 0, 5, 0),
             TappedCommand = new Command(OnClearTapped),
@@ -178,12 +179,14 @@ public partial class TextField : InputField
                 Fill = ColorResource.GetColor("OnBackground", "OnBackgroundDark", Colors.DarkGray).WithAlpha(.5f),
             }
         };
+
         contentView.SetId("ClearIcon");
         contentView.SetBinding(StatefulContentView.IsFocusableProperty, new Binding(nameof(DisallowClearButtonFocus), source: this));
-        contentView.SetBinding(StatefulContentView.IsVisibleProperty, new Binding(nameof(Text), converter: UraniumConverters.StringIsNotNullOrEmptyConverter, source: this));
+        contentView.SetBinding(IsVisibleProperty, new Binding(nameof(Text), converter: UraniumConverters.StringIsNotNullOrEmptyConverter, source: this));
+
         return contentView;
     }
-
+  
     /// <summary>
     /// Input has be be already focused when this method is called.
     /// </summary>

--- a/src/UraniumUI.Material/Controls/TextField.cs
+++ b/src/UraniumUI.Material/Controls/TextField.cs
@@ -141,7 +141,10 @@ public partial class TextField : InputField
 
     protected virtual void UpdateClearIconState()
     {
+        if (endIconsContainer is null) { return; }
+
         var existing = endIconsContainer.FindByViewQueryIdInVisualTreeDescendants<StatefulContentView>("ClearIcon");
+
         if (AllowClear)
         {
             if (existing == null)

--- a/test/UraniumUI.Material.Tests/Controls/TextField_Test.cs
+++ b/test/UraniumUI.Material.Tests/Controls/TextField_Test.cs
@@ -4,6 +4,8 @@ using Shouldly;
 using System.Windows.Input;
 using UraniumUI.Material.Controls;
 using UraniumUI.Tests.Core;
+using UraniumUI.ViewExtensions;
+using UraniumUI.Views;
 
 namespace UraniumUI.Material.Tests.Controls;
 public class TextField_Test
@@ -40,23 +42,23 @@ public class TextField_Test
         control.Text.ShouldBe(viewModel.Text);
     }
 
-	[Fact]
-	public void Text_Binding_RaisesPropertyChangedEvent_ExactlyOnce()
-	{
-		var control = AnimationReadyHandler.Prepare(new TextField());
-		var viewModel = new TestViewModel { Text = "Text Initial Value" };
-		control.BindingContext = viewModel;
-		control.SetBinding(TextField.TextProperty, new Binding(nameof(TestViewModel.Text)));
+    [Fact]
+    public void Text_Binding_RaisesPropertyChangedEvent_ExactlyOnce()
+    {
+        var control = AnimationReadyHandler.Prepare(new TextField());
+        var viewModel = new TestViewModel { Text = "Text Initial Value" };
+        control.BindingContext = viewModel;
+        control.SetBinding(TextField.TextProperty, new Binding(nameof(TestViewModel.Text)));
 
-		var monitoredSubject = control.Monitor();
-		// Act
-		viewModel.Text = "Changed Value";
+        var monitoredSubject = control.Monitor();
+        // Act
+        viewModel.Text = "Changed Value";
 
-		// Assert
-		monitoredSubject.Should().RaisePropertyChangeFor(x => x.Text).ShouldHaveSingleItem();
-	}
+        // Assert
+        monitoredSubject.Should().RaisePropertyChangeFor(x => x.Text).ShouldHaveSingleItem();
+    }
 
-	[Fact]
+    [Fact]
     public void Text_Binding_ToSource()
     {
         var control = AnimationReadyHandler.Prepare(new TextField());
@@ -89,6 +91,23 @@ public class TextField_Test
 
         // Assert
         control.Text.ShouldBe(control.EntryView.Text);
+    }
+
+    [Fact]
+    public void TextChanges_ShouldShouldCorrectlyUpdateClearButtonVisibility()
+    {
+        var control = AnimationReadyHandler.Prepare(new TextField() { AllowClear = true });
+        // Currently no easier way provided by TextField/InputField to access this control
+        var clearIcon = control.FindByViewQueryIdInVisualTreeDescendants<StatefulContentView>("ClearIcon");
+
+        // Since we initialized with AllowClear = true
+        clearIcon.Should().NotBeNull();
+        // TextField initialized without text -> clear icon should be initially hidden
+        clearIcon.IsVisible.ShouldBeFalse();
+        control.Text = "Test";
+        clearIcon.IsVisible.ShouldBeTrue();
+        control.Text = "";
+        clearIcon.IsVisible.ShouldBeFalse();
     }
 
     [Fact]


### PR DESCRIPTION
Fixes #861
Fixes #874

The initial undesired behavior can be verified when checking out the first commit in the MR (where the MAUI version is incremented manually)

The underlying issue was that when initializing clearIcon with `IsVisible = false`, it would not be properly updated after MAUI version 9.0.30 through the binding, probably due to MAUI performance optimizations.

From the [MAUI method documentation](https://learn.microsoft.com/en-us/dotnet/api/microsoft.maui.controls.visualelement.isvisible?view=net-maui-9.0#remarks):

> When an element has [IsVisible](https://learn.microsoft.com/en-us/dotnet/api/microsoft.maui.controls.visualelement.isvisible?view=net-maui-9.0#microsoft-maui-controls-visualelement-isvisible) set to false it will no longer take up space in layouts or be eligible to receive any kind of input event.

---

In this MR:

- Set `IsVisible  = true` for the initial `ClearIcon StatefulContentView`
- Added a test case `TextChanges_ShouldShouldCorrectlyUpdateClearButtonVisibility` that ensures that the updates function correctly (even that `IsVisible` is updated to false correctly when starting with empty text)
- Changed `UpdateClearIconState()` to trigger on propertyChanged (instead of propertyChanging). This seems more in line with other bindable properties.

Edit: btw, I opted not to change it to remove the Converter binding and simply call

`existing.IsVisible = !string.IsNullOrEmpty(Text);` in `UpdateClearIconState()`

, since I did not want to undo the last major refactoring on this file (TextField.cs)




