### PR TITLE
Refactor: TreeView to replace BindingLayout with CollectionView

### DIFF
--- a/demo/UraniumApp/Pages/TreeViews/TreeViewFileSystemPage.xaml
+++ b/demo/UraniumApp/Pages/TreeViews/TreeViewFileSystemPage.xaml
@@ -18,6 +18,7 @@
 
                 <material:TreeView
                     x:Name="treeView"
+                    IsExpandedPropertyName="IsExtended"
                     IsLeafPropertyName="IsLeaf"
                     ItemsSource="{Binding Nodes}"
                     LoadChildrenCommand="{Binding LoadChildrenCommand}"

--- a/demo/UraniumApp/Pages/TreeViews/TreeViewFileSystemPage.xaml
+++ b/demo/UraniumApp/Pages/TreeViews/TreeViewFileSystemPage.xaml
@@ -1,12 +1,13 @@
 ﻿<?xml version="1.0" encoding="UTF-8" ?>
-<ContentPage x:Class="UraniumApp.Pages.TreeViews.TreeViewFileSystemPage"
-             xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
-             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
-             xmlns:material="http://schemas.enisn-projects.io/dotnet/maui/uraniumui/material"
-             xmlns:m="clr-namespace:UraniumUI.Icons.MaterialSymbols;assembly=UraniumUI.Icons.MaterialSymbols"
-             xmlns:vm="clr-namespace:UraniumApp.ViewModels"
-             xmlns:root="clr-namespace:UraniumApp"
-             xmlns:local="clr-namespace:UraniumApp.Pages.TreeViews">
+<ContentPage
+    x:Class="UraniumApp.Pages.TreeViews.TreeViewFileSystemPage"
+    xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+    xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+    xmlns:local="clr-namespace:UraniumApp.Pages.TreeViews"
+    xmlns:m="clr-namespace:UraniumUI.Icons.MaterialSymbols;assembly=UraniumUI.Icons.MaterialSymbols"
+    xmlns:material="http://schemas.enisn-projects.io/dotnet/maui/uraniumui/material"
+    xmlns:root="clr-namespace:UraniumApp"
+    xmlns:vm="clr-namespace:UraniumApp.ViewModels">
     <ContentPage.BindingContext>
         <vm:TreeViewFileSystemViewModel />
     </ContentPage.BindingContext>
@@ -16,25 +17,34 @@
             <VerticalStackLayout>
 
                 <material:TreeView
-                    SelectionMode="Multiple"
                     x:Name="treeView"
+                    IsLeafPropertyName="IsLeaf"
                     ItemsSource="{Binding Nodes}"
                     LoadChildrenCommand="{Binding LoadChildrenCommand}"
-                    IsLeafPropertyName="IsLeaf">
+                    SelectionMode="Multiple">
                     <material:TreeView.ItemTemplate>
                         <DataTemplate>
                             <HorizontalStackLayout Spacing="5" VerticalOptions="Center">
                                 <Image>
                                     <Image.Triggers>
-                                        <DataTrigger TargetType="Image" Binding="{Binding IsDirectory}" Value="True">
+                                        <DataTrigger
+                                            Binding="{Binding IsDirectory}"
+                                            TargetType="Image"
+                                            Value="True">
                                             <Setter Property="Source" Value="{FontImageSource FontFamily=MaterialSharp, Glyph={x:Static m:MaterialSharp.Folder}, Color={AppThemeBinding Light={StaticResource Primary}, Dark={StaticResource PrimaryDark}}}" />
                                         </DataTrigger>
-                                        <DataTrigger TargetType="Image" Binding="{Binding IsDirectory}" Value="False">
+                                        <DataTrigger
+                                            Binding="{Binding IsDirectory}"
+                                            TargetType="Image"
+                                            Value="False">
                                             <Setter Property="Source" Value="{FontImageSource FontFamily=MaterialSharp, Glyph={x:Static m:MaterialSharp.File_open}, Color={AppThemeBinding Light={StaticResource Primary}, Dark={StaticResource PrimaryDark}}}" />
                                         </DataTrigger>
                                     </Image.Triggers>
                                 </Image>
-                                <Label Text="{Binding Name}" FontAttributes="Bold" VerticalOptions="Center" />
+                                <Label
+                                    FontAttributes="Bold"
+                                    Text="{Binding Name}"
+                                    VerticalOptions="Center" />
                             </HorizontalStackLayout>
                         </DataTemplate>
                     </material:TreeView.ItemTemplate>
@@ -42,9 +52,12 @@
 
                 <BoxView StyleClass="Divider" />
 
-                <Border StyleClass="SurfaceContainer,Rounded" HorizontalOptions="Center" MaximumWidthRequest="400">
-                    
-                <root:PropertyEditorView Value="{Binding ., Source={x:Reference treeView}}"/>
+                <Border
+                    HorizontalOptions="Center"
+                    MaximumWidthRequest="400"
+                    StyleClass="SurfaceContainer,Rounded">
+
+                    <root:PropertyEditorView Value="{Binding ., Source={x:Reference treeView}}" />
                 </Border>
             </VerticalStackLayout>
         </ScrollView>

--- a/demo/UraniumApp/Pages/TreeViews/TreeViewPage.xaml
+++ b/demo/UraniumApp/Pages/TreeViews/TreeViewPage.xaml
@@ -1,12 +1,13 @@
 ﻿<?xml version="1.0" encoding="UTF-8" ?>
-<ContentPage x:Class="UraniumApp.Pages.TreeViews.TreeViewPage"
-             xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
-             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
-             xmlns:material="http://schemas.enisn-projects.io/dotnet/maui/uraniumui/material"
-             xmlns:vm="clr-namespace:UraniumApp.ViewModels"
-             xmlns:m="clr-namespace:UraniumUI.Icons.MaterialSymbols;assembly=UraniumUI.Icons.MaterialSymbols"
-             xmlns:root="clr-namespace:UraniumApp"
-             xmlns:local="clr-namespace:UraniumApp.Pages">
+<ContentPage
+    x:Class="UraniumApp.Pages.TreeViews.TreeViewPage"
+    xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+    xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+    xmlns:local="clr-namespace:UraniumApp.Pages"
+    xmlns:m="clr-namespace:UraniumUI.Icons.MaterialSymbols;assembly=UraniumUI.Icons.MaterialSymbols"
+    xmlns:material="http://schemas.enisn-projects.io/dotnet/maui/uraniumui/material"
+    xmlns:root="clr-namespace:UraniumApp"
+    xmlns:vm="clr-namespace:UraniumApp.ViewModels">
     <ContentPage.BindingContext>
         <vm:TreeViewPageViewModel />
     </ContentPage.BindingContext>
@@ -17,7 +18,11 @@
                 <material:TabItem Title="Simple">
                     <material:TabItem.ContentTemplate>
                         <DataTemplate>
-                            <material:TreeView SelectionMode="Multiple" ItemsSource="{Binding Nodes}" IsExpandedPropertyName="IsExtended"/>
+                            <material:TreeView
+                                IsExpandedPropertyName="IsExtended"
+                                IsLeafPropertyName="IsLeaf"
+                                ItemsSource="{Binding Nodes}"
+                                SelectionMode="Multiple" />
                         </DataTemplate>
                     </material:TabItem.ContentTemplate>
                 </material:TabItem>
@@ -25,12 +30,18 @@
                 <material:TabItem Title="Templated">
                     <material:TabItem.ContentTemplate>
                         <DataTemplate>
-                            <material:TreeView ItemsSource="{Binding Nodes}">
+                            <material:TreeView
+                                IsExpandedPropertyName="IsExtended"
+                                IsLeafPropertyName="IsLeaf"
+                                ItemsSource="{Binding Nodes}">
                                 <material:TreeView.ItemTemplate>
                                     <DataTemplate>
-                                        <HorizontalStackLayout Margin="0,12" Spacing="5" VerticalOptions="Center">
+                                        <HorizontalStackLayout
+                                            Margin="0,12"
+                                            Spacing="5"
+                                            VerticalOptions="Center">
                                             <Image Source="{FontImageSource FontFamily=MaterialSharp, Glyph={x:Static m:MaterialSharp.Folder}, Color={AppThemeBinding Light={StaticResource Primary}, Dark={StaticResource PrimaryDark}}}" />
-                                            <Label Text="{Binding Name}" FontAttributes="Bold" />
+                                            <Label FontAttributes="Bold" Text="{Binding Name}" />
                                             <Label Text="{Binding Children.Count, StringFormat='({0})'}" />
                                         </HorizontalStackLayout>
                                     </DataTemplate>
@@ -43,14 +54,20 @@
                 <material:TabItem Title="Template selector">
                     <material:TabItem.ContentTemplate>
                         <DataTemplate>
-                            <material:TreeView ItemsSource="{Binding Nodes}">
+                            <material:TreeView
+                                IsExpandedPropertyName="IsExtended"
+                                IsLeafPropertyName="IsLeaf"
+                                ItemsSource="{Binding Nodes}">
                                 <material:TreeView.ItemTemplate>
                                     <vm:MyTemplateSelector>
                                         <vm:MyTemplateSelector.TemplateDefault>
                                             <DataTemplate>
-                                                <HorizontalStackLayout Margin="0,8" Spacing="5" VerticalOptions="Center">
+                                                <HorizontalStackLayout
+                                                    Margin="0,8"
+                                                    Spacing="5"
+                                                    VerticalOptions="Center">
                                                     <Image Source="{FontImageSource FontFamily=MaterialSharp, Glyph={x:Static m:MaterialSharp.Folder}, Color={AppThemeBinding Light={StaticResource Primary}, Dark={StaticResource PrimaryDark}}}" />
-                                                    <Label Text="{Binding Name}" FontAttributes="Bold" />
+                                                    <Label FontAttributes="Bold" Text="{Binding Name}" />
                                                     <Label Text="{Binding Children.Count, StringFormat='({0})'}" />
                                                     <Label Text="Default Template" />
                                                 </HorizontalStackLayout>
@@ -58,9 +75,12 @@
                                         </vm:MyTemplateSelector.TemplateDefault>
                                         <vm:MyTemplateSelector.TemplateA>
                                             <DataTemplate>
-                                                <HorizontalStackLayout Margin="0,8" Spacing="5" VerticalOptions="Center">
+                                                <HorizontalStackLayout
+                                                    Margin="0,8"
+                                                    Spacing="5"
+                                                    VerticalOptions="Center">
                                                     <Image Source="{FontImageSource FontFamily=MaterialSharp, Glyph={x:Static m:MaterialSharp.Folder}, Color={AppThemeBinding Light={StaticResource Tertiary}, Dark={StaticResource TertiaryDark}}}" />
-                                                    <Label Text="{Binding Name}" FontAttributes="Bold" />
+                                                    <Label FontAttributes="Bold" Text="{Binding Name}" />
                                                     <Label Text="{Binding Children.Count, StringFormat='({0})'}" />
                                                     <Label Text="Template for A" />
                                                 </HorizontalStackLayout>
@@ -68,9 +88,12 @@
                                         </vm:MyTemplateSelector.TemplateA>
                                         <vm:MyTemplateSelector.TemplateB>
                                             <DataTemplate>
-                                                <HorizontalStackLayout Margin="0,8" Spacing="5" VerticalOptions="Center">
+                                                <HorizontalStackLayout
+                                                    Margin="0,8"
+                                                    Spacing="5"
+                                                    VerticalOptions="Center">
                                                     <Image Source="{FontImageSource FontFamily=MaterialSharp, Glyph={x:Static m:MaterialSharp.Folder}, Color={AppThemeBinding Light={StaticResource Secondary}, Dark={StaticResource SecondaryDark}}}" />
-                                                    <Label Text="{Binding Name}" FontAttributes="Bold" />
+                                                    <Label FontAttributes="Bold" Text="{Binding Name}" />
                                                     <Label Text="{Binding Children.Count, StringFormat='({0})'}" />
                                                     <Label Text="Template for B" />
                                                 </HorizontalStackLayout>
@@ -78,9 +101,12 @@
                                         </vm:MyTemplateSelector.TemplateB>
                                         <vm:MyTemplateSelector.TemplateC>
                                             <DataTemplate>
-                                                <HorizontalStackLayout Margin="0,8" Spacing="5" VerticalOptions="Center">
+                                                <HorizontalStackLayout
+                                                    Margin="0,8"
+                                                    Spacing="5"
+                                                    VerticalOptions="Center">
                                                     <Image Source="{FontImageSource FontFamily=MaterialSharp, Glyph={x:Static m:MaterialSharp.Folder}, Color={AppThemeBinding Light={StaticResource Primary}, Dark={StaticResource PrimaryDark}}}" />
-                                                    <Label Text="{Binding Name}" FontAttributes="Bold" />
+                                                    <Label FontAttributes="Bold" Text="{Binding Name}" />
                                                     <Label Text="{Binding Children.Count, StringFormat='({0})'}" />
                                                     <Label Text="Template for C" />
                                                 </HorizontalStackLayout>
@@ -96,7 +122,10 @@
                 <material:TabItem Title="Expander">
                     <material:TabItem.ContentTemplate>
                         <DataTemplate>
-                            <material:TreeView ItemsSource="{Binding Nodes}" IsExpandedPropertyName="IsExtended">
+                            <material:TreeView
+                                IsExpandedPropertyName="IsExtended"
+                                IsLeafPropertyName="IsLeaf"
+                                ItemsSource="{Binding Nodes}">
                                 <material:TreeView.ExpanderTemplate>
                                     <DataTemplate>
                                         <StackLayout WidthRequest="50">
@@ -112,10 +141,13 @@
                 <material:TabItem Title="Selection">
                     <material:TabItem.ContentTemplate>
                         <DataTemplate>
-                            <material:TreeView ItemsSource="{Binding Nodes}" IsExpandedPropertyName="IsExtended">
+                            <material:TreeView
+                                IsExpandedPropertyName="IsExtended"
+                                IsLeafPropertyName="IsLeaf"
+                                ItemsSource="{Binding Nodes}">
                                 <material:TreeView.ItemTemplate>
                                     <DataTemplate>
-                                        <material:CheckBox Text="{Binding Name}" Margin="10">
+                                        <material:CheckBox Margin="10" Text="{Binding Name}">
                                             <material:CheckBox.Behaviors>
                                                 <material:TreeViewHierarchicalSelectBehavior />
                                             </material:CheckBox.Behaviors>

--- a/demo/UraniumApp/ViewModels/TreeViewFileSystemViewModel.cs
+++ b/demo/UraniumApp/ViewModels/TreeViewFileSystemViewModel.cs
@@ -61,6 +61,7 @@ public class TreeViewFileSystemViewModel : UraniumBindableObject
                 Path = d,
                 IsDirectory = true,
                 IsLeaf = false,
+                IsExtended = false,
             };
         }
         var files = Directory.GetFiles(dir);
@@ -73,6 +74,7 @@ public class TreeViewFileSystemViewModel : UraniumBindableObject
                 Path = f,
                 IsDirectory = false,
                 IsLeaf = true,
+                IsExtended = true,
             };
             yield return node;
         }
@@ -81,11 +83,13 @@ public class TreeViewFileSystemViewModel : UraniumBindableObject
     public class NodeItem : UraniumBindableObject
     {
         private bool isLeaf;
+        private bool isExtended;
 
         public string Name { get; set; }
         public string Path { get; set; }
         public bool IsDirectory { get; set; }
-        public bool IsLeaf { get => isLeaf; set => SetProperty(ref isLeaf, value); }
-        public ObservableCollection<NodeItem> Children { get; } = new();
+        public virtual bool IsLeaf { get => isLeaf; set => SetProperty(ref isLeaf, value); }
+        public virtual bool IsExtended { get => isExtended; set => SetProperty(ref isExtended, value); }
+        public virtual IList<NodeItem> Children { get; set; } = new ObservableCollection<NodeItem>();
     }
 }

--- a/src/UraniumUI.Material/Controls/TreeView.cs
+++ b/src/UraniumUI.Material/Controls/TreeView.cs
@@ -6,7 +6,7 @@ using UraniumUI.Extensions;
 using UraniumUI.Resources;
 
 namespace UraniumUI.Material.Controls;
-public partial class TreeView : VerticalStackLayout
+public partial class TreeView : ContentView
 {
     public static DataTemplate DefaultItemTemplate = new DataTemplate(() =>
     {
@@ -15,15 +15,40 @@ public partial class TreeView : VerticalStackLayout
         return label;
     });
 
+    private readonly List<TreeViewNodeHolderView> _registeredNodes = new();
+
+    internal void RegisterNode(TreeViewNodeHolderView node)
+    {
+        _registeredNodes.Add(node);
+    }
+
+    internal IEnumerable<TreeViewNodeHolderView> GetChildViewsOf(TreeViewNodeHolderView parent)
+    {
+        return _registeredNodes.Where(x => x.ParentHolderView == parent);
+    }
+
+    public IEnumerable<TreeViewNodeHolderView> AllNodeViews => _registeredNodes;
+
+    private readonly CollectionView rootView;
+    private bool isTemplateUpdating;
+    private DataTemplate nodeTemplate;
+
+
     public TreeView()
     {
-        BindableLayout.SetItemTemplate(this, new DataTemplate(() =>
+        rootView = new CollectionView
         {
-            var holder = new TreeViewNodeHolderView(ItemTemplate, this, ChildrenBinding);
-            holder.TreeView = this;
-            return holder;
-        }));
+            ItemsLayout = new LinearItemsLayout(ItemsLayoutOrientation.Vertical),
+            SelectionMode = SelectionMode.None
+        };
+
+        Content = rootView;
+
+        OnItemTemplateChanged(DefaultItemTemplate);
     }
+
+    private List<TreeViewNodeHolderView> GetChildViews() =>
+        _registeredNodes.ToList();
 
     protected override void OnHandlerChanged()
     {
@@ -32,25 +57,21 @@ public partial class TreeView : VerticalStackLayout
         if (SelectedItems is INotifyCollectionChanged observableSelectedItems)
         {
             if (Handler is null)
-            {
                 observableSelectedItems.CollectionChanged -= SelectedItemsChanged;
-            }
             else
-            {
                 observableSelectedItems.CollectionChanged += SelectedItemsChanged;
-            }
         }
     }
 
     // TODO: Remove default value and make default value as null in the next major version.
     private BindingBase childrenBinding = new Binding("Children");
-
     public BindingBase ChildrenBinding
     {
-        get => childrenBinding; set
+        get => childrenBinding;
+        set
         {
             childrenBinding = value;
-            foreach (TreeViewNodeHolderView view in this.Children.Where(x => x is TreeViewNodeHolderView))
+            foreach (TreeViewNodeHolderView view in GetChildViews())
             {
                 view.ChildrenBinding = value;
             }
@@ -58,14 +79,13 @@ public partial class TreeView : VerticalStackLayout
     }
 
     private string isExpandedPropertyName;
-
     public string IsExpandedPropertyName
     {
         get => isExpandedPropertyName;
         set
         {
             isExpandedPropertyName = value;
-            foreach (TreeViewNodeHolderView view in this.Children.Where(x => x is TreeViewNodeHolderView))
+            foreach (TreeViewNodeHolderView view in GetChildViews())
             {
                 view.ApplyIsExpandedPropertyBindings();
             }
@@ -73,51 +93,56 @@ public partial class TreeView : VerticalStackLayout
     }
 
     private string isLeafPropertyName;
-
     public string IsLeafPropertyName
     {
         get => isLeafPropertyName;
         set
         {
             isLeafPropertyName = value;
-            foreach (TreeViewNodeHolderView view in this.Children.Where(x => x is TreeViewNodeHolderView))
+            foreach (TreeViewNodeHolderView view in GetChildViews())
             {
                 view.ApplyIsLeafPropertyBindings();
             }
         }
     }
 
-    protected virtual void OnItemsSourceSet()
+    private void OnItemTemplateChanged(DataTemplate newTemplate)
     {
-        BindableLayout.SetItemsSource(this, ItemsSource);
-    }
+        if (isTemplateUpdating || newTemplate == null)
+            return;
 
-    private void OnItemTemplateChanged()
-    {
-        BindableLayout.SetItemTemplate(this, new DataTemplate(() =>
+        try
         {
-            var holder = new TreeViewNodeHolderView(ItemTemplate, this, ChildrenBinding);
-            holder.TreeView = this;
-            return holder;
-        }));
+            isTemplateUpdating = true;
 
-        OnItemsSourceSet();
+            nodeTemplate = newTemplate;
+
+            rootView.ItemTemplate = new DataTemplate(() =>
+            {
+                var holder = new TreeViewNodeHolderView(nodeTemplate, this, ChildrenBinding)
+                {
+                    TreeView = this
+                };
+                return holder;
+            });
+        }
+        finally
+        {
+            isTemplateUpdating = false;
+        }
     }
 
     private void OnExpanderTemplateChanged()
     {
-        // Same logic (for now)
-        OnItemTemplateChanged();
+        OnItemTemplateChanged(ItemTemplate);
     }
 
     protected virtual void SelectedItemChanged()
     {
         if (SelectionMode == SelectionMode.None)
-        {
             return;
-        }
 
-        foreach (var childHolder in Children.OfType<TreeViewNodeHolderView>())
+        foreach (TreeViewNodeHolderView childHolder in GetChildViews())
         {
             childHolder.OnSelectedItemChanged();
         }
@@ -126,16 +151,12 @@ public partial class TreeView : VerticalStackLayout
     protected virtual void OnSelectedItemsChanged(IList oldValue, IList newValue)
     {
         if (oldValue is INotifyCollectionChanged observableOld)
-        {
             observableOld.CollectionChanged -= SelectedItemsChanged;
-        }
 
-        if (newValue is INotifyCollectionChanged observableCollectionNew)
-        {
-            observableCollectionNew.CollectionChanged += SelectedItemsChanged;
-        }
+        if (newValue is INotifyCollectionChanged observableNew)
+            observableNew.CollectionChanged += SelectedItemsChanged;
 
-        foreach (var childNode in this.FindManyInChildrenHierarchy<TreeViewNodeHolderView>())
+        foreach (TreeViewNodeHolderView childNode in _registeredNodes)
         {
             if (newValue.Contains(childNode.BindingContext) && !childNode.IsSelected)
             {
@@ -146,86 +167,140 @@ public partial class TreeView : VerticalStackLayout
 
     private void SelectedItemsChanged(object sender, NotifyCollectionChangedEventArgs e)
     {
-        switch (e.Action)
+        if (e.Action == NotifyCollectionChangedAction.Add)
         {
-            case NotifyCollectionChangedAction.Add:
-                foreach (var item in e.NewItems)
-                {
-                    var node = this.FindManyInChildrenHierarchy<TreeViewNodeHolderView>().FirstOrDefault(x => x.BindingContext == item);
-                    if (node is not null && !node.IsSelected)
-                    {
-                        node.IsSelected = true;
-                    }
-                }
-                break;
-            case NotifyCollectionChangedAction.Remove:
-                foreach (var item in e.OldItems)
-                {
-                    var node = this.FindManyInChildrenHierarchy<TreeViewNodeHolderView>().FirstOrDefault(x => x.BindingContext == item);
-                    if (node is not null && node.IsSelected)
-                    {
-                        node.IsSelected = false;
-                    }
-                }
-                break;
+            foreach (var item in e.NewItems)
+            {
+                var node = _registeredNodes
+                    .FirstOrDefault(x => x.BindingContext == item);
+                if (node != null && !node.IsSelected)
+                    node.IsSelected = true;
+            }
+        }
+        else if (e.Action == NotifyCollectionChangedAction.Remove)
+        {
+            foreach (var item in e.OldItems)
+            {
+                var node = _registeredNodes
+                    .FirstOrDefault(x => x.BindingContext == item);
+                if (node != null && node.IsSelected)
+                    node.IsSelected = false;
+            }
         }
     }
 
-    public SelectionMode SelectionMode { get => (SelectionMode)GetValue(SelectionModeProperty); set => SetValue(SelectionModeProperty, value); }
+    public SelectionMode SelectionMode
+    {
+        get => (SelectionMode)GetValue(SelectionModeProperty);
+        set => SetValue(SelectionModeProperty, value);
+    }
 
     public static readonly BindableProperty SelectionModeProperty = BindableProperty.Create(
-               nameof(SelectionMode), typeof(SelectionMode), typeof(TreeView), SelectionMode.None);
+        nameof(SelectionMode), typeof(SelectionMode), typeof(TreeView), SelectionMode.None);
 
-    public bool UseAnimation { get => (bool)GetValue(UseAnimationProperty); set => SetValue(UseAnimationProperty, value); }
+    public bool UseAnimation
+    {
+        get => (bool)GetValue(UseAnimationProperty);
+        set => SetValue(UseAnimationProperty, value);
+    }
 
     public static readonly BindableProperty UseAnimationProperty = BindableProperty.Create(
-               nameof(UseAnimation), typeof(bool), typeof(TreeView), true);
+        nameof(UseAnimation), typeof(bool), typeof(TreeView), true);
 
-    /// <summary>
-    /// Only indicates if TreeView is busy or not. Doesn't affect anything visually.
-    /// </summary>
     public bool IsBusy { get; set; }
 
-    public IList ItemsSource { get => (IList)GetValue(ItemsSourceProperty); set => SetValue(ItemsSourceProperty, value); }
+    public IEnumerable ItemsSource
+    {
+        get => (IEnumerable)GetValue(ItemsSourceProperty);
+        set => SetValue(ItemsSourceProperty, value);
+    }
 
     public static readonly BindableProperty ItemsSourceProperty = BindableProperty.Create(
-        nameof(ItemsSource), typeof(IList), typeof(TreeView), null,
-        propertyChanged: (b, o, v) => (b as TreeView).OnItemsSourceSet());
+        nameof(ItemsSource), typeof(IEnumerable), typeof(TreeView),
+        propertyChanged: (bindable, oldValue, newValue) =>
+        {
+            if (bindable is TreeView tree)
+            {
+                tree.rootView.ItemsSource = (IEnumerable)newValue;
+            }
+        });
 
-    public object SelectedItem { get => GetValue(SelectedItemProperty); set => SetValue(SelectedItemProperty, value); }
+    public object SelectedItem
+    {
+        get => GetValue(SelectedItemProperty);
+        set => SetValue(SelectedItemProperty, value);
+    }
 
     public static readonly BindableProperty SelectedItemProperty = BindableProperty.Create(
-        nameof(SelectedItem), typeof(object), typeof(TreeView), default, BindingMode.TwoWay, propertyChanged: (bo, ov, nv) => (bo as TreeView).SelectedItemChanged());
+        nameof(SelectedItem), typeof(object), typeof(TreeView), default, BindingMode.TwoWay,
+        propertyChanged: (bo, ov, nv) => (bo as TreeView)?.SelectedItemChanged());
 
-    public IList SelectedItems { get => (IList)GetValue(SelectedItemsProperty); set => SetValue(SelectedItemsProperty, value); }
+    public IList SelectedItems
+    {
+        get => (IList)GetValue(SelectedItemsProperty);
+        set => SetValue(SelectedItemsProperty, value);
+    }
 
     public static readonly BindableProperty SelectedItemsProperty = BindableProperty.Create(
-        nameof(SelectedItems), typeof(IList), typeof(TreeView), defaultValueCreator: bindable => new ObservableCollection<object>(),
-        propertyChanged: (bo, ov, nv) => (bo as TreeView).OnSelectedItemsChanged((IList)ov, (IList)nv));
+        nameof(SelectedItems), typeof(IList), typeof(TreeView),
+        defaultValueCreator: bindable => new ObservableCollection<object>(),
+        propertyChanged: (bo, ov, nv) => (bo as TreeView)?.OnSelectedItemsChanged((IList)ov, (IList)nv));
 
-    public DataTemplate ExpanderTemplate { get => (DataTemplate)GetValue(ExpanderTemplateProperty); set => SetValue(ExpanderTemplateProperty, value); }
+    public DataTemplate ExpanderTemplate
+    {
+        get => (DataTemplate)GetValue(ExpanderTemplateProperty);
+        set => SetValue(ExpanderTemplateProperty, value);
+    }
 
     public static readonly BindableProperty ExpanderTemplateProperty = BindableProperty.Create(
         nameof(ExpanderTemplate), typeof(DataTemplate), typeof(TreeView), null,
-        propertyChanged: (b, o, v) => (b as TreeView).OnExpanderTemplateChanged());
+        propertyChanged: (b, o, v) => (b as TreeView)?.OnExpanderTemplateChanged());
 
-    public DataTemplate ItemTemplate { get => (DataTemplate)GetValue(ItemTemplateProperty); set => SetValue(ItemTemplateProperty, value); }
+    public DataTemplate ItemTemplate
+    {
+        get => (DataTemplate)GetValue(ItemTemplateProperty);
+        set => SetValue(ItemTemplateProperty, value);
+    }
 
     public static readonly BindableProperty ItemTemplateProperty = BindableProperty.Create(
         nameof(ItemTemplate), typeof(DataTemplate), typeof(TreeView),
-        defaultValue: DefaultItemTemplate, propertyChanged: (b, o, n) => (b as TreeView).OnItemTemplateChanged());
+        defaultValue: DefaultItemTemplate,
+        propertyChanged: (b, o, n) => (b as TreeView)?.OnItemTemplateChanged((DataTemplate)n));
 
-    public ICommand LoadChildrenCommand { get => (ICommand)GetValue(LoadChildrenCommandProperty); set => SetValue(LoadChildrenCommandProperty, value); }
+    public ICommand LoadChildrenCommand
+    {
+        get => (ICommand)GetValue(LoadChildrenCommandProperty);
+        set => SetValue(LoadChildrenCommandProperty, value);
+    }
 
     public static readonly BindableProperty LoadChildrenCommandProperty = BindableProperty.Create(
         nameof(LoadChildrenCommand), typeof(ICommand), typeof(TreeView), null);
 
-    public Color SelectionColor { get => (Color)GetValue(SelectionColorProperty); set => SetValue(SelectionColorProperty, value); }
+    public Color SelectionColor
+    {
+        get => (Color)GetValue(SelectionColorProperty);
+        set => SetValue(SelectionColorProperty, value);
+    }
 
     public static readonly BindableProperty SelectionColorProperty = BindableProperty.Create(
-        nameof(SelectionColor), typeof(Color), typeof(TreeView), ColorResource.GetColor("Secondary", "SecondaryDark", Colors.Pink));
+        nameof(SelectionColor), typeof(Color), typeof(TreeView),
+        ColorResource.GetColor("Secondary", "SecondaryDark", Colors.Pink));
 
-    public Brush SelectionBrush { get => (Brush)GetValue(SelectionBrushProperty); set => SetValue(SelectionBrushProperty, value); }
+    public Brush SelectionBrush
+    {
+        get => (Brush)GetValue(SelectionBrushProperty);
+        set => SetValue(SelectionBrushProperty, value);
+    }
+
     public static readonly BindableProperty SelectionBrushProperty = BindableProperty.Create(
         nameof(SelectionBrush), typeof(Brush), typeof(TreeView), null);
+
+    public double ItemSpacing
+    {
+        get => (double)GetValue(ItemSpacingProperty);
+        set => SetValue(ItemSpacingProperty, value);
+    }
+
+    public static readonly BindableProperty ItemSpacingProperty = BindableProperty.Create(
+        nameof(ItemSpacing), typeof(double), typeof(TreeView), 0.0);
 }

--- a/src/UraniumUI.Material/Controls/TreeView.cs
+++ b/src/UraniumUI.Material/Controls/TreeView.cs
@@ -17,6 +17,7 @@ public partial class TreeView : ContentView
 
     private readonly List<TreeViewNodeHolderView> registeredNodes = new();
     public IEnumerable<TreeViewNodeHolderView> AllNodeViews => registeredNodes;
+    private List<TreeViewNodeHolderView> GetChildViews() => registeredNodes.ToList();
     private readonly CollectionView rootView;
     private bool isTemplateUpdating;
     private DataTemplate nodeTemplate;
@@ -43,9 +44,6 @@ public partial class TreeView : ContentView
 
         OnItemTemplateChanged(DefaultItemTemplate);
     }
-
-    private List<TreeViewNodeHolderView> GetChildViews() =>
-        registeredNodes.ToList();
 
     protected override void OnHandlerChanged()
     {

--- a/src/UraniumUI.Material/Controls/TreeView.cs
+++ b/src/UraniumUI.Material/Controls/TreeView.cs
@@ -15,24 +15,21 @@ public partial class TreeView : ContentView
         return label;
     });
 
-    private readonly List<TreeViewNodeHolderView> _registeredNodes = new();
-
-    internal void RegisterNode(TreeViewNodeHolderView node)
-    {
-        _registeredNodes.Add(node);
-    }
-
-    internal IEnumerable<TreeViewNodeHolderView> GetChildViewsOf(TreeViewNodeHolderView parent)
-    {
-        return _registeredNodes.Where(x => x.ParentHolderView == parent);
-    }
-
-    public IEnumerable<TreeViewNodeHolderView> AllNodeViews => _registeredNodes;
-
+    private readonly List<TreeViewNodeHolderView> registeredNodes = new();
+    public IEnumerable<TreeViewNodeHolderView> AllNodeViews => registeredNodes;
     private readonly CollectionView rootView;
     private bool isTemplateUpdating;
     private DataTemplate nodeTemplate;
 
+    internal void RegisterNode(TreeViewNodeHolderView node)
+    {
+        registeredNodes.Add(node);
+    }
+
+    internal IEnumerable<TreeViewNodeHolderView> GetChildViewsOf(TreeViewNodeHolderView parent)
+    {
+        return registeredNodes.Where(x => x.ParentHolderView == parent);
+    }
 
     public TreeView()
     {
@@ -48,7 +45,7 @@ public partial class TreeView : ContentView
     }
 
     private List<TreeViewNodeHolderView> GetChildViews() =>
-        _registeredNodes.ToList();
+        registeredNodes.ToList();
 
     protected override void OnHandlerChanged()
     {
@@ -156,7 +153,7 @@ public partial class TreeView : ContentView
         if (newValue is INotifyCollectionChanged observableNew)
             observableNew.CollectionChanged += SelectedItemsChanged;
 
-        foreach (TreeViewNodeHolderView childNode in _registeredNodes)
+        foreach (TreeViewNodeHolderView childNode in registeredNodes)
         {
             if (newValue.Contains(childNode.BindingContext) && !childNode.IsSelected)
             {
@@ -171,7 +168,7 @@ public partial class TreeView : ContentView
         {
             foreach (var item in e.NewItems)
             {
-                var node = _registeredNodes
+                var node = registeredNodes
                     .FirstOrDefault(x => x.BindingContext == item);
                 if (node != null && !node.IsSelected)
                     node.IsSelected = true;
@@ -181,7 +178,7 @@ public partial class TreeView : ContentView
         {
             foreach (var item in e.OldItems)
             {
-                var node = _registeredNodes
+                var node = registeredNodes
                     .FirstOrDefault(x => x.BindingContext == item);
                 if (node != null && node.IsSelected)
                     node.IsSelected = false;

--- a/src/UraniumUI.Material/Controls/TreeViewHierarchicalSelectBehavior.cs
+++ b/src/UraniumUI.Material/Controls/TreeViewHierarchicalSelectBehavior.cs
@@ -95,8 +95,8 @@ public class TreeViewHierarchicalSelectBehavior : Behavior<CheckBox>
 
             foreach (var child in children)
             {
-                var check = FindCheckBox(child);
-                if (check.IsChecked != firstCheck)
+                var checkBox = FindCheckBox(child);
+                if (checkBox.IsChecked != firstCheck)
                 {
                     mainCheckBox.IconGeometry = InputKit.Shared.Controls.PredefinedShapes.Line;
                     if (!mainCheckBox.IsChecked)

--- a/src/UraniumUI.Material/Controls/TreeViewHierarchicalSelectBehavior.cs
+++ b/src/UraniumUI.Material/Controls/TreeViewHierarchicalSelectBehavior.cs
@@ -50,8 +50,6 @@ public class TreeViewHierarchicalSelectBehavior : Behavior<CheckBox>
 
         var allChildren = holder.TreeView
         .GetChildViewsOf(holder);
-        //.FindManyInChildrenHierarchy<TreeViewNodeHolderView>().ToList();
-        //.Where(x => x.ParentHolderView == holder);
 
         foreach (var child in allChildren)
         {
@@ -89,8 +87,6 @@ public class TreeViewHierarchicalSelectBehavior : Behavior<CheckBox>
 
         var children = holder.TreeView
              .GetChildViewsOf(holder)
-        //.FindManyInChildrenHierarchy<TreeViewNodeHolderView>()
-        //.Where(x => x.ParentHolderView == holder)
         .ToList();
 
         if (children.Count > 0)

--- a/src/UraniumUI.Material/Controls/TreeViewHierarchicalSelectBehavior.cs
+++ b/src/UraniumUI.Material/Controls/TreeViewHierarchicalSelectBehavior.cs
@@ -41,7 +41,19 @@ public class TreeViewHierarchicalSelectBehavior : Behavior<CheckBox>
     protected virtual void ApplyHierarchicalSelection(CheckBox checkBox)
     {
         var holder = checkBox.FindInParents<TreeViewNodeHolderView>() ?? throw new InvalidOperationException("CheckBox isn't in a TreeView ItemTemplate");
-        foreach (TreeViewNodeHolderView child in holder.NodeChildren.Where(x => x is TreeViewNodeHolderView))
+
+        // 👇 Ensure the node is expanded so children are created
+        if (!holder.IsExpanded && !holder.IsLeaf)
+        {
+            holder.IsExpanded = true;
+        }
+
+        var allChildren = holder.TreeView
+        .GetChildViewsOf(holder);
+        //.FindManyInChildrenHierarchy<TreeViewNodeHolderView>().ToList();
+        //.Where(x => x.ParentHolderView == holder);
+
+        foreach (var child in allChildren)
         {
             var childCheckBox = FindCheckBox(child);
             if (childCheckBox.IsChecked != checkBox.IsChecked)
@@ -75,15 +87,20 @@ public class TreeViewHierarchicalSelectBehavior : Behavior<CheckBox>
             mainCheckBox.IconGeometry = InputKit.Shared.Controls.PredefinedShapes.Check;
         }
 
-        if (holder.NodeChildren.Count > 0)
-        {
-            var children = holder.NodeChildren.OfType<TreeViewNodeHolderView>();
+        var children = holder.TreeView
+             .GetChildViewsOf(holder)
+        //.FindManyInChildrenHierarchy<TreeViewNodeHolderView>()
+        //.Where(x => x.ParentHolderView == holder)
+        .ToList();
 
-            var lastItemToCheck = FindCheckBox(children.FirstOrDefault())?.IsChecked ?? throw new InvalidOperationException("CheckBox isn't in a TreeView ItemTemplate");
-            foreach (TreeViewNodeHolderView child in holder.NodeChildren.Where(x => x is TreeViewNodeHolderView))
+        if (children.Count > 0)
+        {
+            var firstCheck = FindCheckBox(children[0])?.IsChecked ?? false;
+
+            foreach (var child in children)
             {
-                var checkBox = FindCheckBox(child);
-                if (lastItemToCheck != checkBox.IsChecked)
+                var check = FindCheckBox(child);
+                if (check.IsChecked != firstCheck)
                 {
                     mainCheckBox.IconGeometry = InputKit.Shared.Controls.PredefinedShapes.Line;
                     if (!mainCheckBox.IsChecked)
@@ -94,11 +111,13 @@ public class TreeViewHierarchicalSelectBehavior : Behavior<CheckBox>
                     return;
                 }
             }
-            if (mainCheckBox.IsChecked != lastItemToCheck)
+
+            if (mainCheckBox.IsChecked != firstCheck)
             {
-                mainCheckBox.IsChecked = lastItemToCheck;
+                mainCheckBox.IsChecked = firstCheck;
             }
         }
+
         CheckStateItself(holder.ParentHolderView);
     }
 

--- a/src/UraniumUI.Material/Controls/TreeViewNodeHolderView.cs
+++ b/src/UraniumUI.Material/Controls/TreeViewNodeHolderView.cs
@@ -63,7 +63,8 @@ public class TreeViewNodeHolderView : VerticalStackLayout
 
     public TreeViewNodeHolderView(DataTemplate dataTemplate, TreeView treeView, BindingBase childrenBinding, int indentLevel = 0)
     {
-        if (indentLevel > 20) return; // prevent runaway recursion
+        if (indentLevel > 20) 
+            throw new ArgumentException("Indent level exceeds the maximum allowed value of 20, which may indicate runaway recursion.", nameof(indentLevel));
 
         TreeView = treeView ?? throw new ArgumentNullException(nameof(treeView));
         treeView.RegisterNode(this);

--- a/src/UraniumUI.Material/Controls/TreeViewNodeHolderView.cs
+++ b/src/UraniumUI.Material/Controls/TreeViewNodeHolderView.cs
@@ -208,7 +208,7 @@ public class TreeViewNodeHolderView : VerticalStackLayout
         if (nodeChildren == null && ChildrenBinding is Binding binding &&
         !string.IsNullOrEmpty(binding.Path) &&
         TryGetInitialChildren(binding.Path, out var children) &&
-        (children?.Cast<object>().Any() ?? false))
+        children?.Cast<object>().Any())
         {
             CreateChildContainer(binding);
             // 🔥 Now that nodeChildren is created, we can safely expand

--- a/src/UraniumUI.Material/Controls/TreeViewNodeHolderView.cs
+++ b/src/UraniumUI.Material/Controls/TreeViewNodeHolderView.cs
@@ -207,7 +207,7 @@ public class TreeViewNodeHolderView : VerticalStackLayout
         if (nodeChildren == null && ChildrenBinding is Binding binding &&
         !string.IsNullOrEmpty(binding.Path) &&
         TryGetInitialChildren(binding.Path, out var children) &&
-        children?.Cast<object>().Any() == true)
+        children?.Cast<object>().Any())
         {
             CreateChildContainer(binding);
             // 🔥 Now that nodeChildren is created, we can safely expand

--- a/src/UraniumUI.Material/Controls/TreeViewNodeHolderView.cs
+++ b/src/UraniumUI.Material/Controls/TreeViewNodeHolderView.cs
@@ -98,8 +98,6 @@ public class TreeViewNodeHolderView : VerticalStackLayout
             CreateChildContainer(binding);
         }
         ChildrenBinding = childrenBinding;
-
-
     }
 
     protected virtual View InitializeArrowExpander()

--- a/src/UraniumUI.Material/Controls/TreeViewNodeHolderView.cs
+++ b/src/UraniumUI.Material/Controls/TreeViewNodeHolderView.cs
@@ -1,4 +1,5 @@
 ﻿using InputKit.Shared.Helpers;
+using System.Collections;
 using UraniumUI.Extensions;
 using UraniumUI.Pages;
 using UraniumUI.Triggers;
@@ -17,17 +18,12 @@ public class TreeViewNodeHolderView : VerticalStackLayout
 
     public TreeView TreeView { get; internal set; }
 
-    protected TreeViewNodeItemContentView nodeContainer = new TreeViewNodeItemContentView
-    {
-        HorizontalOptions = LayoutOptions.Fill,
-    };
+    protected TreeViewNodeItemContentView nodeContainer = new TreeViewNodeItemContentView();
 
-    public VerticalStackLayout NodeChildren => nodeChildren;
+    public CollectionView NodeChildren => nodeChildren;
 
-    internal protected VerticalStackLayout nodeChildren = new VerticalStackLayout
-    {
-        IsVisible = false
-    };
+    internal protected CollectionView nodeChildren;
+    private Grid childContainer;
 
     public DataTemplate DataTemplate { get; }
 
@@ -35,11 +31,12 @@ public class TreeViewNodeHolderView : VerticalStackLayout
     {
         ColumnDefinitions =
         {
-            new ColumnDefinition(GridLength.Auto),
+            new ColumnDefinition(40),
             new ColumnDefinition(GridLength.Star),
         }
     };
-
+    private readonly int indentLevel;
+    private bool hasLoadedChildren;
     private BindingBase childrenBinding;
     public BindingBase ChildrenBinding
     {
@@ -47,13 +44,16 @@ public class TreeViewNodeHolderView : VerticalStackLayout
         internal set
         {
             childrenBinding = value;
-            if (ChildrenBinding is not null)
+            if (nodeChildren != null)
             {
-                nodeChildren.SetBinding(BindableLayout.ItemsSourceProperty, new Binding((ChildrenBinding as Binding)?.Path));
-            }
-            else
-            {
-                nodeChildren.RemoveBinding(BindableLayout.ItemsSourceProperty);
+                if (ChildrenBinding is Binding binding)
+                {
+                    nodeChildren.SetBinding(ItemsView.ItemsSourceProperty, new Binding(binding.Path));
+                }
+                else
+                {
+                    nodeChildren.RemoveBinding(ItemsView.ItemsSourceProperty);
+                }
             }
         }
     }
@@ -63,12 +63,13 @@ public class TreeViewNodeHolderView : VerticalStackLayout
 
     public TreeViewNodeHolderView(DataTemplate dataTemplate, TreeView treeView, BindingBase childrenBinding, int indentLevel = 0)
     {
-        if (treeView is null)
-        {
-            throw new ArgumentNullException(nameof(treeView));
-        }
+        if (indentLevel > 20) return; // prevent runaway recursion
 
-        TreeView = treeView;
+        TreeView = treeView ?? throw new ArgumentNullException(nameof(treeView));
+        treeView.RegisterNode(this);
+
+        this.indentLevel = indentLevel;
+
         DataTemplate = dataTemplate;
 
         nodeContainer.ItemTemplate = DataTemplate;
@@ -76,9 +77,6 @@ public class TreeViewNodeHolderView : VerticalStackLayout
 
         expanderView = TreeView.ExpanderTemplate?.CreateContent() as View ?? InitializeArrowExpander();
         expanderView.BindingContext = this;
-
-        this.SetBinding(SpacingProperty, new Binding(nameof(TreeView.Spacing), source: treeView));
-        nodeChildren.SetBinding(VerticalStackLayout.SpacingProperty, new Binding(nameof(TreeView.Spacing), source: treeView));
 
         rowStack.Add(expanderView);
         rowStack.Add(nodeContainer, column: 1);
@@ -95,30 +93,13 @@ public class TreeViewNodeHolderView : VerticalStackLayout
         };
 
         this.Add(button);
-        this.Add(nodeChildren);
-
-        if (!string.IsNullOrEmpty(TreeView.IsExpandedPropertyName))
+        if (childrenBinding is Binding binding && !string.IsNullOrEmpty(binding.Path) && TryGetInitialChildren(binding.Path, out var children) && children?.Cast<object>().Any() == true)
         {
-            this.SetBinding(IsExpandedProperty, new Binding(TreeView.IsExpandedPropertyName, BindingMode.TwoWay));
+            CreateChildContainer(binding);
         }
-
-        if (!string.IsNullOrEmpty(TreeView.IsLeafPropertyName))
-        {
-            this.SetBinding(IsLeafProperty, new Binding(TreeView.IsLeafPropertyName, BindingMode.TwoWay));
-        }
-
-        BindableLayout.SetItemTemplate(nodeChildren, new DataTemplate(() =>
-        {
-            var node = new TreeViewNodeHolderView(DataTemplate, TreeView, childrenBinding, indentLevel + 1);
-            node.ParentHolderView = this;
-            node.TreeView = TreeView;
-            return node;
-        }));
-
         ChildrenBinding = childrenBinding;
 
-        nodeChildren.ChildAdded += (s, e) => OnPropertyChanged(nameof(IsLeaf));
-        nodeChildren.ChildRemoved += (s, e) => OnPropertyChanged(nameof(IsLeaf));
+
     }
 
     protected virtual View InitializeArrowExpander()
@@ -224,7 +205,64 @@ public class TreeViewNodeHolderView : VerticalStackLayout
     {
         base.OnBindingContextChanged();
         OnSelectedItemChanged();
+
+        if (nodeChildren == null && ChildrenBinding is Binding binding &&
+        !string.IsNullOrEmpty(binding.Path) &&
+        TryGetInitialChildren(binding.Path, out var children) &&
+        children?.Cast<object>().Any() == true)
+        {
+            CreateChildContainer(binding);
+            // 🔥 Now that nodeChildren is created, we can safely expand
+            if (IsExpanded)
+            {
+                OnIsExpandedChanged(true);
+            }
+        }
     }
+    private void CreateChildContainer(Binding binding)
+    {
+        nodeChildren = new CollectionView
+        {
+            IsVisible = false,
+            ItemsLayout = new LinearItemsLayout(ItemsLayoutOrientation.Vertical)
+            {
+                ItemSpacing = TreeView.ItemSpacing
+            },
+            SelectionMode = SelectionMode.None
+        };
+
+        childContainer = new Grid
+        {
+            HeightRequest = 0,
+            IsVisible = false
+        };
+        childContainer.Children.Add(nodeChildren);
+        this.Add(childContainer);
+
+        if (!string.IsNullOrEmpty(TreeView.IsExpandedPropertyName))
+        {
+            this.SetBinding(IsExpandedProperty, new Binding(TreeView.IsExpandedPropertyName, BindingMode.TwoWay));
+        }
+
+        if (!string.IsNullOrEmpty(TreeView.IsLeafPropertyName))
+        {
+            this.SetBinding(IsLeafProperty, new Binding(TreeView.IsLeafPropertyName, BindingMode.TwoWay));
+        }
+
+        nodeChildren.ItemTemplate = new DataTemplate(() =>
+        {
+            var childNode = new TreeViewNodeHolderView(DataTemplate, TreeView, ChildrenBinding, this.indentLevel + 1)
+            {
+                ParentHolderView = this
+            };
+            return childNode;
+        });
+
+        nodeChildren.SetBinding(CollectionView.ItemsSourceProperty, new Binding(binding.Path));
+        nodeChildren.ChildAdded += (s, e) => OnPropertyChanged(nameof(IsLeaf));
+        nodeChildren.ChildRemoved += (s, e) => OnPropertyChanged(nameof(IsLeaf));
+    }
+
 
     protected virtual void ItemClicked()
     {
@@ -264,14 +302,23 @@ public class TreeViewNodeHolderView : VerticalStackLayout
             {
                 IsSelected = false;
             }
-
-            foreach (var childHolder in nodeChildren.Children.OfType<TreeViewNodeHolderView>())
+            if (NodeChildren?.ItemsSource is IEnumerable items)
             {
-                childHolder.OnSelectedItemChanged();
+                foreach (var item in items)
+                {
+                    var holder = FindHolderView(item);
+                    holder?.OnSelectedItemChanged();
+                }
             }
         }
     }
-
+    protected TreeViewNodeHolderView FindHolderView(object item)
+    {
+        return NodeChildren.Handler?.PlatformView is not null
+            ? TreeView.FindManyInChildrenHierarchy<TreeViewNodeHolderView>()
+                .FirstOrDefault(x => x.BindingContext == item)
+            : null;
+    }
     protected virtual void IsSelectedChanged()
     {
         var button = this.FindInChildrenHierarchy<StatefulContentView>();
@@ -382,8 +429,18 @@ public class TreeViewNodeHolderView : VerticalStackLayout
 
     protected internal virtual async void OnIsExpandedChanged(bool isExpanded)
     {
-        if (isExpanded)
+        if (isExpanded && !IsLeaf)
         {
+            if (!hasLoadedChildren && ChildrenBinding is Binding binding)
+            {
+                await MainThread.InvokeOnMainThreadAsync(() =>
+                {
+                    nodeChildren.SetBinding(CollectionView.ItemsSourceProperty, new Binding(binding.Path));
+                    this.InvalidateMeasure();
+                });
+                LoadChildrenIfNecessary();
+            }
+
             if (TreeView.UseAnimation)
             {
                 nodeChildren.IsVisible = true;
@@ -395,23 +452,28 @@ public class TreeViewNodeHolderView : VerticalStackLayout
             {
                 nodeChildren.IsVisible = true;
             }
+
+            childContainer.IsVisible = true;
+            childContainer.ClearValue(HeightRequestProperty); // Let it auto-resize naturally
         }
         else
         {
-            if (TreeView.UseAnimation)
+            if (nodeChildren != null && childContainer != null)
             {
-                nodeChildren.TranslateToSafely(0, -nodeChildren.Height).FireAndForget();
-                nodeChildren.ScaleToSafely(0).FireAndForget();
-                nodeChildren.AnchorX = 0;
-                nodeChildren.AnchorY = 0;
+                if (TreeView.UseAnimation)
+                {
+                    nodeChildren.TranslateToSafely(0, -nodeChildren.Height).FireAndForget();
+                    nodeChildren.ScaleToSafely(0).FireAndForget();
+                    nodeChildren.AnchorX = 0;
+                    nodeChildren.AnchorY = 0;
 
-                await nodeChildren.FadeToSafely(0, 50);
+                    await nodeChildren.FadeToSafely(0, 50);
+                }
+                childContainer.IsVisible = false;
+                childContainer.HeightRequest = 0;
+                nodeChildren.IsVisible = false;
             }
-
-            nodeChildren.IsVisible = false;
         }
-
-        LoadChildrenIfNecessary();
     }
 
     protected virtual void OnIsLeafChanged(bool? newValue)
@@ -424,15 +486,16 @@ public class TreeViewNodeHolderView : VerticalStackLayout
 
     protected virtual void LoadChildrenIfNecessary()
     {
-        if (!IsLeaf && !NodeChildren.Children.Any()) // TODO: And children is empty
+        if (!IsLeaf && !hasLoadedChildren && NodeChildren.ItemsSource is IEnumerable items && !items.Cast<object>().Any())
         {
-            TreeView.LoadChildrenCommand?.Execute(this.BindingContext);
+            TreeView.LoadChildrenCommand?.Execute(BindingContext);
+            hasLoadedChildren = true;
         }
     }
 
     public bool IsLeaf
     {
-        get => (bool?)GetValue(IsLeafProperty) ?? !nodeChildren.Children.Any();
+        get => (bool?)GetValue(IsLeafProperty) ?? nodeChildren == null || nodeChildren.ItemsSource is not IEnumerable items || !items.Cast<object>().Any();
         set => SetValue(IsLeafProperty, value);
     }
 
@@ -458,4 +521,27 @@ public class TreeViewNodeHolderView : VerticalStackLayout
     public static readonly BindableProperty IsSelectedProperty = BindableProperty.Create(
         nameof(IsSelected), typeof(bool), typeof(TreeViewNodeHolderView), false,
             propertyChanged: (bindable, oldValue, newValue) => (bindable as TreeViewNodeHolderView).IsSelectedChanged());
+
+    private bool TryGetInitialChildren(string path, out IEnumerable children)
+    {
+        children = null;
+
+        if (BindingContext == null)
+            return false;
+
+        try
+        {
+            var prop = BindingContext.GetType().GetProperty(path);
+            var value = prop?.GetValue(BindingContext);
+
+            if (value is IEnumerable list)
+            {
+                children = list;
+                return true;
+            }
+        }
+        catch { }
+
+        return false;
+    }
 }

--- a/src/UraniumUI.Material/Controls/TreeViewNodeHolderView.cs
+++ b/src/UraniumUI.Material/Controls/TreeViewNodeHolderView.cs
@@ -217,6 +217,15 @@ public class TreeViewNodeHolderView : VerticalStackLayout
                 OnIsExpandedChanged(true);
             }
         }
+        if (!string.IsNullOrEmpty(TreeView.IsExpandedPropertyName))
+        {
+            this.SetBinding(IsExpandedProperty, new Binding(TreeView.IsExpandedPropertyName, BindingMode.TwoWay));
+    }
+
+        if (!string.IsNullOrEmpty(TreeView.IsLeafPropertyName))
+        {
+            this.SetBinding(IsLeafProperty, new Binding(TreeView.IsLeafPropertyName, BindingMode.TwoWay));
+        }
     }
     private void CreateChildContainer(Binding binding)
     {

--- a/src/UraniumUI.Material/Controls/TreeViewNodeHolderView.cs
+++ b/src/UraniumUI.Material/Controls/TreeViewNodeHolderView.cs
@@ -247,15 +247,6 @@ public class TreeViewNodeHolderView : VerticalStackLayout
         childContainer.Children.Add(nodeChildren);
         this.Add(childContainer);
 
-        if (!string.IsNullOrEmpty(TreeView.IsExpandedPropertyName))
-        {
-            this.SetBinding(IsExpandedProperty, new Binding(TreeView.IsExpandedPropertyName, BindingMode.TwoWay));
-        }
-
-        if (!string.IsNullOrEmpty(TreeView.IsLeafPropertyName))
-        {
-            this.SetBinding(IsLeafProperty, new Binding(TreeView.IsLeafPropertyName, BindingMode.TwoWay));
-        }
 
         nodeChildren.ItemTemplate = new DataTemplate(() =>
         {

--- a/src/UraniumUI.Material/Controls/TreeViewNodeHolderView.cs
+++ b/src/UraniumUI.Material/Controls/TreeViewNodeHolderView.cs
@@ -493,7 +493,7 @@ public class TreeViewNodeHolderView : VerticalStackLayout
 
     protected virtual void LoadChildrenIfNecessary()
     {
-        if (!IsLeaf && !hasLoadedChildren && (NodeChildren == null || NodeChildren.ItemsSource is IEnumerable items && !items.Cast<object>().Any()))
+        if (!IsLeaf && !hasLoadedChildren && (NodeChildren == null || (NodeChildren.ItemsSource is IEnumerable items && !items.Cast<object>().Any())))
         {
             TreeView.LoadChildrenCommand?.Execute(BindingContext);
             hasLoadedChildren = true;

--- a/src/UraniumUI.Material/Controls/TreeViewNodeHolderView.cs
+++ b/src/UraniumUI.Material/Controls/TreeViewNodeHolderView.cs
@@ -220,7 +220,7 @@ public class TreeViewNodeHolderView : VerticalStackLayout
         if (!string.IsNullOrEmpty(TreeView.IsExpandedPropertyName))
         {
             this.SetBinding(IsExpandedProperty, new Binding(TreeView.IsExpandedPropertyName, BindingMode.TwoWay));
-    }
+        }
 
         if (!string.IsNullOrEmpty(TreeView.IsLeafPropertyName))
         {
@@ -434,10 +434,18 @@ public class TreeViewNodeHolderView : VerticalStackLayout
             {
                 await MainThread.InvokeOnMainThreadAsync(() =>
                 {
-                    nodeChildren.SetBinding(CollectionView.ItemsSourceProperty, new Binding(binding.Path));
+                    if (nodeChildren == null)
+                    {
+                        CreateChildContainer(binding);
+                    }
+
+                    if (nodeChildren.ItemsSource is IEnumerable items && !items.Cast<object>().Any())
+                    {
+                        LoadChildrenIfNecessary();
+                    }
+
                     this.InvalidateMeasure();
                 });
-                LoadChildrenIfNecessary();
             }
 
             if (TreeView.UseAnimation)
@@ -485,7 +493,7 @@ public class TreeViewNodeHolderView : VerticalStackLayout
 
     protected virtual void LoadChildrenIfNecessary()
     {
-        if (!IsLeaf && !hasLoadedChildren && NodeChildren.ItemsSource is IEnumerable items && !items.Cast<object>().Any())
+        if (!IsLeaf && !hasLoadedChildren && (NodeChildren == null || NodeChildren.ItemsSource is IEnumerable items && !items.Cast<object>().Any()))
         {
             TreeView.LoadChildrenCommand?.Execute(BindingContext);
             hasLoadedChildren = true;

--- a/src/UraniumUI.Material/Controls/TreeViewNodeHolderView.cs
+++ b/src/UraniumUI.Material/Controls/TreeViewNodeHolderView.cs
@@ -94,7 +94,9 @@ public class TreeViewNodeHolderView : VerticalStackLayout
         };
 
         this.Add(button);
-        if (childrenBinding is Binding binding && !string.IsNullOrEmpty(binding.Path) && TryGetInitialChildren(binding.Path, out var children) && children?.Cast<object>().Any() == true)
+        if (childrenBinding is Binding binding && !string.IsNullOrEmpty(binding.Path) &&
+            TryGetInitialChildren(binding.Path, out var children) && 
+            children is IEnumerable enumerable && enumerable.Cast<object>().Any())
         {
             CreateChildContainer(binding);
         }
@@ -208,7 +210,7 @@ public class TreeViewNodeHolderView : VerticalStackLayout
         if (nodeChildren == null && ChildrenBinding is Binding binding &&
         !string.IsNullOrEmpty(binding.Path) &&
         TryGetInitialChildren(binding.Path, out var children) &&
-        children?.Cast<object>().Any())
+        children is IEnumerable enumerable && enumerable.Cast<object>().Any())
         {
             CreateChildContainer(binding);
             // 🔥 Now that nodeChildren is created, we can safely expand

--- a/src/UraniumUI.Material/Controls/TreeViewNodeHolderView.cs
+++ b/src/UraniumUI.Material/Controls/TreeViewNodeHolderView.cs
@@ -208,7 +208,7 @@ public class TreeViewNodeHolderView : VerticalStackLayout
         if (nodeChildren == null && ChildrenBinding is Binding binding &&
         !string.IsNullOrEmpty(binding.Path) &&
         TryGetInitialChildren(binding.Path, out var children) &&
-        children?.Cast<object>().Any())
+        (children?.Cast<object>().Any() ?? false))
         {
             CreateChildContainer(binding);
             // 🔥 Now that nodeChildren is created, we can safely expand

--- a/src/UraniumUI.Material/Controls/TreeViewNodeHolderView.cs
+++ b/src/UraniumUI.Material/Controls/TreeViewNodeHolderView.cs
@@ -538,8 +538,11 @@ public class TreeViewNodeHolderView : VerticalStackLayout
                 return true;
             }
         }
-        catch { }
-
+        catch (Exception ex)
+        {
+            System.Diagnostics.Debug.WriteLine($"Error in TryGetInitialChildren: {ex.Message}");
+            System.Diagnostics.Debug.WriteLine(ex.StackTrace);
+        }
         return false;
     }
 }

--- a/src/UraniumUI/Converters/ItemSpacingToItemsLayoutConverter.cs
+++ b/src/UraniumUI/Converters/ItemSpacingToItemsLayoutConverter.cs
@@ -1,0 +1,32 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace UraniumUI.Converters
+{
+    public class ItemSpacingToItemsLayoutConverter : IValueConverter
+    {
+        public object Convert(object value, Type targetType, object parameter, System.Globalization.CultureInfo culture)
+        {
+            double spacing = 0;
+
+            if (value is double s)
+                spacing = s;
+
+            return new LinearItemsLayout(ItemsLayoutOrientation.Vertical)
+            {
+                ItemSpacing = spacing
+            };
+        }
+
+        public object ConvertBack(object value, Type targetType, object parameter, System.Globalization.CultureInfo culture)
+        {
+            if (value is LinearItemsLayout layout)
+                return layout.ItemSpacing;
+
+            return 0;
+        }
+    }
+}


### PR DESCRIPTION
This is a major PR which improves performance especially with large trees.
Removing the binding Layout allows rendering of items which are in view only and not the whole tree. This prevents the layout cycle issue.
