### PR TITLE
feat: extends datagrid column auto names with DisplayAttribute Name p…

### DIFF
--- a/src/UraniumUI.Material/Controls/DataGrid.cs
+++ b/src/UraniumUI.Material/Controls/DataGrid.cs
@@ -3,6 +3,7 @@ using System.Collections;
 using System.Collections.ObjectModel;
 using System.Collections.Specialized;
 using System.ComponentModel;
+using System.ComponentModel.DataAnnotations;
 using System.Reflection;
 using UraniumUI.Extensions;
 

--- a/src/UraniumUI.Material/Controls/DataGrid.cs
+++ b/src/UraniumUI.Material/Controls/DataGrid.cs
@@ -136,7 +136,7 @@ public partial class DataGrid : Border
             Columns = CurrentType?.GetProperties(BindingFlags.Instance | BindingFlags.Public)
                 .Select(s => new DataGridColumn
                 {
-                    Title = s.GetCustomAttribute<DisplayNameAttribute>()?.DisplayName ?? s.Name,
+                    Title = s.GetCustomAttribute<DisplayNameAttribute>()?.DisplayName ?? s.GetCustomAttribute<DisplayAttribute>()?.Name ?? s.Name,
                     ValueBinding = new Binding(s.Name),
                 }).ToList();
 


### PR DESCRIPTION
…roperty

In order to allow reusing code for differentUI libraries now auto names for data grid are catch from DisplayNameAttribute, then from DisplayAttribute, then fron property name.

This simple feature extends compatibility to both decoration styles:
- [DisplayName("TheName")]
- [Diplay(Name="TheName")]