### PR TITLE
[FIX] Dialog with DisplayFormAsync does not properly dismiss popup on selecting "Close" instead of "Submit"

### DIFF
--- a/src/UraniumUI.Dialogs.CommunityToolkit/CommunityToolkitDialogService.cs
+++ b/src/UraniumUI.Dialogs.CommunityToolkit/CommunityToolkitDialogService.cs
@@ -537,6 +537,7 @@ public class CommunityToolkitDialogService : CommunityToolkitDialogServiceBase, 
             { cancel, new Command(() =>
             {
                 tcs.TrySetResult(null);
+                popup.Close();
             }) }
         });
 


### PR DESCRIPTION
Cancel branch on CommunityToolkitDialogService.DisplayFormViewAsync did not call popup.Close()

Fixes #864 