### PR TITLE
[FIX] InputField.TitleFontSize is no longer bindable as of 2.10.0

### DIFF
--- a/src/UraniumUI.Material/Controls/InputField.cs
+++ b/src/UraniumUI.Material/Controls/InputField.cs
@@ -112,7 +112,6 @@ public partial class InputField : ContentView
         labelTitle.SetBinding(Label.FontSizeProperty, GetRelativeBinding(nameof(TitleFontSize)));
         labelTitle.SetBinding(Label.FontAttributesProperty, GetRelativeBinding(nameof(FontAttributes)));
         labelTitle.SetBinding(Label.FontFamilyProperty, GetRelativeBinding(nameof(FontFamily)));
-        labelTitle.SetBinding(Label.FontSizeProperty, GetRelativeBinding(nameof(FontSize)));
         labelTitle.SetBinding(Label.FontAutoScalingEnabledProperty, GetRelativeBinding(nameof(FontAutoScalingEnabled)));
 
         @this.Add(labelTitle);


### PR DESCRIPTION
Removed accidental duplicate binding for FontSizeProperty of InputField.Title

The code accidentally bound the property twice (see first and last line of snippet), and the latter one inadvertently overwrote the intended binding:

```csharp
labelTitle.SetBinding(Label.FontSizeProperty, GetRelativeBinding(nameof(TitleFontSize)));
labelTitle.SetBinding(Label.FontAttributesProperty, GetRelativeBinding(nameof(FontAttributes)));
labelTitle.SetBinding(Label.FontFamilyProperty, GetRelativeBinding(nameof(FontFamily)));
labelTitle.SetBinding(Label.FontSizeProperty, GetRelativeBinding(nameof(FontSize)));
```

Fixes #886 
