### PR TITLE
FIX CheckBox Windows handler NullReferenceException #912

### DIFF
--- a/src/UraniumUI.Material/Controls/CheckBox.Windows.cs
+++ b/src/UraniumUI.Material/Controls/CheckBox.Windows.cs
@@ -4,26 +4,20 @@ using Microsoft.UI.Xaml.Controls;
 namespace UraniumUI.Material.Controls;
 public partial class CheckBox
 {
-    protected override void OnHandlerChanged()
+    protected override void OnHandlerChanging(HandlerChangingEventArgs args)
     {
-        base.OnHandlerChanged();
-        if (Handler != null)
+        base.OnHandlerChanging(args);
+        if (args.OldHandler != null && args.OldHandler.PlatformView is Panel oldContentPanel)
         {
-            if (Handler.PlatformView is Panel contentPanel)
-            {
-                contentPanel.IsTabStop = true;
-                contentPanel.UseSystemFocusVisuals = true;
-                contentPanel.KeyDown += PlatformView_KeyDown;
-                contentPanel.KeyUp += PlatformView_KeyUp;
-            }
+            oldContentPanel.KeyDown -= PlatformView_KeyDown;
+            oldContentPanel.KeyUp -= PlatformView_KeyUp;
         }
-        else
+        if (args.NewHandler != null && args.NewHandler.PlatformView is Panel newContentPanel)
         {
-            if (Handler.PlatformView is Panel contentPanel)
-            {
-                contentPanel.KeyDown -= PlatformView_KeyDown;
-                contentPanel.KeyUp -= PlatformView_KeyUp;
-            }
+            newContentPanel.IsTabStop = true;
+            newContentPanel.UseSystemFocusVisuals = true;
+            newContentPanel.KeyDown += PlatformView_KeyDown;
+            newContentPanel.KeyUp += PlatformView_KeyUp;
         }
     }
 

--- a/src/UraniumUI.Material/Controls/CheckBox.Windows.cs
+++ b/src/UraniumUI.Material/Controls/CheckBox.Windows.cs
@@ -7,12 +7,12 @@ public partial class CheckBox
     protected override void OnHandlerChanging(HandlerChangingEventArgs args)
     {
         base.OnHandlerChanging(args);
-        if (args.OldHandler != null && args.OldHandler.PlatformView is Panel oldContentPanel)
+        if (args.OldHandler?.PlatformView is Panel oldContentPanel)
         {
             oldContentPanel.KeyDown -= PlatformView_KeyDown;
             oldContentPanel.KeyUp -= PlatformView_KeyUp;
         }
-        if (args.NewHandler != null && args.NewHandler.PlatformView is Panel newContentPanel)
+        if (args.NewHandler?.PlatformView is Panel newContentPanel)
         {
             newContentPanel.IsTabStop = true;
             newContentPanel.UseSystemFocusVisuals = true;


### PR DESCRIPTION
Fixes #912. Replace override OnHandlerChanged with OnHandlerChanging with unregistering events from old handler.