### PR TITLE
Reorder command execution after event invocation

### DIFF
--- a/UraniumUI.slnx
+++ b/UraniumUI.slnx
@@ -1,0 +1,34 @@
+<Solution>
+  <Folder Name="/demo/">
+    <Project Path="demo/UraniumApp/UraniumApp.csproj">
+      <Deploy />
+    </Project>
+  </Folder>
+  <Folder Name="/src/">
+    <Project Path="src/UraniumUI.Blurs/UraniumUI.Blurs.csproj" />
+    <Project Path="src/UraniumUI.Dialogs.CommunityToolkit/UraniumUI.Dialogs.CommunityToolkit.csproj" />
+    <Project Path="src/UraniumUI.Dialogs.Mopups/UraniumUI.Dialogs.Mopups.csproj" />
+    <Project Path="src/UraniumUI.Icons.FontAwesome/UraniumUI.Icons.FontAwesome.csproj">
+      <Deploy Solution="Release|*" />
+    </Project>
+    <Project Path="src/UraniumUI.Icons.MaterialIcons/UraniumUI.Icons.MaterialIcons.csproj">
+      <Deploy Solution="Release|*" />
+    </Project>
+    <Project Path="src/UraniumUI.Icons.MaterialSymbols/UraniumUI.Icons.MaterialSymbols.csproj" />
+    <Project Path="src/UraniumUI.Icons.SegoeFluent/UraniumUI.Icons.SegoeFluent.csproj" />
+    <Project Path="src/UraniumUI.Material/UraniumUI.Material.csproj">
+      <Deploy Solution="Release|*" />
+    </Project>
+    <Project Path="src/UraniumUI.Validations.DataAnnotations/UraniumUI.Validations.DataAnnotations.csproj" />
+    <Project Path="src/UraniumUI.WebComponents/UraniumUI.WebComponents.csproj" />
+    <Project Path="src/UraniumUI/UraniumUI.csproj">
+      <Deploy Solution="Release|*" />
+    </Project>
+  </Folder>
+  <Folder Name="/test/">
+    <Project Path="test/UraniumUI.Material.Tests/UraniumUI.Material.Tests.csproj" />
+    <Project Path="test/UraniumUI.Tests.Core/UraniumUI.Tests.Core.csproj" />
+    <Project Path="test/UraniumUI.Tests/UraniumUI.Tests.csproj" />
+  </Folder>
+  <Folder Name="/themes/" />
+</Solution>

--- a/src/UraniumUI/Handlers/StatefulContentViewHandler.Android.cs
+++ b/src/UraniumUI/Handlers/StatefulContentViewHandler.Android.cs
@@ -37,16 +37,16 @@ public partial class StatefulContentViewHandler
         if (e.Event.Action == MotionEventActions.HoverEnter)
         {
             GoToState(StatefulView, CommonStates.PointerOver);
-            ExecuteCommandIfCan(StatefulView.HoverCommand);
             StatefulView.InvokeHovered();
+            ExecuteCommandIfCan(StatefulView.HoverCommand);
             return;
         }
 
         if (e.Event.Action == MotionEventActions.HoverExit)
         {
             GoToState(StatefulView, CommonStates.Normal);
-            ExecuteCommandIfCan(StatefulView.HoverExitCommand);
             StatefulView.InvokeHoverExited();
+            ExecuteCommandIfCan(StatefulView.HoverExitCommand);
         }
     }
 
@@ -55,8 +55,8 @@ public partial class StatefulContentViewHandler
         if (e.Event.Action == MotionEventActions.Down)
         {
             GoToState(StatefulView, "Pressed");
-            ExecuteCommandIfCan(StatefulView.PressedCommand);
             StatefulView.InvokePressed();
+            ExecuteCommandIfCan(StatefulView.PressedCommand);
             e.Handled = false;
         }
         else if (e.Event.Action == MotionEventActions.Up)
@@ -69,14 +69,14 @@ public partial class StatefulContentViewHandler
     private void PlatformView_Click(object sender, EventArgs e)
     {
         GoToState(StatefulView, CommonStates.Normal);
-        ExecuteCommandIfCan(StatefulView.TappedCommand);
         StatefulView.InvokeTapped();
+        ExecuteCommandIfCan(StatefulView.TappedCommand);
     }
 
     private void PlatformView_LongClick(object sender, Android.Views.View.LongClickEventArgs e)
     {
-        ExecuteCommandIfCan(StatefulView.LongPressCommand);
         StatefulView.InvokeLongPressed();
+        ExecuteCommandIfCan(StatefulView.LongPressCommand);
     }
 
     public static void MapIsFocusable(StatefulContentViewHandler handler, StatefulContentView view)

--- a/src/UraniumUI/Handlers/StatefulContentViewHandler.Apple.cs
+++ b/src/UraniumUI/Handlers/StatefulContentViewHandler.Apple.cs
@@ -28,8 +28,8 @@ public partial class StatefulContentViewHandler
 
     private void OnLongPress(UILongPressGestureRecognizer recognizer)
     {
-        ExecuteCommandIfCan(StatefulView.LongPressCommand);
         StatefulView.InvokeLongPressed();
+        ExecuteCommandIfCan(StatefulView.LongPressCommand);
     }
 
     private void OnHover(UIHoverGestureRecognizer recognizer)
@@ -39,15 +39,15 @@ public partial class StatefulContentViewHandler
             case UIGestureRecognizerState.Began:
 
                 GoToState(StatefulView, CommonStates.PointerOver);
-                ExecuteCommandIfCan(StatefulView.HoverCommand);
                 StatefulView.InvokeHovered();
+                ExecuteCommandIfCan(StatefulView.HoverCommand);
                 break;
             case UIGestureRecognizerState.Ended:
             case UIGestureRecognizerState.Cancelled:
             case UIGestureRecognizerState.Failed:
                 GoToState(StatefulView, CommonStates.Normal);
-                ExecuteCommandIfCan(StatefulView.HoverExitCommand);
                 StatefulView.InvokeHoverExited();
+                ExecuteCommandIfCan(StatefulView.HoverExitCommand);
                 break;
         }
     }
@@ -58,14 +58,14 @@ public partial class StatefulContentViewHandler
         {
             case UIGestureRecognizerState.Began:
                 GoToState(StatefulView, "Pressed");
-                ExecuteCommandIfCan(StatefulView.PressedCommand);
                 StatefulView.InvokePressed();
+                ExecuteCommandIfCan(StatefulView.PressedCommand);
 
                 break;
             case UIGestureRecognizerState.Ended:
                 GoToState(StatefulView, CommonStates.Normal);
-                ExecuteCommandIfCan(StatefulView.TappedCommand);
                 StatefulView.InvokeTapped();
+                ExecuteCommandIfCan(StatefulView.TappedCommand);
 
                 //// TODO: Fix working of native gesture recognizers of MAUI
                 foreach (var item in StatefulView.GestureRecognizers)

--- a/src/UraniumUI/Handlers/StatefulContentViewHandler.Windows.cs
+++ b/src/UraniumUI/Handlers/StatefulContentViewHandler.Windows.cs
@@ -47,15 +47,15 @@ public partial class StatefulContentViewHandler
     private void PlatformView_PointerExited(object sender, PointerRoutedEventArgs e)
     {
         GoToState(StatefulView, CommonStates.Normal);
-        ExecuteCommandIfCan(StatefulView.HoverExitCommand);
         StatefulView.InvokeHoverExited();
+        ExecuteCommandIfCan(StatefulView.HoverExitCommand);
     }
 
     private void PlatformView_PointerEntered(object sender, PointerRoutedEventArgs e)
     {
         GoToState(StatefulView, CommonStates.PointerOver);
-        ExecuteCommandIfCan(StatefulView.HoverCommand);
         StatefulView.InvokeHovered();
+        ExecuteCommandIfCan(StatefulView.HoverCommand);
     }
 
     long lastPressed;
@@ -65,8 +65,8 @@ public partial class StatefulContentViewHandler
         lastPressed = DateTime.Now.Ticks;
 
         GoToState(StatefulView, "Pressed");
-        ExecuteCommandIfCan(StatefulView.PressedCommand);
         StatefulView.InvokePressed();
+        ExecuteCommandIfCan(StatefulView.PressedCommand);
     }
 
     private void PlatformView_PointerReleased(object sender, PointerRoutedEventArgs e)
@@ -78,8 +78,8 @@ public partial class StatefulContentViewHandler
         }
 
         GoToState(StatefulView, CommonStates.Normal);
-        ExecuteCommandIfCan(StatefulView.TappedCommand);
         StatefulView.InvokeTapped();
+        ExecuteCommandIfCan(StatefulView.TappedCommand);
     }
 
     private void PlatformView_KeyDown(object sender, KeyRoutedEventArgs e)
@@ -87,8 +87,8 @@ public partial class StatefulContentViewHandler
         if (IsActionKey(e.Key))
         {
             GoToState(StatefulView, "Pressed");
-            ExecuteCommandIfCan(StatefulView.PressedCommand);
             StatefulView.InvokePressed();
+            ExecuteCommandIfCan(StatefulView.PressedCommand);
         }
     }
 
@@ -96,9 +96,9 @@ public partial class StatefulContentViewHandler
     {
         if (IsActionKey(e.Key))
         {
-            ExecuteCommandIfCan(StatefulView.TappedCommand);
-            StatefulView.InvokeTapped();
             GoToState(StatefulView, CommonStates.Normal);
+            StatefulView.InvokeTapped();
+            ExecuteCommandIfCan(StatefulView.TappedCommand);
         }
     }
 


### PR DESCRIPTION
Resolves https://github.com/enisn/UraniumUI/issues/877

Moved `ExecuteCommandIfCan()` calls to occur after the corresponding event invocation methods (e.g., InvokeTapped, InvokePressed) in StatefulContentViewHandler for Android, Apple, and Windows. This ensures that event handlers are executed before any associated commands, improving consistency across platforms.