### PR TITLE
Add GetValueForValidator override

### DIFF
--- a/src/UraniumUI.Material/Controls/MultiplePickerField.cs
+++ b/src/UraniumUI.Material/Controls/MultiplePickerField.cs
@@ -110,6 +110,11 @@ public partial class MultiplePickerField : InputField
 
         return layout;
     }
+    
+    protected override object GetValueForValidator()
+    {
+        return SelectedItems;
+    }
 
     protected virtual void OnItemsSourceSet()
     {


### PR DESCRIPTION
This PR fix the #628 issue.

It just adds an override of the `InputField.Validator.GetValueForValidator()` method in order to return the `MultiplePickerField.SelectedItems` property instead of a `new object()` of the base method implementation.