### PR TITLE
Fix binding of nullable Date and Time to non-nullable fields

### DIFF
--- a/src/UraniumUI.Material/Controls/DatePickerField.cs
+++ b/src/UraniumUI.Material/Controls/DatePickerField.cs
@@ -103,7 +103,7 @@ public class DatePickerField : InputField
     #endif
 #endif
         // End of workaround
-        Date = default;
+        Date = (DateTime)DatePicker.DateProperty.DefaultValue;
 
 #if MACCATALYST
         DatePickerView.Unfocus();
@@ -170,14 +170,15 @@ public class DatePickerField : InputField
 
     public override void ResetValidation()
     {
-        Date = default;
+        Date = DateTime.Today;
         base.ResetValidation();
     }
 
     public DateTime Date { get => (DateTime)GetValue(DateProperty); set => SetValue(DateProperty, value); }
 
     public static readonly BindableProperty DateProperty = BindableProperty.Create(
-        nameof(Date), typeof(DateTime), typeof(DatePickerField), defaultValue: default, defaultBindingMode: BindingMode.TwoWay,
+        nameof(Date), typeof(DateTime), typeof(DatePickerField),
+        defaultValue: DateTime.Today, defaultBindingMode: BindingMode.TwoWay,
         propertyChanged: (bindable, oldValue, newValue) => (bindable as DatePickerField).OnDateChanged()
         );
 

--- a/src/UraniumUI.Material/Controls/DatePickerField.cs
+++ b/src/UraniumUI.Material/Controls/DatePickerField.cs
@@ -103,7 +103,7 @@ public class DatePickerField : InputField
     #endif
 #endif
         // End of workaround
-        Date = null;
+        Date = default;
 
 #if MACCATALYST
         DatePickerView.Unfocus();
@@ -170,21 +170,21 @@ public class DatePickerField : InputField
 
     public override void ResetValidation()
     {
-        Date = null;
+        Date = default;
         base.ResetValidation();
     }
 
-    public DateTime? Date { get => (DateTime?)GetValue(DateProperty); set => SetValue(DateProperty, value); }
+    public DateTime Date { get => (DateTime)GetValue(DateProperty); set => SetValue(DateProperty, value); }
 
     public static readonly BindableProperty DateProperty = BindableProperty.Create(
-        nameof(Date), typeof(DateTime?), typeof(DatePickerField), defaultValue: null, defaultBindingMode: BindingMode.TwoWay,
+        nameof(Date), typeof(DateTime), typeof(DatePickerField), defaultValue: default, defaultBindingMode: BindingMode.TwoWay,
         propertyChanged: (bindable, oldValue, newValue) => (bindable as DatePickerField).OnDateChanged()
         );
 
     public DateTime MaximumDate { get => (DateTime)GetValue(MaximumDateProperty); set => SetValue(MaximumDateProperty, value); }
 
     public static readonly BindableProperty MaximumDateProperty = BindableProperty.Create(
-         nameof(MaximumDate), typeof(DateTime?), typeof(DatePickerField),
+         nameof(MaximumDate), typeof(DateTime), typeof(DatePickerField),
          defaultValue: DatePicker.MaximumDateProperty.DefaultValue,
          propertyChanged: (bindable, oldValue, newValue) => (bindable as DatePickerField).DatePickerView.MaximumDate = (DateTime)newValue
          );
@@ -192,7 +192,7 @@ public class DatePickerField : InputField
     public DateTime MinimumDate { get => (DateTime)GetValue(MinimumDateProperty); set => SetValue(MinimumDateProperty, value); }
 
     public static readonly BindableProperty MinimumDateProperty = BindableProperty.Create(
-         nameof(MinimumDate), typeof(DateTime?), typeof(DatePickerField),
+         nameof(MinimumDate), typeof(DateTime), typeof(DatePickerField),
          defaultValue: DatePicker.MinimumDateProperty.DefaultValue,
          propertyChanged: (bindable, oldValue, newValue) => (bindable as DatePickerField).DatePickerView.MinimumDate = (DateTime)newValue
          );

--- a/src/UraniumUI.Material/Controls/TimePickerField.cs
+++ b/src/UraniumUI.Material/Controls/TimePickerField.cs
@@ -83,7 +83,7 @@ public class TimePickerField : InputField
             TimePickerView.Time += TimeSpan.FromSeconds(1);
             // End of workaround
 
-            Time = default;
+            Time = (TimeSpan)TimePicker.TimeProperty.DefaultValue;
         }
     }
 
@@ -140,14 +140,14 @@ public class TimePickerField : InputField
 
     public override void ResetValidation()
     {
-        Time = default;
+        Time = (TimeSpan)TimePicker.TimeProperty.DefaultValue;
         base.ResetValidation();
     }
 
     public TimeSpan Time { get => (TimeSpan)GetValue(TimeProperty); set => SetValue(TimeProperty, value); }
 
-    public static readonly BindableProperty TimeProperty =
-        BindableProperty.Create(nameof(Time), typeof(TimeSpan), typeof(TimePickerField), default, defaultBindingMode: BindingMode.TwoWay,
+    public static readonly BindableProperty TimeProperty = BindableProperty.Create(
+        nameof(Time), typeof(TimeSpan), typeof(TimePickerField), TimePicker.TimeProperty.DefaultValue, defaultBindingMode: BindingMode.TwoWay,
             propertyChanged: (bindable, oldValue, newValue) => (bindable as TimePickerField).OnTimeChanged());
 
     public string Format { get => (string)GetValue(FormatProperty); set => SetValue(FormatProperty, value); }

--- a/src/UraniumUI.Material/Controls/TimePickerField.cs
+++ b/src/UraniumUI.Material/Controls/TimePickerField.cs
@@ -83,7 +83,7 @@ public class TimePickerField : InputField
             TimePickerView.Time += TimeSpan.FromSeconds(1);
             // End of workaround
 
-            Time = null;
+            Time = default;
         }
     }
 
@@ -140,14 +140,14 @@ public class TimePickerField : InputField
 
     public override void ResetValidation()
     {
-        Time = null;
+        Time = default;
         base.ResetValidation();
     }
 
-    public TimeSpan? Time { get => (TimeSpan?)GetValue(TimeProperty); set => SetValue(TimeProperty, value); }
+    public TimeSpan Time { get => (TimeSpan)GetValue(TimeProperty); set => SetValue(TimeProperty, value); }
 
     public static readonly BindableProperty TimeProperty =
-        BindableProperty.Create(nameof(Time), typeof(TimeSpan?), typeof(TimePickerField), null, defaultBindingMode: BindingMode.TwoWay,
+        BindableProperty.Create(nameof(Time), typeof(TimeSpan), typeof(TimePickerField), default, defaultBindingMode: BindingMode.TwoWay,
             propertyChanged: (bindable, oldValue, newValue) => (bindable as TimePickerField).OnTimeChanged());
 
     public string Format { get => (string)GetValue(FormatProperty); set => SetValue(FormatProperty, value); }

--- a/test/UraniumUI.Material.Tests/Controls/DatePickerField_Test.cs
+++ b/test/UraniumUI.Material.Tests/Controls/DatePickerField_Test.cs
@@ -183,7 +183,7 @@ public class DatePickerField_Test
 
     public class TestViewModel : UraniumBindableObject
     {
-        private DateTime? time;
+        private DateTime time;
         private string format;
         private Color textColor;
         private double characterSpacing;
@@ -191,7 +191,7 @@ public class DatePickerField_Test
         private string fontFamily;
         private double fontSize;
 
-        public DateTime? Date { get => time; set => SetProperty(ref time, value); }
+        public DateTime Date { get => time; set => SetProperty(ref time, value); }
 
         public string Format { get => format; set => SetProperty(ref format, value); }
 

--- a/test/UraniumUI.Material.Tests/Controls/TimePickerField_Test.cs
+++ b/test/UraniumUI.Material.Tests/Controls/TimePickerField_Test.cs
@@ -183,7 +183,7 @@ public class TimePickerField_Test
 
     public class TestViewModel : UraniumBindableObject
     {
-        private TimeSpan? time;
+        private TimeSpan time;
         private string format;
         private Color textColor;
         private double characterSpacing;
@@ -191,7 +191,7 @@ public class TimePickerField_Test
         private string fontFamily;
         private double fontSize;
 
-        public TimeSpan? Time { get => time; set => SetProperty(ref time, value); }
+        public TimeSpan Time { get => time; set => SetProperty(ref time, value); }
 
         public string Format { get => format; set => SetProperty(ref format, value); }
 


### PR DESCRIPTION
Fixing some binding nullable class to not nullable class causing errors and crash of the application :
```'' cannot be converted to type 'System.DateTime'```

Fixes #903 