### PR TITLE
fix: DropdownField hover text color on Windows dark theme (#896)

### DIFF
--- a/src/UraniumUI/Handlers/DropdownHandler.Windows.cs
+++ b/src/UraniumUI/Handlers/DropdownHandler.Windows.cs
@@ -138,7 +138,7 @@ public partial class DropdownHandler : ButtonHandler
         else
         {
             PlatformView.Content = GetTextForItem(VirtualViewDropdown, VirtualViewDropdown.SelectedItem);
-            PlatformView.Foreground = VirtualViewDropdown.TextColor?.ToPlatform() ?? Colors.Black.ToPlatform();
+            PlatformView.Foreground = VirtualViewDropdown.TextColor.ToPlatform();
         }
     }
 


### PR DESCRIPTION
## Summary
- Fixes Issue #896: Hovering over DropdownField on Windows sets text color to black in dark theme
- Removed incorrect Colors.Black fallback in Windows handler
- TextColor is already set correctly via SetAppThemeColor (White for dark theme, Black for light theme)

## Changes
- src/UraniumUI/Handlers/DropdownHandler.Windows.cs: Changed to use TextColor.ToPlatform() directly instead of falling back to Black