### PR TITLE
fix: Add ClearCommand as BindableProperty to TextField (#852)

### DIFF
--- a/docs/en/themes/material/components/TextField.md
+++ b/docs/en/themes/material/components/TextField.md
@@ -35,6 +35,7 @@ Then you can use it like this:
 
 ### Behavior Properties
 - `AllowClear` - Gets or sets whether a clear button is shown to clear the text
+- `ClearCommand` - Gets or sets the command to execute when the clear button is pressed
 - `DisallowClearButtonFocus` - Gets or sets whether the clear button can receive focus
 - `SelectAllTextOnFocus` - Gets or sets whether all text should be selected when the field receives focus
 - `IsReadOnly` - Gets or sets whether the TextField is read-only

--- a/src/UraniumUI.Material/Controls/TextField.BindableProperties.cs
+++ b/src/UraniumUI.Material/Controls/TextField.BindableProperties.cs
@@ -82,6 +82,14 @@ public partial class TextField
         typeof(TextField),
         defaultBindingMode: BindingMode.TwoWay);
 
+    public ICommand ClearCommand { get => (ICommand)GetValue(ClearCommandProperty); set => SetValue(ClearCommandProperty, value); }
+
+    public static readonly BindableProperty ClearCommandProperty = BindableProperty.Create(
+        nameof(ClearCommand),
+        typeof(ICommand),
+        typeof(TextField),
+        defaultBindingMode: BindingMode.TwoWay);
+
     public double CharacterSpacing { get => (double)GetValue(CharacterSpacingProperty); set => SetValue(CharacterSpacingProperty, value); }
 
     public static readonly BindableProperty CharacterSpacingProperty = BindableProperty.Create(

--- a/src/UraniumUI.Material/Controls/TextField.cs
+++ b/src/UraniumUI.Material/Controls/TextField.cs
@@ -35,8 +35,6 @@ public partial class TextField : InputField
     public event EventHandler<TextChangedEventArgs> TextChanged;
     public event EventHandler Completed;
 
-    public ICommand ClearCommand { get; protected set; }
-
     public TextField()
     {
         base.RegisterForEvents();


### PR DESCRIPTION
## Summary
- Fixes Issue #852: ClearCommand not found in TextField
- Added ClearCommand as a BindableProperty in TextField.BindableProperties.cs
- Removed conflicting regular property from TextField.cs

## Changes
- src/UraniumUI.Material/Controls/TextField.BindableProperties.cs: Added ClearCommandProperty as BindableProperty
- src/UraniumUI.Material/Controls/TextField.cs: Removed conflicting regular property

## Usage
Users can now bind to ClearCommand in XAML:
