### PR TITLE
fix: apply PickerField text color on Windows

### DIFF
--- a/src/UraniumUI.Material/Controls/PickerField.cs
+++ b/src/UraniumUI.Material/Controls/PickerField.cs
@@ -147,12 +147,11 @@ public class PickerField : InputField
 
     protected virtual void OnTextColorChanged()
     {
-        PickerView.TextColor = TextColor;
-
 #if WINDOWS
-        if (labelSelectedItem != null)
+        var label = labelSelectedItem;
+        if (label != null)
         {
-            labelSelectedItem.TextColor = TextColor ?? ColorResource.GetColor("OnBackground", "OnBackgroundDark", Colors.Gray);
+            label.TextColor = TextColor ?? ColorResource.GetColor("OnBackground", "OnBackgroundDark", Colors.Gray);
         }
 #endif
     }

--- a/src/UraniumUI.Material/Controls/PickerField.cs
+++ b/src/UraniumUI.Material/Controls/PickerField.cs
@@ -145,6 +145,18 @@ public class PickerField : InputField
         UpdateClearIconState();
     }
 
+    protected virtual void OnTextColorChanged()
+    {
+        PickerView.TextColor = TextColor;
+
+#if WINDOWS
+        if (labelSelectedItem != null)
+        {
+            labelSelectedItem.TextColor = TextColor ?? ColorResource.GetColor("OnBackground", "OnBackgroundDark", Colors.Gray);
+        }
+#endif
+    }
+
     protected virtual void UpdateClearIconState()
     {
         var existing = endIconsContainer.FindByViewQueryIdInVisualTreeDescendants<StatefulContentView>("ClearIcon");
@@ -225,7 +237,8 @@ public class PickerField : InputField
     public Color TextColor { get => (Color)GetValue(TextColorProperty); set => SetValue(TextColorProperty, value); }
 
     public static readonly BindableProperty TextColorProperty = BindableProperty.Create(
-        nameof(TextColor), typeof(Color), typeof(PickerField), Picker.TextColorProperty.DefaultValue);
+        nameof(TextColor), typeof(Color), typeof(PickerField), Picker.TextColorProperty.DefaultValue,
+        propertyChanged: (bindable, oldValue, newValue) => (bindable as PickerField).OnTextColorChanged());
 
     public double CharacterSpacing { get => (double)GetValue(CharacterSpacingProperty); set => SetValue(CharacterSpacingProperty, value); }
 


### PR DESCRIPTION
## Summary
- update `PickerField` so `TextColor` also updates the Windows selected-item label used for rendering
- preserve the existing themed fallback color when `TextColor` is not set
- fixes #946

<img width="482" height="183" alt="image" src="https://github.com/user-attachments/assets/c3eb235c-afe3-4713-bdca-8fbcb0a04f14" />


## Testing
- `dotnet test "test/UraniumUI.Material.Tests/UraniumUI.Material.Tests.csproj"`
- `dotnet build "src/UraniumUI.Material/UraniumUI.Material.csproj" -f net10.0-windows10.0.19041.0`