### PR TITLE
fix: refresh MultiplePickerField layout after selection changes

### DIFF
--- a/src/UraniumUI.Material/Controls/MultiplePickerField.cs
+++ b/src/UraniumUI.Material/Controls/MultiplePickerField.cs
@@ -124,6 +124,7 @@ public partial class MultiplePickerField : InputField
     protected virtual void OnSelectedItemsSet(IList oldValue, IList newValue)
     {
         BindableLayout.SetItemsSource(chipsHolderLayout, SelectedItems);
+        RefreshChipLayout();
         UpdateState();
 
         if (oldValue is INotifyCollectionChanged oldObservable)
@@ -140,9 +141,28 @@ public partial class MultiplePickerField : InputField
 
     private void SelectedItemsChanged(object sender, NotifyCollectionChangedEventArgs e)
     {
+        RefreshChipLayout();
         UpdateState();
         SelectedValuesChangedCommand?.Execute(SelectedItems);
         SelectedValuesChanged?.Invoke(sender, SelectedItems);
+    }
+
+    protected virtual void RefreshChipLayout()
+    {
+        if (Dispatcher?.IsDispatchRequired ?? false)
+        {
+            Dispatcher.Dispatch(RefreshChipLayoutCore);
+            return;
+        }
+
+        RefreshChipLayoutCore();
+    }
+
+    private void RefreshChipLayoutCore()
+    {
+        chipsHolderLayout?.InvalidateMeasure();
+        MainContentView?.InvalidateMeasure();
+        InvalidateMeasure();
     }
 
     public IList ItemsSource { get => (IList)GetValue(ItemsSourceProperty); set => SetValue(ItemsSourceProperty, value); }

--- a/test/UraniumUI.Material.Tests/Controls/MultiplePickerField_Test.cs
+++ b/test/UraniumUI.Material.Tests/Controls/MultiplePickerField_Test.cs
@@ -34,6 +34,41 @@ public class MultiplePickerField_Test
         control.SelectedItems[0].ShouldBe(viewModel.ItemsSource[0]);
     }
 
+    [Fact]
+    public void SetSelectedItems_ShouldRefreshLayout()
+    {
+        var control = AnimationReadyHandler.Prepare(new TestMultiplePickerField());
+
+        control.SelectedItems = new ObservableCollection<object>
+        {
+            "Option 1"
+        };
+
+        control.RefreshChipLayoutCallCount.ShouldBe(1);
+    }
+
+    [Fact]
+    public void ChangeSelectedItems_ShouldRefreshLayout()
+    {
+        var selectedItems = new ObservableCollection<object>();
+        var control = AnimationReadyHandler.Prepare(new TestMultiplePickerField());
+        control.SelectedItems = selectedItems;
+
+        selectedItems.Add("Option 1");
+
+        control.RefreshChipLayoutCallCount.ShouldBe(2);
+    }
+
+    private sealed class TestMultiplePickerField : MultiplePickerField
+    {
+        public int RefreshChipLayoutCallCount { get; private set; }
+
+        protected override void RefreshChipLayout()
+        {
+            RefreshChipLayoutCallCount++;
+        }
+    }
+
     public class TestViewModel : UraniumBindableObject
     {
         public string[] ItemsSource { get; set; } = new string[] { "Option 1", "Option 2", "Option 3", "Option 4", };


### PR DESCRIPTION
## Summary
- refresh `MultiplePickerField` layout when the selected chip collection changes so wrapped rows are remeasured immediately
- add regression coverage to ensure selection updates trigger a layout refresh

## Testing
- dotnet test \"test/UraniumUI.Material.Tests/UraniumUI.Material.Tests.csproj\" --filter \"MultiplePickerField_Test\"

Closes #945