### PR TITLE
fix: make PickerField ItemDisplayBinding work in XAML

### DIFF
--- a/src/UraniumUI.Material/Controls/PickerField.cs
+++ b/src/UraniumUI.Material/Controls/PickerField.cs
@@ -122,22 +122,25 @@ public class PickerField : InputField
         CheckAndShowValidations();
 
 #if WINDOWS
-        if (ItemDisplayBinding != null)
-        {
-            Binding itemDisplayBinding = (Binding)ItemDisplayBinding;
-            string nameOfDisplayProperty = itemDisplayBinding.Path;
-            labelSelectedItem.SetBinding(Label.TextProperty, new Binding(nameof(SelectedItem) + '.' + nameOfDisplayProperty, source: this));
-        }
-        else
-        {
-            labelSelectedItem.Text = SelectedItem?.ToString();
-        }
+        UpdateSelectedItemLabel();
 #endif
 
         UpdateState();
 
         SelectedValueChangedCommand?.Execute(SelectedItem);
         SelectedValueChanged?.Invoke(this, SelectedItem);
+    }
+
+    protected virtual void OnItemDisplayBindingChanged()
+    {
+        if (Content is PickerView pickerView)
+        {
+            pickerView.ItemDisplayBinding = ItemDisplayBinding;
+        }
+
+#if WINDOWS
+        UpdateSelectedItemLabel();
+#endif
     }
 
     protected virtual void OnAllowClearChanged()
@@ -155,6 +158,27 @@ public class PickerField : InputField
         }
 #endif
     }
+
+#if WINDOWS
+    private void UpdateSelectedItemLabel()
+    {
+        var selectedLabel = labelSelectedItem;
+
+        if (selectedLabel == null)
+        {
+            return;
+        }
+
+        if (ItemDisplayBinding is Binding itemDisplayBinding)
+        {
+            selectedLabel.SetBinding(Label.TextProperty, new Binding($"{nameof(SelectedItem)}.{itemDisplayBinding.Path}", source: this));
+            return;
+        }
+
+        selectedLabel.RemoveBinding(Label.TextProperty);
+        selectedLabel.Text = SelectedItem?.ToString();
+    }
+#endif
 
     protected virtual void UpdateClearIconState()
     {
@@ -231,7 +255,11 @@ public class PickerField : InputField
        nameof(ItemsSource), typeof(IList), typeof(PickerField),
        defaultValue: Picker.ItemsSourceProperty.DefaultValue);
 
-    public BindingBase ItemDisplayBinding { get => PickerView.ItemDisplayBinding; set => PickerView.ItemDisplayBinding = value; }
+    public BindingBase ItemDisplayBinding { get => (BindingBase)GetValue(ItemDisplayBindingProperty); set => SetValue(ItemDisplayBindingProperty, value); }
+
+    public static readonly BindableProperty ItemDisplayBindingProperty = BindableProperty.Create(
+        nameof(ItemDisplayBinding), typeof(BindingBase), typeof(PickerField),
+        propertyChanged: (bindable, oldValue, newValue) => (bindable as PickerField).OnItemDisplayBindingChanged());
 
     public Color TextColor { get => (Color)GetValue(TextColorProperty); set => SetValue(TextColorProperty, value); }
 

--- a/test/UraniumUI.Material.Tests/Controls/PickerField_Test.cs
+++ b/test/UraniumUI.Material.Tests/Controls/PickerField_Test.cs
@@ -91,6 +91,20 @@ public class PickerField_Test
     }
 
     [Fact]
+    public void ItemDisplayBinding_ShouldBeSet_FromBindableProperty()
+    {
+        var control = AnimationReadyHandler.Prepare(new PickerField());
+        var itemDisplayBinding = new Binding(nameof(TestItem.DisplayName));
+
+        // Act
+        control.SetValue(PickerField.ItemDisplayBindingProperty, itemDisplayBinding);
+
+        // Assert
+        control.ItemDisplayBinding.ShouldBeSameAs(itemDisplayBinding);
+        control.PickerView.ItemDisplayBinding.ShouldBeSameAs(itemDisplayBinding);
+    }
+
+    [Fact]
     public void TextColor_ShouldBeSet_FromViewModel()
     {
         var control = AnimationReadyHandler.Prepare(new PickerField());
@@ -227,5 +241,10 @@ public class PickerField_Test
         public double FontSize { get => fontSize; set => SetProperty(ref fontSize, value); }
 
         public IList ItemsSource { get => itemsSource; set => SetProperty(ref itemsSource, value); }
+    }
+
+    private sealed class TestItem
+    {
+        public string DisplayName { get; set; }
     }
 }


### PR DESCRIPTION
## Summary
- make `PickerField.ItemDisplayBinding` a bindable property so XAML passes the binding through to the inner picker
- refresh the Windows selected-item label when the display binding changes and add regression coverage

## Testing
- dotnet test \"test/UraniumUI.Material.Tests/UraniumUI.Material.Tests.csproj\" --filter \"FullyQualifiedName~PickerField_Test\"
- dotnet test \"test/UraniumUI.Material.Tests/UraniumUI.Material.Tests.csproj\" --filter \"FullyQualifiedName=UraniumUI.Material.Tests.Attachments.BackdropView_Test.Title_BindingForInitialization_FromSource\"

Closes #937