### PR TITLE
fix: guard InputField template part initialization

### DIFF
--- a/src/UraniumUI.Material/Controls/InputField.cs
+++ b/src/UraniumUI.Material/Controls/InputField.cs
@@ -193,6 +193,8 @@ public partial class InputField : ContentView
 
         if (args.NewHandler is null)
         {
+            isTemplateApplied = false;
+            ResetTemplateParts();
             ReleaseEvents();
         }
     }

--- a/src/UraniumUI.Material/Controls/InputField.cs
+++ b/src/UraniumUI.Material/Controls/InputField.cs
@@ -17,6 +17,7 @@ public partial class InputField : ContentView
     private Grid rootGridPart;
     private Grid innerGridPart;
     private HorizontalStackLayout endIconsContainerPart;
+    private bool isTemplateApplied;
 
     public virtual new View Content { get => (View)GetValue(ContentProperty); set => SetValue(ContentProperty, value); }
 
@@ -169,14 +170,12 @@ public partial class InputField : ContentView
     private T FindTemplatePart<T>(string id)
         where T : VisualElement
     {
-        try
-        {
-            return this.FindByViewQueryIdInVisualTreeDescendants<T>(id);
-        }
-        catch (NullReferenceException)
+        if (!isTemplateApplied && Handler is null)
         {
             return null;
         }
+
+        return this.FindByViewQueryIdInVisualTreeDescendants<T>(id);
     }
 
     private void ResetTemplateParts()
@@ -453,6 +452,8 @@ public partial class InputField : ContentView
     protected override void OnApplyTemplate()
     {
         base.OnApplyTemplate();
+
+        isTemplateApplied = true;
 
         ResetTemplateParts();
 

--- a/src/UraniumUI.Material/Controls/InputField.cs
+++ b/src/UraniumUI.Material/Controls/InputField.cs
@@ -11,6 +11,13 @@ public partial class InputField : ContentView
 {
     internal const double FirstDash = 6;
     internal const double MaxCornerRadius = 24;
+
+    private Label titleLabelPart;
+    private Border borderPart;
+    private Grid rootGridPart;
+    private Grid innerGridPart;
+    private HorizontalStackLayout endIconsContainerPart;
+
     public virtual new View Content { get => (View)GetValue(ContentProperty); set => SetValue(ContentProperty, value); }
 
     public static readonly new BindableProperty ContentProperty = BindableProperty.Create(
@@ -37,13 +44,13 @@ public partial class InputField : ContentView
             inputField.OnPropertyChanged(nameof(Content));
         }, defaultBindingMode: BindingMode.TwoWay);
 
-    protected Label labelTitle => this.FindByViewQueryIdInVisualTreeDescendants<Label>("TitleLabel");
+    protected Label labelTitle => titleLabelPart ??= FindTemplatePart<Label>("TitleLabel");
 
-    protected Border border => this.FindByViewQueryIdInVisualTreeDescendants<Border>("Border");
+    protected Border border => borderPart ??= FindTemplatePart<Border>("Border");
 
-    protected Grid rootGrid => this.FindByViewQueryIdInVisualTreeDescendants<Grid>("RootGrid");
+    protected Grid rootGrid => rootGridPart ??= FindTemplatePart<Grid>("RootGrid");
 
-    protected Grid innerGrid => this.FindByViewQueryIdInVisualTreeDescendants<Grid>("InnerGrid");
+    protected Grid innerGrid => innerGridPart ??= FindTemplatePart<Grid>("InnerGrid");
 
     protected Lazy<Image> imageIcon = new Lazy<Image>(() =>
     {
@@ -58,7 +65,7 @@ public partial class InputField : ContentView
         };
     });
 
-    protected HorizontalStackLayout endIconsContainer => this.FindByViewQueryIdInVisualTreeDescendants<HorizontalStackLayout>("EndIconsContainer");
+    protected HorizontalStackLayout endIconsContainer => endIconsContainerPart ??= FindTemplatePart<HorizontalStackLayout>("EndIconsContainer");
 
     public IList<IView> Attachments => endIconsContainer?.Children;
 
@@ -159,6 +166,28 @@ public partial class InputField : ContentView
         }
     }
 
+    private T FindTemplatePart<T>(string id)
+        where T : VisualElement
+    {
+        try
+        {
+            return this.FindByViewQueryIdInVisualTreeDescendants<T>(id);
+        }
+        catch (NullReferenceException)
+        {
+            return null;
+        }
+    }
+
+    private void ResetTemplateParts()
+    {
+        titleLabelPart = null;
+        borderPart = null;
+        rootGridPart = null;
+        innerGridPart = null;
+        endIconsContainerPart = null;
+    }
+
     protected override void OnHandlerChanging(HandlerChangingEventArgs args)
     {
         base.OnHandlerChanging(args);
@@ -213,7 +242,10 @@ public partial class InputField : ContentView
 
     protected virtual void OnFocusChanged(object sender, FocusEventArgs args)
     {
-        (this.rootGrid as IGridLayout).IsFocused = args.IsFocused;
+        if (rootGrid is IGridLayout gridLayout)
+        {
+            gridLayout.IsFocused = args.IsFocused;
+        }
     }
 #endif
 
@@ -253,7 +285,10 @@ public partial class InputField : ContentView
 
     private void InitializeBorder()
     {
-        if (labelTitle is null)
+        var currentLabelTitle = labelTitle;
+        var currentBorder = border;
+
+        if (currentLabelTitle is null || currentBorder is null)
         {
             return;
         }
@@ -261,36 +296,39 @@ public partial class InputField : ContentView
         var perimeter = (this.Width + this.Height) * 2;
         var calculatedFirstDash = FirstDash + CornerRadius.Clamp(FirstDash, double.MaxValue);
 
-        var space = (labelTitle.Width + calculatedFirstDash) * .8;
-        if (labelTitle.Width <= 0)
+        var space = (currentLabelTitle.Width + calculatedFirstDash) * .8;
+        if (currentLabelTitle.Width <= 0)
             space = 0;
 
 #if ANDROID
         if (this.IsRtl())
         {
-            calculatedFirstDash += this.Width - labelTitle.Width;
+            calculatedFirstDash += this.Width - currentLabelTitle.Width;
         }
 #endif
 
-        border.StrokeDashArray = new DoubleCollection { calculatedFirstDash * 0.9 / BorderThickness, space / BorderThickness, perimeter, 0 };
+        currentBorder.StrokeDashArray = new DoubleCollection { calculatedFirstDash * 0.9 / BorderThickness, space / BorderThickness, perimeter, 0 };
 
         UpdateState();
     }
 
     protected virtual void UpdateState()
     {
+        var currentBorder = border;
+        var currentLabelTitle = labelTitle;
+
         if (Content is null)
         {
             return;
         }
 
-        if (border.StrokeDashArray == null || border.StrokeDashArray.Count == 0 || labelTitle.Width <= 0)
+        if (currentBorder?.StrokeDashArray == null || currentBorder.StrokeDashArray.Count == 0 || currentLabelTitle is null || currentLabelTitle.Width <= 0)
         {
             return;
         }
 
-        using (border.Batch())
-        using (labelTitle.Batch())
+        using (currentBorder.Batch())
+        using (currentLabelTitle.Batch())
         {
             if (HasValue || Content.IsFocused)
             {
@@ -298,34 +336,34 @@ public partial class InputField : ContentView
 
                 UpdateOffset(0.01);
 
-                labelTitle.AnchorX = 0;
+                currentLabelTitle.AnchorX = 0;
 
-                labelTitle.CancelAnimations();
+                currentLabelTitle.CancelAnimations();
                 if (HasValue)
                 {
-                    labelTitle.TranslationX = x;
-                    labelTitle.TranslationY = -25;
-                    labelTitle.Scale = .8;
+                    currentLabelTitle.TranslationX = x;
+                    currentLabelTitle.TranslationY = -25;
+                    currentLabelTitle.Scale = .8;
                 }
                 else
                 {
-                    labelTitle.TranslateToSafely(x, -25, 90, Easing.BounceOut);
-                    labelTitle.ScaleToSafely(.8, 90);
+                    currentLabelTitle.TranslateToSafely(x, -25, 90, Easing.BounceOut);
+                    currentLabelTitle.ScaleToSafely(.8, 90);
                 }
 
 #if ANDROID
                 if (this.IsRtl())
                 {
-                    labelTitle.AnchorX = .5;
+                    currentLabelTitle.AnchorX = .5;
                 }
 #endif
             }
             else
             {
-                var offsetToGo = border.StrokeDashArray[0] + border.StrokeDashArray[1] + FirstDash;
+                var offsetToGo = currentBorder.StrokeDashArray[0] + currentBorder.StrokeDashArray[1] + FirstDash;
                 UpdateOffset(offsetToGo);
 
-                labelTitle.CancelAnimations();
+                currentLabelTitle.CancelAnimations();
 
                 var x = imageIcon.IsValueCreated ? imageIcon.Value.Width : 0;
 
@@ -336,16 +374,19 @@ public partial class InputField : ContentView
                 }
 #endif
 
-                labelTitle.AnchorX = 0;
-                labelTitle.TranslateToSafely(x, 0, 90, Easing.BounceOut);
-                labelTitle.ScaleToSafely(1, 90);
+                currentLabelTitle.AnchorX = 0;
+                currentLabelTitle.TranslateToSafely(x, 0, 90, Easing.BounceOut);
+                currentLabelTitle.ScaleToSafely(1, 90);
             }
         }
     }
 
     protected virtual void UpdateOffset(double value)
     {
-        border.StrokeDashOffset = value;
+        if (border is not null)
+        {
+            border.StrokeDashOffset = value;
+        }
     }
 
     protected virtual void RegisterForEvents()
@@ -370,8 +411,11 @@ public partial class InputField : ContentView
 
     private void Content_Unfocused(object sender, FocusEventArgs e)
     {
-        border.SetBinding(Border.StrokeProperty, GetRelativeBinding(nameof(BorderColor)));
-        labelTitle.SetBinding(Label.TextColorProperty, GetRelativeBinding(nameof(TitleColor)));
+        var currentBorder = border;
+        var currentLabelTitle = labelTitle;
+
+        currentBorder?.SetBinding(Border.StrokeProperty, GetRelativeBinding(nameof(BorderColor)));
+        currentLabelTitle?.SetBinding(Label.TextColorProperty, GetRelativeBinding(nameof(TitleColor)));
         UpdateState();
 
         if (Icon is FontImageSource fontImageSource)
@@ -382,8 +426,16 @@ public partial class InputField : ContentView
 
     private void Content_Focused(object sender, FocusEventArgs e)
     {
-        border.Stroke = AccentColor;
-        labelTitle.TextColor = AccentColor;
+        if (border is not null)
+        {
+            border.Stroke = AccentColor;
+        }
+
+        if (labelTitle is not null)
+        {
+            labelTitle.TextColor = AccentColor;
+        }
+
         UpdateState();
 
         if (Icon is FontImageSource fontImageSource && fontImageSource.Color != AccentColor)
@@ -401,12 +453,19 @@ public partial class InputField : ContentView
     protected override void OnApplyTemplate()
     {
         base.OnApplyTemplate();
+
+        ResetTemplateParts();
+
         if (Icon != null)
         {
-            if (innerGrid != null && !innerGrid.Contains(imageIcon.Value))
-            {
-                innerGrid.Add(imageIcon.Value, column: 0);
-            }
+            OnIconChanged();
+        }
+
+        OnCornerRadiusChanged();
+
+        if (!string.IsNullOrEmpty(ContentAutomationId) && Content != null)
+        {
+            Content.AutomationId = ContentAutomationId;
         }
     }
 
@@ -440,7 +499,7 @@ public partial class InputField : ContentView
             return;
         }
 
-        if (border.StrokeShape is RoundRectangle roundRectangle)
+        if (border?.StrokeShape is RoundRectangle roundRectangle)
         {
             roundRectangle.CornerRadius = CornerRadius;
 #if WINDOWS
@@ -559,10 +618,10 @@ public partial class InputField : ContentView
         nameof(FontAutoScalingEnabled), typeof(bool), typeof(InputField), Picker.FontAutoScalingEnabledProperty.DefaultValue,
         propertyChanged: (bindable, oldValue, newValue) =>
         {
-            var inputField = bindable as InputField;
-            if (inputField?.labelTitle != null)
+            var titleLabel = (bindable as InputField)?.labelTitle;
+            if (titleLabel != null)
             {
-                inputField.labelTitle.FontAutoScalingEnabled = (bool)newValue;
+                titleLabel.FontAutoScalingEnabled = (bool)newValue;
             }
         });
 

--- a/src/UraniumUI.Material/Controls/PickerField.cs
+++ b/src/UraniumUI.Material/Controls/PickerField.cs
@@ -158,6 +158,11 @@ public class PickerField : InputField
 
     protected virtual void UpdateClearIconState()
     {
+        if (endIconsContainer is null)
+        {
+            return;
+        }
+
         var existing = endIconsContainer.FindByViewQueryIdInVisualTreeDescendants<StatefulContentView>("ClearIcon");
 
         if (AllowClear)

--- a/src/UraniumUI.Material/Controls/PickerField.cs
+++ b/src/UraniumUI.Material/Controls/PickerField.cs
@@ -179,6 +179,12 @@ public class PickerField : InputField
         }
     }
 
+    protected override void OnApplyTemplate()
+    {
+        base.OnApplyTemplate();
+        UpdateClearIconState();
+    }
+
     public override void ResetValidation()
     {
         PickerView.SelectedItem = null;

--- a/test/UraniumUI.Material.Tests/ApplicationResourcesCollection.cs
+++ b/test/UraniumUI.Material.Tests/ApplicationResourcesCollection.cs
@@ -1,0 +1,8 @@
+using Xunit;
+
+namespace UraniumUI.Material.Tests;
+
+[CollectionDefinition("ApplicationResources", DisableParallelization = true)]
+public class ApplicationResourcesCollectionDefinition
+{
+}

--- a/test/UraniumUI.Material.Tests/Controls/PickerField_Test.cs
+++ b/test/UraniumUI.Material.Tests/Controls/PickerField_Test.cs
@@ -207,20 +207,36 @@ public class PickerField_Test
     }
 
     [Fact]
-    public void FontAutoScalingEnabled_CanBeSetViaImplicitStyle()
+    public void FontAutoScalingEnabled_CanBeSetViaImplicitStyle_DuringConstruction()
     {
         var style = new Style(typeof(PickerField));
         style.Setters.Add(new Setter { Property = PickerField.FontAutoScalingEnabledProperty, Value = false });
 
-        var resources = new ResourceDictionary();
-        resources.Add(style);
+        var originalResources = Application.Current.Resources;
 
-        var control = AnimationReadyHandler.Prepare(new PickerField());
+        var resources = new ResourceDictionary
+        {
+            style,
+        };
 
-        control.Resources = resources;
+        Application.Current.Resources = resources;
 
-        control.FontAutoScalingEnabled.ShouldBeFalse();
-        control.PickerView.FontAutoScalingEnabled.ShouldBeFalse();
+        try
+        {
+            PickerField control = null;
+            var exception = Record.Exception(() => control = new PickerField());
+
+            exception.ShouldBeNull();
+
+            AnimationReadyHandler.Prepare(control);
+
+            control.FontAutoScalingEnabled.ShouldBeFalse();
+            control.PickerView.FontAutoScalingEnabled.ShouldBeFalse();
+        }
+        finally
+        {
+            Application.Current.Resources = originalResources;
+        }
     }
 
     [Fact]

--- a/test/UraniumUI.Material.Tests/Controls/PickerField_Test.cs
+++ b/test/UraniumUI.Material.Tests/Controls/PickerField_Test.cs
@@ -212,14 +212,13 @@ public class PickerField_Test
         var style = new Style(typeof(PickerField));
         style.Setters.Add(new Setter { Property = PickerField.FontAutoScalingEnabledProperty, Value = false });
 
-        var originalResources = Application.Current.Resources;
-
-        var resources = new ResourceDictionary
+        var applicationResources = Application.Current.Resources ??= new ResourceDictionary();
+        var testResources = new ResourceDictionary
         {
             style,
         };
 
-        Application.Current.Resources = resources;
+        applicationResources.MergedDictionaries.Add(testResources);
 
         try
         {
@@ -235,7 +234,7 @@ public class PickerField_Test
         }
         finally
         {
-            Application.Current.Resources = originalResources;
+            applicationResources.MergedDictionaries.Remove(testResources);
         }
     }
 

--- a/test/UraniumUI.Material.Tests/Controls/PickerField_Test.cs
+++ b/test/UraniumUI.Material.Tests/Controls/PickerField_Test.cs
@@ -1,8 +1,10 @@
-﻿using Shouldly;
+using Shouldly;
 using System.Collections;
 using System.Collections.ObjectModel;
+using System.Linq;
 using UraniumUI.Material.Controls;
 using UraniumUI.Tests.Core;
+using UraniumUI.ViewExtensions;
 
 namespace UraniumUI.Material.Tests.Controls;
 public class PickerField_Test
@@ -202,6 +204,47 @@ public class PickerField_Test
 
         // Assert
         control.PickerView.FontSize.ShouldBe(fontSize);
+    }
+
+    [Fact]
+    public void FontAutoScalingEnabled_CanBeSetViaImplicitStyle()
+    {
+        var style = new Style(typeof(PickerField));
+        style.Setters.Add(new Setter { Property = PickerField.FontAutoScalingEnabledProperty, Value = false });
+
+        var resources = new ResourceDictionary();
+        resources.Add(style);
+
+        var control = AnimationReadyHandler.Prepare(new PickerField());
+
+        control.Resources = resources;
+
+        control.FontAutoScalingEnabled.ShouldBeFalse();
+        control.PickerView.FontAutoScalingEnabled.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void Icon_ShouldBeAdded_WhenSetBeforeHandler()
+    {
+        var icon = new FontImageSource
+        {
+            FontFamily = "MaterialSharp",
+            Glyph = "A",
+        };
+
+        var control = new PickerField
+        {
+            Icon = icon,
+        };
+
+        AnimationReadyHandler.Prepare(control);
+
+        var innerGrid = control.FindByViewQueryIdInVisualTreeDescendants<Grid>("InnerGrid");
+        var iconView = innerGrid?.Children.OfType<Image>().FirstOrDefault(x => ReferenceEquals(x.Source, icon));
+
+        innerGrid.ShouldNotBeNull();
+        iconView.ShouldNotBeNull();
+        control.Content.Margin.Left.ShouldBe(5);
     }
 
     public class TestViewModel : UraniumBindableObject

--- a/test/UraniumUI.Material.Tests/Controls/PickerField_Test.cs
+++ b/test/UraniumUI.Material.Tests/Controls/PickerField_Test.cs
@@ -5,8 +5,10 @@ using System.Linq;
 using UraniumUI.Material.Controls;
 using UraniumUI.Tests.Core;
 using UraniumUI.ViewExtensions;
+using UraniumUI.Views;
 
 namespace UraniumUI.Material.Tests.Controls;
+[Collection("ApplicationResources")]
 public class PickerField_Test
 {
     public PickerField_Test()
@@ -260,6 +262,16 @@ public class PickerField_Test
         innerGrid.ShouldNotBeNull();
         iconView.ShouldNotBeNull();
         control.Content.Margin.Left.ShouldBe(5);
+    }
+
+    [Fact]
+    public void ClearIcon_ShouldBeAdded_AfterTemplateApplied_WhenAllowClearIsEnabled()
+    {
+        var control = AnimationReadyHandler.Prepare(new PickerField());
+
+        var clearIcon = control.FindByViewQueryIdInVisualTreeDescendants<StatefulContentView>("ClearIcon");
+
+        clearIcon.ShouldNotBeNull();
     }
 
     public class TestViewModel : UraniumBindableObject


### PR DESCRIPTION
## Summary
- guard `InputField` template part lookups until the template is actually available
- re-apply icon and other template-dependent state after template initialization so `PickerField` startup no longer crashes and its icon still renders
- add `PickerField` coverage for implicit `FontAutoScalingEnabled` styles and icons set before handler creation

## Testing
- dotnet test \"test/UraniumUI.Material.Tests/UraniumUI.Material.Tests.csproj\" --filter \"FullyQualifiedName~PickerField_Test.FontAutoScalingEnabled_CanBeSetViaImplicitStyle|FullyQualifiedName~PickerField_Test.Icon_ShouldBeAdded_WhenSetBeforeHandler\"

Closes #931