### PR TITLE
fix: release TreeView nodes during disposal

### DIFF
--- a/src/UraniumUI.Material/Controls/TreeView.cs
+++ b/src/UraniumUI.Material/Controls/TreeView.cs
@@ -24,7 +24,25 @@ public partial class TreeView : ContentView
 
     internal void RegisterNode(TreeViewNodeHolderView node)
     {
-        registeredNodes.Add(node);
+        if (!registeredNodes.Contains(node))
+        {
+            registeredNodes.Add(node);
+        }
+    }
+
+    internal void UnregisterNode(TreeViewNodeHolderView node)
+    {
+        registeredNodes.Remove(node);
+    }
+
+    internal void ReleaseRegisteredNodes()
+    {
+        foreach (var node in registeredNodes.ToList())
+        {
+            node.Release();
+        }
+
+        registeredNodes.Clear();
     }
 
     internal IEnumerable<TreeViewNodeHolderView> GetChildViewsOf(TreeViewNodeHolderView parent)
@@ -56,6 +74,16 @@ public partial class TreeView : ContentView
             else
                 observableSelectedItems.CollectionChanged += SelectedItemsChanged;
         }
+    }
+
+    protected override void OnHandlerChanging(HandlerChangingEventArgs args)
+    {
+        if (args.NewHandler is null)
+        {
+            ReleaseRegisteredNodes();
+        }
+
+        base.OnHandlerChanging(args);
     }
 
     // TODO: Remove default value and make default value as null in the next major version.

--- a/src/UraniumUI.Material/Controls/TreeView.cs
+++ b/src/UraniumUI.Material/Controls/TreeView.cs
@@ -24,10 +24,7 @@ public partial class TreeView : ContentView
 
     internal void RegisterNode(TreeViewNodeHolderView node)
     {
-        if (!registeredNodes.Contains(node))
-        {
-            registeredNodes.Add(node);
-        }
+        registeredNodes.Add(node);
     }
 
     internal void UnregisterNode(TreeViewNodeHolderView node)

--- a/src/UraniumUI.Material/Controls/TreeView.cs
+++ b/src/UraniumUI.Material/Controls/TreeView.cs
@@ -75,12 +75,12 @@ public partial class TreeView : ContentView
 
     protected override void OnHandlerChanging(HandlerChangingEventArgs args)
     {
+        base.OnHandlerChanging(args);
+
         if (args.NewHandler is null)
         {
             ReleaseRegisteredNodes();
         }
-
-        base.OnHandlerChanging(args);
     }
 
     // TODO: Remove default value and make default value as null in the next major version.

--- a/src/UraniumUI.Material/Controls/TreeViewNodeHolderView.cs
+++ b/src/UraniumUI.Material/Controls/TreeViewNodeHolderView.cs
@@ -288,6 +288,8 @@ public class TreeViewNodeHolderView : VerticalStackLayout
         if (nodeChildren is not null)
         {
             nodeChildren.IsVisible = false;
+            nodeChildren.RemoveBinding(ItemsView.ItemsSourceProperty);
+            nodeChildren.ClearValue(ItemsView.ItemsSourceProperty);
             nodeChildren.ItemsSource = null;
         }
 

--- a/src/UraniumUI.Material/Controls/TreeViewNodeHolderView.cs
+++ b/src/UraniumUI.Material/Controls/TreeViewNodeHolderView.cs
@@ -205,6 +205,11 @@ public class TreeViewNodeHolderView : VerticalStackLayout
 
     protected override void OnBindingContextChanged()
     {
+        if (isReleased)
+        {
+            return;
+        }
+
         base.OnBindingContextChanged();
         OnSelectedItemChanged();
 
@@ -286,23 +291,8 @@ public class TreeViewNodeHolderView : VerticalStackLayout
         isReleased = true;
 
         // Stop receiving updates for expansion-related properties after release.
-        try
-        {
-            this.RemoveBinding(IsExpandedProperty);
-        }
-        catch
-        {
-            // Ignore if the binding was not set or the property is unavailable.
-        }
-
-        try
-        {
-            this.RemoveBinding(IsLeafProperty);
-        }
-        catch
-        {
-            // Ignore if the binding was not set or the property is unavailable.
-        }
+        this.RemoveBinding(IsExpandedProperty);
+        this.RemoveBinding(IsLeafProperty);
 
         if (nodeChildren is not null)
         {
@@ -487,6 +477,11 @@ public class TreeViewNodeHolderView : VerticalStackLayout
 
     protected internal virtual async void OnIsExpandedChanged(bool isExpanded)
     {
+        if (isReleased)
+        {
+            return;
+        }
+
         if (isExpanded && !IsLeaf)
         {
             if (!hasLoadedChildren && ChildrenBinding is Binding binding)

--- a/src/UraniumUI.Material/Controls/TreeViewNodeHolderView.cs
+++ b/src/UraniumUI.Material/Controls/TreeViewNodeHolderView.cs
@@ -205,12 +205,16 @@ public class TreeViewNodeHolderView : VerticalStackLayout
 
     protected override void OnBindingContextChanged()
     {
+        // Always let the base class propagate the BindingContext to children,
+        // even when this view has been "released".
+        base.OnBindingContextChanged();
+
         if (isReleased)
         {
+            // Skip TreeView-specific rebinding/selection logic when released.
             return;
         }
 
-        base.OnBindingContextChanged();
         OnSelectedItemChanged();
 
         if (nodeChildren == null && ChildrenBinding is Binding binding &&

--- a/src/UraniumUI.Material/Controls/TreeViewNodeHolderView.cs
+++ b/src/UraniumUI.Material/Controls/TreeViewNodeHolderView.cs
@@ -233,12 +233,12 @@ public class TreeViewNodeHolderView : VerticalStackLayout
 
     protected override void OnHandlerChanging(HandlerChangingEventArgs args)
     {
+        base.OnHandlerChanging(args);
+
         if (args.NewHandler is null)
         {
             Release();
         }
-
-        base.OnHandlerChanging(args);
     }
 
     private void CreateChildContainer(Binding binding)

--- a/src/UraniumUI.Material/Controls/TreeViewNodeHolderView.cs
+++ b/src/UraniumUI.Material/Controls/TreeViewNodeHolderView.cs
@@ -271,7 +271,7 @@ public class TreeViewNodeHolderView : VerticalStackLayout
             return childNode;
         });
 
-        nodeChildren.SetBinding(CollectionView.ItemsSourceProperty, new Binding(binding.Path));
+        nodeChildren.SetBinding(ItemsView.ItemsSourceProperty, new Binding(binding.Path));
         nodeChildren.ChildAdded += (s, e) => OnPropertyChanged(nameof(IsLeaf));
         nodeChildren.ChildRemoved += (s, e) => OnPropertyChanged(nameof(IsLeaf));
     }

--- a/src/UraniumUI.Material/Controls/TreeViewNodeHolderView.cs
+++ b/src/UraniumUI.Material/Controls/TreeViewNodeHolderView.cs
@@ -285,6 +285,25 @@ public class TreeViewNodeHolderView : VerticalStackLayout
 
         isReleased = true;
 
+        // Stop receiving updates for expansion-related properties after release.
+        try
+        {
+            this.RemoveBinding(IsExpandedProperty);
+        }
+        catch
+        {
+            // Ignore if the binding was not set or the property is unavailable.
+        }
+
+        try
+        {
+            this.RemoveBinding(IsLeafProperty);
+        }
+        catch
+        {
+            // Ignore if the binding was not set or the property is unavailable.
+        }
+
         if (nodeChildren is not null)
         {
             nodeChildren.IsVisible = false;

--- a/src/UraniumUI.Material/Controls/TreeViewNodeHolderView.cs
+++ b/src/UraniumUI.Material/Controls/TreeViewNodeHolderView.cs
@@ -24,6 +24,7 @@ public class TreeViewNodeHolderView : VerticalStackLayout
 
     internal protected CollectionView nodeChildren;
     private Grid childContainer;
+    private bool isReleased;
 
     public DataTemplate DataTemplate { get; }
 
@@ -229,6 +230,17 @@ public class TreeViewNodeHolderView : VerticalStackLayout
             this.SetBinding(IsLeafProperty, new Binding(TreeView.IsLeafPropertyName, BindingMode.TwoWay));
         }
     }
+
+    protected override void OnHandlerChanging(HandlerChangingEventArgs args)
+    {
+        if (args.NewHandler is null)
+        {
+            Release();
+        }
+
+        base.OnHandlerChanging(args);
+    }
+
     private void CreateChildContainer(Binding binding)
     {
         nodeChildren = new CollectionView
@@ -262,6 +274,30 @@ public class TreeViewNodeHolderView : VerticalStackLayout
         nodeChildren.SetBinding(CollectionView.ItemsSourceProperty, new Binding(binding.Path));
         nodeChildren.ChildAdded += (s, e) => OnPropertyChanged(nameof(IsLeaf));
         nodeChildren.ChildRemoved += (s, e) => OnPropertyChanged(nameof(IsLeaf));
+    }
+
+    internal void Release()
+    {
+        if (isReleased)
+        {
+            return;
+        }
+
+        isReleased = true;
+
+        if (nodeChildren is not null)
+        {
+            nodeChildren.IsVisible = false;
+            nodeChildren.ItemsSource = null;
+        }
+
+        if (childContainer is not null)
+        {
+            childContainer.IsVisible = false;
+            childContainer.HeightRequest = 0;
+        }
+
+        TreeView?.UnregisterNode(this);
     }
 
 

--- a/test/UraniumUI.Material.Tests/Controls/TreeView_Test.cs
+++ b/test/UraniumUI.Material.Tests/Controls/TreeView_Test.cs
@@ -99,6 +99,51 @@ public class TreeView_Test
         node.NodeChildren.ItemsSource.ShouldBeNull();
     }
 
+    [Fact]
+    public void ReleasingNode_ShouldPreventChildItemsSourceFromRebinding()
+    {
+        var tree = AnimationReadyHandler.Prepare(new TreeView());
+        var node = AnimationReadyHandler.Prepare(new TreeViewNodeHolderView(TreeView.DefaultItemTemplate, tree, new Binding(nameof(TestTreeNode.Children))));
+
+        node.BindingContext = new TestTreeNode
+        {
+            Children = new[] { new TestTreeNode() }
+        };
+
+        node.Handler = null;
+        node.BindingContext = new TestTreeNode
+        {
+            Children = new[] { new TestTreeNode(), new TestTreeNode() }
+        };
+
+        node.NodeChildren.ItemsSource.ShouldBeNull();
+    }
+
+    [Fact]
+    public void ReleasingTree_ShouldReleaseAllRegisteredNodes()
+    {
+        var tree = AnimationReadyHandler.Prepare(new TreeView());
+        var firstNode = AnimationReadyHandler.Prepare(new TreeViewNodeHolderView(TreeView.DefaultItemTemplate, tree, new Binding(nameof(TestTreeNode.Children))));
+        var secondNode = AnimationReadyHandler.Prepare(new TreeViewNodeHolderView(TreeView.DefaultItemTemplate, tree, new Binding(nameof(TestTreeNode.Children))));
+
+        firstNode.BindingContext = new TestTreeNode
+        {
+            Children = new[] { new TestTreeNode() }
+        };
+        secondNode.BindingContext = new TestTreeNode
+        {
+            Children = new[] { new TestTreeNode(), new TestTreeNode() }
+        };
+
+        tree.AllNodeViews.Count().ShouldBe(2);
+
+        tree.Handler = null;
+
+        tree.AllNodeViews.ShouldBeEmpty();
+        firstNode.NodeChildren.ItemsSource.ShouldBeNull();
+        secondNode.NodeChildren.ItemsSource.ShouldBeNull();
+    }
+
     public class TestViewModel : UraniumBindableObject
     {
         private IList itemSource;

--- a/test/UraniumUI.Material.Tests/Controls/TreeView_Test.cs
+++ b/test/UraniumUI.Material.Tests/Controls/TreeView_Test.cs
@@ -67,6 +67,38 @@ public class TreeView_Test
         viewModel.SelectedItem.ShouldBe(itemSource[0]);
     }
 
+    [Fact]
+    public void Node_ShouldBeUnregistered_WhenHandlerIsReleased()
+    {
+        var tree = AnimationReadyHandler.Prepare(new TreeView());
+        var node = AnimationReadyHandler.Prepare(new TreeViewNodeHolderView(TreeView.DefaultItemTemplate, tree, new Binding("Children")));
+
+        tree.AllNodeViews.ShouldContain(node);
+
+        node.Handler = null;
+
+        tree.AllNodeViews.ShouldNotContain(node);
+    }
+
+    [Fact]
+    public void ReleasingNode_ShouldDetachChildItemsSource()
+    {
+        var tree = AnimationReadyHandler.Prepare(new TreeView());
+        var node = AnimationReadyHandler.Prepare(new TreeViewNodeHolderView(TreeView.DefaultItemTemplate, tree, new Binding(nameof(TestTreeNode.Children))));
+
+        node.BindingContext = new TestTreeNode
+        {
+            Children = new[] { new TestTreeNode() }
+        };
+
+        node.NodeChildren.ShouldNotBeNull();
+        node.NodeChildren.ItemsSource.ShouldNotBeNull();
+
+        node.Handler = null;
+
+        node.NodeChildren.ItemsSource.ShouldBeNull();
+    }
+
     public class TestViewModel : UraniumBindableObject
     {
         private IList itemSource;
@@ -75,5 +107,10 @@ public class TreeView_Test
         public IList ItemSource { get => itemSource; set => SetProperty(ref itemSource, value); }
 
         public object SelectedItem { get => selectedItem; set => SetProperty(ref selectedItem, value); }
+    }
+
+    public class TestTreeNode
+    {
+        public IEnumerable<TestTreeNode> Children { get; set; }
     }
 }


### PR DESCRIPTION
## Summary
- unregister TreeView nodes when their handlers are disconnected so the control stops retaining expanded node views
- release nested child collections during teardown to reduce cleanup work when the TreeView is cleared or disposed
- add TreeView coverage for node unregistration and child collection detachment

## Testing
- dotnet test \"test/UraniumUI.Material.Tests/UraniumUI.Material.Tests.csproj\" --filter \"FullyQualifiedName~TreeView_Test\"

Closes #926