### PR TITLE
fix: avoid Android Mopups overlay regression

### DIFF
--- a/src/UraniumUI.Dialogs.Mopups/UraniumUI.Dialogs.Mopups.csproj
+++ b/src/UraniumUI.Dialogs.Mopups/UraniumUI.Dialogs.Mopups.csproj
@@ -26,7 +26,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Mopups" Version="1.3.4" />
+    <PackageReference Include="Mopups" Version="1.3.2" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Summary
- pin `UraniumUI.Dialogs.Mopups` back to `Mopups` `1.3.2`
- avoid the Android overlay regression introduced by the newer Mopups package after `2.12.1`

## Testing
- dotnet build `src/UraniumUI.Dialogs.Mopups/UraniumUI.Dialogs.Mopups.csproj` -f net9.0-android
- dotnet build `src/UraniumUI.Dialogs.Mopups/UraniumUI.Dialogs.Mopups.csproj` -f net9.0-windows10.0.19041.0

Closes #924