### PR TITLE
fix: restore paginator button state after navigation

### DIFF
--- a/src/UraniumUI.Material/Controls/Paginator.cs
+++ b/src/UraniumUI.Material/Controls/Paginator.cs
@@ -146,8 +146,16 @@ public class Paginator : ContentView
 
     protected virtual void ApplyCurrentPageState()
     {
+        foreach (var button in PagesStackLayout.Children.OfType<Button>().Where(x => ViewQuery.GetId(x) == "paginator-btn"))
+        {
+            button.IsEnabled = true;
+        }
+
         var currentPageBtn = this.FindInChildrenHierarchy<Button>(x => ViewQuery.GetId(x) == "paginator-btn" && x.CommandParameter.Equals(CurrentPage));
-        currentPageBtn.IsEnabled = false;
+        if (currentPageBtn is not null)
+        {
+            currentPageBtn.IsEnabled = false;
+        }
     }
 
     protected virtual void UpdateCanGoProperties()

--- a/test/UraniumUI.Material.Tests/Controls/Paginator_Test.cs
+++ b/test/UraniumUI.Material.Tests/Controls/Paginator_Test.cs
@@ -1,0 +1,44 @@
+using Shouldly;
+using System.Linq;
+using UraniumUI.Material.Controls;
+using UraniumUI.Tests.Core;
+using UraniumUI.ViewExtensions;
+
+namespace UraniumUI.Material.Tests.Controls;
+
+public class Paginator_Test
+{
+    public Paginator_Test()
+    {
+        ApplicationExtensions.CreateAndSetMockApplication();
+    }
+
+    [Fact]
+    public void CurrentPage_Change_ShouldReenablePreviousPageButton()
+    {
+        var control = AnimationReadyHandler.Prepare(new Paginator());
+
+        control.TotalPageCount = 5;
+        control.CurrentPage = 1;
+
+        GetPageButtons(control)
+            .Single(x => (int)x.CommandParameter == 1)
+            .IsEnabled
+            .ShouldBeFalse();
+
+        control.CurrentPage = 2;
+
+        var pageButtons = GetPageButtons(control).ToList();
+
+        pageButtons.Single(x => (int)x.CommandParameter == 1).IsEnabled.ShouldBeTrue();
+        pageButtons.Single(x => (int)x.CommandParameter == 2).IsEnabled.ShouldBeFalse();
+    }
+
+    private static IEnumerable<Button> GetPageButtons(Paginator control)
+    {
+        return control.FindByViewQueryId<HorizontalStackLayout>("PagesStackLayout")
+            .Children
+            .OfType<Button>()
+            .Where(x => ViewQuery.GetId(x) == "paginator-btn");
+    }
+}


### PR DESCRIPTION
## Summary
- re-enable paginator page buttons before disabling the newly selected page
- add coverage for page navigation so previously selected buttons become clickable again

## Testing
- dotnet test test/UraniumUI.Material.Tests/UraniumUI.Material.Tests.csproj --filter \"FullyQualifiedName~Paginator_Test\"
- dotnet test test/UraniumUI.Material.Tests/UraniumUI.Material.Tests.csproj

Closes #890