### PR TITLE
fix: allow Mac Catalyst TreeView expander input

### DIFF
--- a/src/UraniumUI.Material/Handlers/ButtonViewHandler.Apple.cs
+++ b/src/UraniumUI.Material/Handlers/ButtonViewHandler.Apple.cs
@@ -9,12 +9,45 @@ public partial class ButtonViewHandler
     protected override void ConnectHandler(Microsoft.Maui.Platform.ContentView platformView)
     {
         base.ConnectHandler(platformView);
-        platformView.AddGestureRecognizer(new UIContinousGestureRecognizer(Tapped));
+        var tapRecognizer = new UIContinousGestureRecognizer(Tapped)
+        {
+            CancelsTouchesInView = false,
+            Delegate = new IgnoreInteractiveChildTouchesGestureDelegate(platformView)
+        };
+
+        platformView.AddGestureRecognizer(tapRecognizer);
         if (OperatingSystem.IsIOSVersionAtLeast(13))
         {
             platformView.AddGestureRecognizer(new UIHoverGestureRecognizer(OnHover));
         }
-        platformView.AddGestureRecognizer(new UILongPressGestureRecognizer(OnLongPress));
+
+        var longPressRecognizer = new UILongPressGestureRecognizer(OnLongPress)
+        {
+            CancelsTouchesInView = false,
+            Delegate = new IgnoreInteractiveChildTouchesGestureDelegate(platformView)
+        };
+
+        platformView.AddGestureRecognizer(longPressRecognizer);
+    }
+
+    internal sealed class IgnoreInteractiveChildTouchesGestureDelegate(UIView ownerView) : UIGestureRecognizerDelegate
+    {
+        public override bool ShouldReceiveTouch(UIGestureRecognizer recognizer, UITouch touch)
+        {
+            var view = touch.View;
+
+            while (view is not null && view != ownerView)
+            {
+                if (view is UIControl)
+                {
+                    return false;
+                }
+
+                view = view.Superview;
+            }
+
+            return true;
+        }
     }
 
     private void OnLongPress(UILongPressGestureRecognizer recognizer)

--- a/src/UraniumUI.Material/Handlers/ButtonViewHandler.Apple.cs
+++ b/src/UraniumUI.Material/Handlers/ButtonViewHandler.Apple.cs
@@ -6,28 +6,57 @@ using UIKit;
 namespace UraniumUI.Material.Handlers;
 public partial class ButtonViewHandler
 {
+    private UIContinousGestureRecognizer _tapRecognizer;
+    private UIHoverGestureRecognizer _hoverRecognizer;
+    private UILongPressGestureRecognizer _longPressRecognizer;
+
     protected override void ConnectHandler(Microsoft.Maui.Platform.ContentView platformView)
     {
         base.ConnectHandler(platformView);
-        var tapRecognizer = new UIContinousGestureRecognizer(Tapped)
+
+        _tapRecognizer = new UIContinousGestureRecognizer(Tapped)
         {
             CancelsTouchesInView = false,
             Delegate = new IgnoreInteractiveChildTouchesGestureDelegate(platformView)
         };
 
-        platformView.AddGestureRecognizer(tapRecognizer);
+        platformView.AddGestureRecognizer(_tapRecognizer);
         if (OperatingSystem.IsIOSVersionAtLeast(13))
         {
-            platformView.AddGestureRecognizer(new UIHoverGestureRecognizer(OnHover));
+            _hoverRecognizer = new UIHoverGestureRecognizer(OnHover);
+            platformView.AddGestureRecognizer(_hoverRecognizer);
         }
 
-        var longPressRecognizer = new UILongPressGestureRecognizer(OnLongPress)
+        _longPressRecognizer = new UILongPressGestureRecognizer(OnLongPress)
         {
             CancelsTouchesInView = false,
             Delegate = new IgnoreInteractiveChildTouchesGestureDelegate(platformView)
         };
 
-        platformView.AddGestureRecognizer(longPressRecognizer);
+        platformView.AddGestureRecognizer(_longPressRecognizer);
+    }
+
+    protected override void DisconnectHandler(Microsoft.Maui.Platform.ContentView platformView)
+    {
+        if (_tapRecognizer != null)
+        {
+            platformView.RemoveGestureRecognizer(_tapRecognizer);
+            _tapRecognizer = null;
+        }
+
+        if (_hoverRecognizer != null)
+        {
+            platformView.RemoveGestureRecognizer(_hoverRecognizer);
+            _hoverRecognizer = null;
+        }
+
+        if (_longPressRecognizer != null)
+        {
+            platformView.RemoveGestureRecognizer(_longPressRecognizer);
+            _longPressRecognizer = null;
+        }
+
+        base.DisconnectHandler(platformView);
     }
 
     internal sealed class IgnoreInteractiveChildTouchesGestureDelegate(UIView ownerView) : UIGestureRecognizerDelegate

--- a/src/UraniumUI/Handlers/StatefulContentViewHandler.Apple.cs
+++ b/src/UraniumUI/Handlers/StatefulContentViewHandler.Apple.cs
@@ -23,6 +23,8 @@ public partial class StatefulContentViewHandler
     protected override void ConnectHandler(Microsoft.Maui.Platform.ContentView platformView)
     {
         _tapRecognizer = new UIContinousGestureRecognizer(Tapped);
+        _tapRecognizer.CancelsTouchesInView = false;
+        _tapRecognizer.Delegate = new IgnoreInteractiveChildTouchesGestureDelegate(platformView);
         platformView.AddGestureRecognizer(_tapRecognizer);
         if (OperatingSystem.IsIOSVersionAtLeast(13))
         {
@@ -30,6 +32,8 @@ public partial class StatefulContentViewHandler
             platformView.AddGestureRecognizer(_hoverRecognizer);
         }
         _longPressRecognizer = new UILongPressGestureRecognizer(OnLongPress);
+        _longPressRecognizer.CancelsTouchesInView = false;
+        _longPressRecognizer.Delegate = new IgnoreInteractiveChildTouchesGestureDelegate(platformView);
         platformView.AddGestureRecognizer(_longPressRecognizer);
         _isConnected = true;
         base.ConnectHandler(platformView);
@@ -154,6 +158,26 @@ public partial class StatefulContentViewHandler
     internal void UpdateFocusable()
     {
         
+    }
+
+    internal sealed class IgnoreInteractiveChildTouchesGestureDelegate(UIView ownerView) : UIGestureRecognizerDelegate
+    {
+        public override bool ShouldReceiveTouch(UIGestureRecognizer recognizer, UITouch touch)
+        {
+            var view = touch.View;
+
+            while (view is not null && view != ownerView)
+            {
+                if (view is UIControl)
+                {
+                    return false;
+                }
+
+                view = view.Superview;
+            }
+
+            return true;
+        }
     }
 
     // TODO: Move it to the different file


### PR DESCRIPTION
## Summary
- allow Apple handler tap and long-press recognizers to coexist with interactive child controls
- stop TreeView expander templates on Mac Catalyst from swallowing checkbox-style input
- clean up Apple `ButtonView` recognizers on detach so reconnects do not accumulate callbacks

## Automated Testing
- dotnet test \"test/UraniumUI.Material.Tests/UraniumUI.Material.Tests.csproj\"
- dotnet build \"src/UraniumUI.Material/UraniumUI.Material.csproj\" -f net10.0-maccatalyst
- no new unit test was added because the failure depends on UIKit/Mac Catalyst native gesture routing, which the current unit test project does not execute

## Manual Testing
- on macOS, run `demo/UraniumApp/UraniumApp.csproj` with the `net10.0-maccatalyst` target
- in `demo/UraniumApp/Pages/TreeViews/TreeViewPage.xaml`, replace the `Switch` in the `ExpanderTemplate` with the issue repro control, for example `<CheckBox />`
- launch the demo app and open `TreeView` -> `Scenarios` -> `Expander`
- tap the `CheckBox` inside the expander template and verify it receives the tap and toggles correctly
- tap the row outside the child control and verify normal TreeView item interaction still works
- navigate away and back or otherwise recreate the handler, then verify a single tap still results in a single callback with no duplicate behavior
- switch the sample back to `Switch` and verify the existing expander scenario still works

Closes #894