### PR TITLE
fix: avoid TreeView layout cycles with large child sets

### DIFF
--- a/src/UraniumUI.Material/Controls/TreeViewNodeHolderView.cs
+++ b/src/UraniumUI.Material/Controls/TreeViewNodeHolderView.cs
@@ -33,8 +33,7 @@ public class TreeViewNodeHolderView : Grid
         {
             new ColumnDefinition(40),
             new ColumnDefinition(GridLength.Star),
-        },
-        RowSpacing = 0
+        }
     };
     private readonly int indentLevel;
     private bool hasLoadedChildren;

--- a/src/UraniumUI.Material/Controls/TreeViewNodeHolderView.cs
+++ b/src/UraniumUI.Material/Controls/TreeViewNodeHolderView.cs
@@ -10,7 +10,7 @@ using Path = Microsoft.Maui.Controls.Shapes.Path;
 namespace UraniumUI.Material.Controls;
 
 [ContentProperty(nameof(NodeView))]
-public class TreeViewNodeHolderView : VerticalStackLayout
+public class TreeViewNodeHolderView : Grid
 {
     public View NodeView { get => nodeContainer.Content; set => nodeContainer.Content = value; }
 
@@ -33,7 +33,8 @@ public class TreeViewNodeHolderView : VerticalStackLayout
         {
             new ColumnDefinition(40),
             new ColumnDefinition(GridLength.Star),
-        }
+        },
+        RowSpacing = 0
     };
     private readonly int indentLevel;
     private bool hasLoadedChildren;
@@ -68,6 +69,10 @@ public class TreeViewNodeHolderView : VerticalStackLayout
 
         TreeView = treeView ?? throw new ArgumentNullException(nameof(treeView));
         treeView.RegisterNode(this);
+
+        RowDefinitions.Add(new RowDefinition(GridLength.Auto));
+        RowDefinitions.Add(new RowDefinition(GridLength.Auto));
+        RowSpacing = 0;
 
         this.indentLevel = indentLevel;
 
@@ -247,7 +252,7 @@ public class TreeViewNodeHolderView : VerticalStackLayout
             IsVisible = false
         };
         childContainer.Children.Add(nodeChildren);
-        this.Add(childContainer);
+        this.Add(childContainer, row: 1);
 
 
         nodeChildren.ItemTemplate = new DataTemplate(() =>

--- a/test/UraniumUI.Material.Tests/Controls/TreeView_Test.cs
+++ b/test/UraniumUI.Material.Tests/Controls/TreeView_Test.cs
@@ -88,7 +88,24 @@ public class TreeView_Test
         holder.Handler = handler;
         holder.BindingContext = item;
 
-        (holder is Grid).ShouldBeTrue();
+        var grid = holder.ShouldBeOfType<Grid>();
+
+        // Ensure the layout has two rows: one for header/button (row 0) and one for children container (row 1).
+        grid.RowDefinitions.Count.ShouldBe(2);
+
+        // There should be exactly two direct children: header and children container.
+        grid.Children.Count.ShouldBe(2);
+
+        // Validate that one child is placed in row 0 and one in row 1.
+        var row0Children = grid.Children
+            .Where(child => Grid.GetRow((BindableObject)child) == 0)
+            .ToList();
+        var row1Children = grid.Children
+            .Where(child => Grid.GetRow((BindableObject)child) == 1)
+            .ToList();
+
+        row0Children.Count.ShouldBe(1);
+        row1Children.Count.ShouldBe(1);
     }
 
     public class TestViewModel : UraniumBindableObject

--- a/test/UraniumUI.Material.Tests/Controls/TreeView_Test.cs
+++ b/test/UraniumUI.Material.Tests/Controls/TreeView_Test.cs
@@ -67,6 +67,30 @@ public class TreeView_Test
         viewModel.SelectedItem.ShouldBe(itemSource[0]);
     }
 
+    [Fact]
+    public void TreeViewNodeHolderView_ShouldUseGridContainer()
+    {
+        var item = new TestTreeItem
+        {
+            Children = Enumerable.Range(1, 200)
+                .Select(i => new TestTreeItem { Name = $"Child {i}" })
+                .ToList()
+        };
+
+        var treeView = new TreeView
+        {
+            UseAnimation = false,
+            ItemsSource = new[] { item }
+        };
+        var holder = new TreeViewNodeHolderView(TreeView.DefaultItemTemplate, treeView, new Binding(nameof(TestTreeItem.Children)));
+
+        AnimationReadyHandler.Prepare(treeView, out var handler);
+        holder.Handler = handler;
+        holder.BindingContext = item;
+
+        (holder is Grid).ShouldBeTrue();
+    }
+
     public class TestViewModel : UraniumBindableObject
     {
         private IList itemSource;
@@ -75,5 +99,12 @@ public class TreeView_Test
         public IList ItemSource { get => itemSource; set => SetProperty(ref itemSource, value); }
 
         public object SelectedItem { get => selectedItem; set => SetProperty(ref selectedItem, value); }
+    }
+
+    public class TestTreeItem
+    {
+        public string Name { get; set; }
+
+        public IList<TestTreeItem> Children { get; set; } = new List<TestTreeItem>();
     }
 }


### PR DESCRIPTION
## Summary
- switch `TreeViewNodeHolderView` from `VerticalStackLayout` to `Grid` so nested child `CollectionView`s are no longer measured inside a stack layout
- keep the existing TreeView child rendering behavior while placing expanded child containers on a dedicated grid row
- add a focused TreeView test that guards the grid-based container structure behind this fix

## Automated Testing
- `dotnet test test/UraniumUI.Material.Tests/UraniumUI.Material.Tests.csproj --filter \"FullyQualifiedName~TreeView_Test\"`

## Manual Testing
- Environment: Windows MAUI demo app on `rel-2.15`
- In `demo/UraniumApp/ViewModels/TreeViewPageViewModel.cs`, replace the `D` node with the repro payload from issue #888 so it creates about 200 child nodes
- Run the demo app, open the TreeView sample, and expand the `D` node
- Expected result: the node expands without throwing `Layout cycle detected. Layout could not complete.`

Closes #888