### PR TITLE
Align Dependabot package upgrades across MAUI targets

### DIFF
--- a/demo/UraniumApp/UraniumApp.csproj
+++ b/demo/UraniumApp/UraniumApp.csproj
@@ -52,12 +52,12 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Include="AdamE.MemoryToolkit.Maui" Version="1.0.0" />
+		<PackageReference Include="AdamE.MemoryToolkit.Maui" Version="2.0.0" />
 		<PackageReference Include="DotNurse.Injector" Version="2.5.2" />
 		<PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
 		<PackageReference Include="ReactiveUI.Fody" Version="19.5.1" />
-		<PackageReference Include="Bogus" Version="35.4.0" />
-        <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="9.0.0" />
+		<PackageReference Include="Bogus" Version="35.6.5" />
+        <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="10.0.7" />
         <PackageReference Include="Microsoft.Maui.Controls.Compatibility" Version="$(MauiVersion)" />
 	</ItemGroup>
 

--- a/maui.common.props
+++ b/maui.common.props
@@ -3,9 +3,9 @@
         <MauiVersion>8.0.83</MauiVersion>
     </PropertyGroup>
     <PropertyGroup Condition="$(TargetFramework.Contains('net9'))">
-        <MauiVersion>9.0.100</MauiVersion>
+        <MauiVersion>9.0.120</MauiVersion>
     </PropertyGroup>
     <PropertyGroup Condition="$(TargetFramework.Contains('net10'))">
-        <MauiVersion>10.0.11</MauiVersion>
+        <MauiVersion>10.0.51</MauiVersion>
     </PropertyGroup>
 </Project>

--- a/src/UraniumUI.Dialogs.CommunityToolkit/UraniumUI.Dialogs.CommunityToolkit.csproj
+++ b/src/UraniumUI.Dialogs.CommunityToolkit/UraniumUI.Dialogs.CommunityToolkit.csproj
@@ -26,7 +26,7 @@
   </PropertyGroup>
 
   <ItemGroup Condition="$(TargetFramework.Contains('net9'))">
-    <PackageReference Include="CommunityToolkit.Maui" Version="12.2.0" />
+    <PackageReference Include="CommunityToolkit.Maui" Version="12.3.0" />
   </ItemGroup>
   <ItemGroup Condition="$(TargetFramework.Contains('net10'))">
     <PackageReference Include="CommunityToolkit.Maui" Version="13.0.0" />

--- a/src/UraniumUI.Validations.DataAnnotations/UraniumUI.Validations.DataAnnotations.csproj
+++ b/src/UraniumUI.Validations.DataAnnotations/UraniumUI.Validations.DataAnnotations.csproj
@@ -19,7 +19,7 @@
   </PropertyGroup>
 
   <ItemGroup Condition="$(TargetFramework.Contains('net9'))">
-    <PackageReference Include="InputKit.Maui" Version="4.5.1" />
+    <PackageReference Include="InputKit.Maui" Version="4.5.2" />
   </ItemGroup>
   <ItemGroup Condition="$(TargetFramework.Contains('net10'))">
     <PackageReference Include="InputKit.Maui" Version="4.6.0" />

--- a/test/UraniumUI.Material.Tests/AssemblyInfo.cs
+++ b/test/UraniumUI.Material.Tests/AssemblyInfo.cs
@@ -1,0 +1,3 @@
+using Xunit;
+
+[assembly: CollectionBehavior(DisableTestParallelization = true)]

--- a/test/UraniumUI.Material.Tests/UraniumUI.Material.Tests.csproj
+++ b/test/UraniumUI.Material.Tests/UraniumUI.Material.Tests.csproj
@@ -9,14 +9,14 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="FluentAssertions" Version="6.12.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
+    <PackageReference Include="FluentAssertions" Version="8.9.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.0" />
     <PackageReference Include="xunit" Version="2.6.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.5.4">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.collector" Version="6.0.0">
+    <PackageReference Include="coverlet.collector" Version="10.0.0">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/test/UraniumUI.Tests.Core/UraniumUI.Tests.Core.csproj
+++ b/test/UraniumUI.Tests.Core/UraniumUI.Tests.Core.csproj
@@ -10,7 +10,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.0" />
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="Shouldly" Version="4.2.1" />
     <PackageReference Include="xunit" Version="2.6.2" />
@@ -18,7 +18,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.collector" Version="6.0.0">
+    <PackageReference Include="coverlet.collector" Version="10.0.0">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/test/UraniumUI.Tests/UraniumUI.Tests.csproj
+++ b/test/UraniumUI.Tests/UraniumUI.Tests.csproj
@@ -10,13 +10,13 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.0" />
     <PackageReference Include="xunit" Version="2.6.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.5.4">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.collector" Version="6.0.0">
+    <PackageReference Include="coverlet.collector" Version="10.0.0">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>


### PR DESCRIPTION
## Summary
- batch the reviewed Dependabot package upgrades into one validated change set across the demo app, MAUI props, toolkit dependencies, and test packages
- keep the MAUI package bands aligned by moving `net10` to `10.0.51` and `net9` to `9.0.120`, which is required for `CommunityToolkit.Maui 12.3.0`
- disable xUnit parallelization for `UraniumUI.Material.Tests` so the shared MAUI property mapper no longer corrupts test state during the package refresh

## Validation
- `dotnet build "UraniumUI.slnx"`
- `dotnet test "UraniumUI.slnx" --no-build`

## Supersedes
- #975
- #976
- #977
- #978
- #979
- #980
- #981
- #982
- #983
- #984