### PR TITLE
Fix iOS MultiplePickerField chip removal crash

### DIFF
--- a/src/UraniumUI/Handlers/StatefulContentViewHandler.Apple.cs
+++ b/src/UraniumUI/Handlers/StatefulContentViewHandler.Apple.cs
@@ -54,27 +54,33 @@ public partial class StatefulContentViewHandler
 
     private void Tapped(UIGestureRecognizer recognizer)
     {
+        var statefulView = StatefulView;
+        if (statefulView is null)
+        {
+            return;
+        }
+
         switch (recognizer.State)
         {
             case UIGestureRecognizerState.Began:
-                GoToState(StatefulView, "Pressed");
-                StatefulView.InvokePressed();
-                ExecuteCommandIfCan(StatefulView.PressedCommand);
+                GoToState(statefulView, "Pressed");
+                statefulView.InvokePressed();
+                ExecuteCommandIfCan(statefulView.PressedCommand);
 
                 break;
             case UIGestureRecognizerState.Ended:
-                GoToState(StatefulView, CommonStates.Normal);
-                StatefulView.InvokeTapped();
-                ExecuteCommandIfCan(StatefulView.TappedCommand);
+                // The tap handler may remove the view from the tree, which disconnects the handler.
+                var tapGestureRecognizers = statefulView.GestureRecognizers.OfType<TapGestureRecognizer>().ToArray();
+
+                GoToState(statefulView, CommonStates.Normal);
+                statefulView.InvokeTapped();
+                ExecuteCommandIfCan(statefulView.TappedCommand);
 
                 //// TODO: Fix working of native gesture recognizers of MAUI
-                foreach (var item in StatefulView.GestureRecognizers)
+                foreach (var item in tapGestureRecognizers)
                 {
                     Debug.WriteLine(item.GetType().Name);
-                    if (item is TapGestureRecognizer tgr)
-                    {
-                        tgr.Command?.Execute(StatefulView);
-                    }
+                    item.Command?.Execute(statefulView);
                 }
 
                 break;


### PR DESCRIPTION
## Summary
- preserve the tapped StatefulContentView reference while the chip removal command runs on iOS
- stop MultiplePickerField chip deletion from re-reading a disconnected VirtualView

## Automated Testing
- dotnet test "test/UraniumUI.Material.Tests/UraniumUI.Material.Tests.csproj"
- dotnet build "src/UraniumUI/UraniumUI.csproj" -f net10.0-ios

## Manual Testing
- Environment: iOS simulator or device with a .NET 9 or .NET 10 app using UraniumUI.Material
- Repro: open a page with MultiplePickerField, select multiple items, then tap the cross icon on one selected chip
- Expected result: the tapped chip is removed and the app does not crash

Closes #974