### PR TITLE
Fix DatePickerField initial binding for today's date

### DIFF
--- a/src/UraniumUI.Material/Controls/DatePickerField.cs
+++ b/src/UraniumUI.Material/Controls/DatePickerField.cs
@@ -42,6 +42,7 @@ public class DatePickerField : InputField
     public DatePickerField()
     {
         base.RegisterForEvents();
+        Loaded += (_, _) => EnsureInitialBoundDateState();
         iconClear.TappedCommand = new Command(OnClearTapped);
 #if WINDOWS
         if (DatePickerView.Parent is Microsoft.Maui.Controls.ContentView cv)
@@ -78,6 +79,12 @@ public class DatePickerField : InputField
             })
         });
 #endif
+    }
+
+    protected override void OnBindingContextChanged()
+    {
+        base.OnBindingContextChanged();
+        EnsureInitialBoundDateState();
     }
 
     protected override object GetValueForValidator()
@@ -133,6 +140,18 @@ public class DatePickerField : InputField
         }
 
         UpdateState();
+    }
+
+    private void EnsureInitialBoundDateState()
+    {
+        // When the bound value matches the bindable property's default (today), MAUI keeps the
+        // value but skips the property-changed callback that normally reveals the picker.
+        if (DatePickerView.Opacity != 0 || BindingContext is null || !IsSet(DateProperty))
+        {
+            return;
+        }
+
+        OnDateChanged();
     }
 
     protected override void OnIconChanged()

--- a/src/UraniumUI.Material/Controls/DatePickerField.cs
+++ b/src/UraniumUI.Material/Controls/DatePickerField.cs
@@ -42,7 +42,6 @@ public class DatePickerField : InputField
     public DatePickerField()
     {
         base.RegisterForEvents();
-        Loaded += (_, _) => EnsureInitialBoundDateState();
         iconClear.TappedCommand = new Command(OnClearTapped);
 #if WINDOWS
         if (DatePickerView.Parent is Microsoft.Maui.Controls.ContentView cv)
@@ -79,6 +78,16 @@ public class DatePickerField : InputField
             })
         });
 #endif
+    }
+
+    protected override void OnHandlerChanged()
+    {
+        base.OnHandlerChanged();
+
+        if (Handler != null)
+        {
+            EnsureInitialBoundDateState();
+        }
     }
 
     protected override void OnBindingContextChanged()
@@ -146,7 +155,7 @@ public class DatePickerField : InputField
     {
         // When the bound value matches the bindable property's default (today), MAUI keeps the
         // value but skips the property-changed callback that normally reveals the picker.
-        if (DatePickerView.Opacity != 0 || BindingContext is null || !IsSet(DateProperty))
+        if (DatePickerView.Opacity != 0 || !IsSet(DateProperty))
         {
             return;
         }

--- a/test/UraniumUI.Material.Tests/Controls/DatePickerField_Test.cs
+++ b/test/UraniumUI.Material.Tests/Controls/DatePickerField_Test.cs
@@ -23,6 +23,28 @@ public class DatePickerField_Test
     }
 
     [Fact]
+    public void Date_ShouldStartHidden_WhenNoValueIsAssigned()
+    {
+        var control = AnimationReadyHandler.Prepare(new DatePickerField());
+
+        control.DatePickerView.Opacity.ShouldBe(0);
+    }
+
+    [Fact]
+    public void Date_BindingForInitialization_FromSource_WhenValueIsToday_ShouldShowDate()
+    {
+        var control = AnimationReadyHandler.Prepare(new DatePickerField());
+        var viewModel = new TestViewModel { Date = DateTime.Today };
+
+        // Mimics the XAML flow where the binding exists before the BindingContext arrives.
+        control.SetBinding(DatePickerField.DateProperty, new Binding(nameof(TestViewModel.Date)));
+        control.BindingContext = viewModel;
+
+        control.Date.ShouldBe(viewModel.Date);
+        control.DatePickerView.Opacity.ShouldBe(1);
+    }
+
+    [Fact]
     public void Date_Binding_FromSource()
     {
         var control = AnimationReadyHandler.Prepare(new DatePickerField());

--- a/test/UraniumUI.Material.Tests/Controls/DatePickerField_Test.cs
+++ b/test/UraniumUI.Material.Tests/Controls/DatePickerField_Test.cs
@@ -47,6 +47,18 @@ public class DatePickerField_Test
     [Fact]
     public void Date_BindingForInitialization_FromExplicitSource_WhenValueIsToday_ShouldShowDate()
     {
+        var control = AnimationReadyHandler.Prepare(new DatePickerField());
+        var viewModel = new TestViewModel { Date = DateTime.Today };
+
+        control.SetBinding(DatePickerField.DateProperty, new Binding(nameof(TestViewModel.Date), source: viewModel));
+
+        control.Date.ShouldBe(viewModel.Date);
+        control.DatePickerView.Opacity.ShouldBe(1);
+    }
+
+    [Fact]
+    public void Date_BindingForInitialization_FromExplicitSource_WhenValueIsToday_ShouldShowDate()
+    {
         var control = new DatePickerField();
         var viewModel = new TestViewModel { Date = DateTime.Today };
 

--- a/test/UraniumUI.Material.Tests/Controls/DatePickerField_Test.cs
+++ b/test/UraniumUI.Material.Tests/Controls/DatePickerField_Test.cs
@@ -45,6 +45,33 @@ public class DatePickerField_Test
     }
 
     [Fact]
+    public void Date_BindingForInitialization_FromExplicitSource_WhenValueIsToday_ShouldShowDate()
+    {
+        var control = new DatePickerField();
+        var viewModel = new TestViewModel { Date = DateTime.Today };
+
+        // Mimics source-based XAML bindings that are applied before the control is loaded.
+        control.SetBinding(DatePickerField.DateProperty, new Binding(nameof(TestViewModel.Date), source: viewModel));
+        AnimationReadyHandler.Prepare(control);
+
+        control.Date.ShouldBe(viewModel.Date);
+        control.DatePickerView.Opacity.ShouldBe(1);
+    }
+
+    [Fact]
+    public void Date_SetForInitialization_WhenValueIsToday_ShouldShowDate()
+    {
+        var control = new DatePickerField
+        {
+            Date = DateTime.Today
+        };
+
+        AnimationReadyHandler.Prepare(control);
+
+        control.DatePickerView.Opacity.ShouldBe(1);
+    }
+
+    [Fact]
     public void Date_Binding_FromSource()
     {
         var control = AnimationReadyHandler.Prepare(new DatePickerField());


### PR DESCRIPTION
## Summary
- fix DatePickerField visibility when the initial bound value matches the field's `DateTime.Today` default
- add regression coverage for blank initial state and bound-today initialization

## Automated Testing
- dotnet test test/UraniumUI.Material.Tests/UraniumUI.Material.Tests.csproj

Closes #970