### PR TITLE
FIX #1002: TextField reserves Icon slot when Icon binding clears to null

### DIFF
--- a/demo/UraniumApp/Pages/InputFields/TextFieldPage.xaml
+++ b/demo/UraniumApp/Pages/InputFields/TextFieldPage.xaml
@@ -45,6 +45,30 @@
             ]]>
         </x:String>
 
+        <x:String x:Key="SourceCode4">
+            <![CDATA[
+<Grid ColumnDefinitions="*,Auto" ColumnSpacing="12">
+    <VerticalStackLayout Spacing="12">
+        <material:TextField Title="Sample Text">
+            <material:TextField.Triggers>
+                <DataTrigger TargetType="material:TextField"
+                             Binding="{Binding Source={x:Reference ShowIconCheckBox}, Path=IsChecked}"
+                             Value="True">
+                    <Setter Property="Icon"
+                            Value="{FontImageSource FontFamily=MaterialSharp,
+                                                    Glyph={x:Static m:MaterialSharp.Visibility}}"/>
+                </DataTrigger>
+            </material:TextField.Triggers>
+        </material:TextField>
+
+        <!-- Reference field that never had an icon. When the CheckBox is unchecked, the two should be layout-identical. -->
+        <material:TextField Title="Sample Text" />
+    </VerticalStackLayout>
+    <CheckBox x:Name="ShowIconCheckBox" Grid.Column="1" IsChecked="True" VerticalOptions="Center" />
+</Grid>
+            ]]>
+        </x:String>
+
         <x:String x:Key="DocLink">https://enisn-projects.io/docs/en/uranium/latest/themes/material/components/TextField</x:String>
         <x:String x:Key="SourceLink">https://github.com/enisn/UraniumUI/blob/develop/demo/UraniumApp/Pages/InputFields/TextFieldPage.xaml</x:String>
     </ContentPage.Resources>
@@ -107,7 +131,44 @@
                     </uranium:ExpanderView>
                 </VerticalStackLayout>
             </Border>
-            
+
+            <BoxView StyleClass="Divider" />
+
+            <Border Margin="{OnIdiom 10, Phone=0}" StyleClass="SurfaceContainer, Rounded" StrokeThickness="0">
+                <VerticalStackLayout>
+                    <Label Text="Dynamic Icon (toggle via CheckBox)" FontSize="Subtitle" Margin="20"/>
+                    <Label Margin="20,0,20,10"
+                           Text="Toggling the CheckBox sets the TextField's Icon to a value or null. The leading icon slot must collapse to zero width when null so the text starts at the leading edge (see #1002)." />
+                    <Grid StyleClass="ControlPreview" ColumnDefinitions="*,Auto" ColumnSpacing="12">
+                        <VerticalStackLayout Spacing="12">
+                            <material:TextField Title="Sample Text">
+                                <material:TextField.Triggers>
+                                    <DataTrigger TargetType="material:TextField"
+                                                 Binding="{Binding Source={x:Reference ShowIconCheckBox}, Path=IsChecked}"
+                                                 Value="True">
+                                        <Setter Property="Icon"
+                                                Value="{FontImageSource FontFamily=MaterialSharp, Glyph={x:Static m:MaterialSharp.Visibility}}"/>
+                                    </DataTrigger>
+                                </material:TextField.Triggers>
+                            </material:TextField>
+
+                            <material:TextField Title="Sample Text" />
+                        </VerticalStackLayout>
+                        <CheckBox x:Name="ShowIconCheckBox" Grid.Column="1" IsChecked="True" VerticalOptions="Center" />
+                    </Grid>
+
+                    <uranium:ExpanderView>
+                        <uranium:ExpanderView.Header>
+                            <Label Text="Source Code (XAML)" Padding="10" />
+                        </uranium:ExpanderView.Header>
+                        <Grid>
+                            <uranium:CodeView Language="xml" SourceCode="{StaticResource SourceCode4}" HeightRequest="240"/>
+                            <local:CopyButton TextToCopy="{StaticResource SourceCode4}" />
+                        </Grid>
+                    </uranium:ExpanderView>
+                </VerticalStackLayout>
+            </Border>
+
             <BoxView StyleClass="Divider" />
             
             <Border Margin="{OnIdiom 10, Phone=0}" StyleClass="SurfaceContainer, Rounded" StrokeThickness="0">

--- a/src/UraniumUI.Material/Controls/InputField.cs
+++ b/src/UraniumUI.Material/Controls/InputField.cs
@@ -47,7 +47,7 @@ public partial class InputField : ContentView
 
     protected Lazy<Image> imageIcon = new Lazy<Image>(() =>
     {
-        return new Image
+        var image = new Image
         {
             StyleClass = new[] { "InputField.Icon" },
             HorizontalOptions = LayoutOptions.Start,
@@ -56,6 +56,9 @@ public partial class InputField : ContentView
             HeightRequest = 20,
             Margin = new Thickness(10, 0, 0, 0),
         };
+        image.SetId("IconImage");
+
+        return image;
     });
 
     protected HorizontalStackLayout endIconsContainer => this.FindByViewQueryIdInVisualTreeDescendants<HorizontalStackLayout>("EndIconsContainer");
@@ -64,7 +67,12 @@ public partial class InputField : ContentView
 
     private Color LastFontimageColor;
 
+    private Thickness? originalContentMargin;
+
     private bool hasValue;
+
+    // Leading-icon predicate. Invariant: imageIcon is materialized, in the grid, and visible iff this is true.
+    protected bool HasIcon => Icon != null;
 
     private static Binding GetRelativeBinding(string path, BindingMode mode = BindingMode.Default) => new Binding(path, mode: mode, source: new RelativeBindingSource(RelativeBindingSourceMode.TemplatedParent));
 
@@ -327,12 +335,12 @@ public partial class InputField : ContentView
 
                 labelTitle.CancelAnimations();
 
-                var x = imageIcon.IsValueCreated ? imageIcon.Value.Width : 0;
+                var x = HasIcon ? imageIcon.Value.Width : 0;
 
 #if ANDROID
                 if (this.IsRtl())
                 {
-                    x = imageIcon.IsValueCreated ? -imageIcon.Value.Width : 0;
+                    x = HasIcon ? -imageIcon.Value.Width : 0;
                 }
 #endif
 
@@ -412,24 +420,49 @@ public partial class InputField : ContentView
 
     protected virtual void OnIconChanged()
     {
-        imageIcon.Value.Source = Icon;
-
-        if (Icon is FontImageSource font && font.Color.IsNullOrTransparent())
+        if (this.Content != null && originalContentMargin == null)
         {
-            // TODO: Add IconColor bindable property.??? What if it's not FontImage?
-            font.SetAppThemeColor(
-                FontImageSource.ColorProperty,
-                ColorResource.GetColor("OnBackground", Colors.Gray),
-                ColorResource.GetColor("OnBackgroundDark", Colors.Gray));
+            originalContentMargin = this.Content.Margin;
         }
 
-        if (innerGrid != null && !innerGrid.Contains(imageIcon.Value))
+        if (HasIcon)
         {
-            innerGrid.Add(imageIcon.Value, column: 0);
+            imageIcon.Value.Source = Icon;
+            imageIcon.Value.IsVisible = true;
+
+            if (Icon is FontImageSource font && font.Color.IsNullOrTransparent())
+            {
+                // TODO: Add IconColor bindable property.??? What if it's not FontImage?
+                font.SetAppThemeColor(
+                    FontImageSource.ColorProperty,
+                    ColorResource.GetColor("OnBackground", Colors.Gray),
+                    ColorResource.GetColor("OnBackgroundDark", Colors.Gray));
+            }
+
+            if (innerGrid != null && !innerGrid.Contains(imageIcon.Value))
+            {
+                innerGrid.Add(imageIcon.Value, column: 0);
+            }
+
+            this.Content.Margin = new Thickness(5, 0, 0, 0);
+        }
+        else
+        {
+            if (imageIcon.IsValueCreated)
+            {
+                // Collapse the leading Auto column when Icon is cleared (e.g. binding goes back to null).
+                imageIcon.Value.Source = null;
+                imageIcon.Value.IsVisible = false;
+            }
+
+            if (this.Content != null && originalContentMargin.HasValue)
+            {
+                this.Content.Margin = originalContentMargin.Value;
+            }
         }
 
-        var leftMargin = Icon != null ? 5 : 10;
-        this.Content.Margin = new Thickness(leftMargin, 0, 0, 0);
+        // Re-run the title-position logic so the floating Label tracks the icon's new presence/absence.
+        UpdateState();
     }
 
     protected virtual void OnCornerRadiusChanged()

--- a/test/UraniumUI.Material.Tests/Controls/TextField_Test.cs
+++ b/test/UraniumUI.Material.Tests/Controls/TextField_Test.cs
@@ -94,6 +94,40 @@ public class TextField_Test
     }
 
     [Fact]
+    public void Icon_ClearedToNull_CollapsesLeadingIconSlot()
+    {
+        // Repro for #1002 AND assertion of the InputField invariant maintained by OnIconChanged:
+        //   imageIcon is materialized, in the grid, and visible iff Icon != null (i.e. iff HasIcon).
+        // Also: Content.Margin must match a TextField that never had an icon when Icon is null,
+        // so the cleared field is layout-identical to a never-iconed field.
+        var iconA = new FontImageSource { FontFamily = "MaterialSharp", Glyph = "A" };
+
+        var reference = AnimationReadyHandler.Prepare(new TextField());
+        var referenceMargin = reference.Content.Margin;
+
+        var control = AnimationReadyHandler.Prepare(new TextField { Icon = iconA });
+        var imageIcon = control.FindByViewQueryIdInVisualTreeDescendants<Image>("IconImage");
+
+        imageIcon.ShouldNotBeNull();
+        imageIcon.IsVisible.ShouldBeTrue();
+        imageIcon.Source.ShouldBe(iconA);
+
+        // Clear the Icon (e.g. the binding now resolves to null).
+        control.Icon = null;
+
+        // The same Image instance is still in the visual tree but collapsed.
+        imageIcon.IsVisible.ShouldBeFalse();
+        imageIcon.Source.ShouldBeNull();
+        // And Content.Margin must match a TextField that never had an icon.
+        control.Content.Margin.ShouldBe(referenceMargin);
+
+        // Restoring a non-null Icon must un-collapse it.
+        control.Icon = iconA;
+        imageIcon.IsVisible.ShouldBeTrue();
+        imageIcon.Source.ShouldBe(iconA);
+    }
+
+    [Fact]
     public void TextChanges_ShouldShouldCorrectlyUpdateClearButtonVisibility()
     {
         var control = AnimationReadyHandler.Prepare(new TextField() { AllowClear = true });


### PR DESCRIPTION


<img width="1238" height="572" alt="2026-05-13_18-31-20" src="https://github.com/user-attachments/assets/0422c3e7-aefa-4e9c-9466-cee56a3fbbf7" />

Fixes #1002.

## Problem

`InputField.OnIconChanged` added the leading `Image` to the layout on the first non-null `Icon`, but never collapsed it when `Icon` went back to null (e.g. a binding toggling between an `ImageSource` and `null`). The `Image`'s `WidthRequest = 20` + `Margin = (10, 0, 0, 0)` left ~30 px reserved on the leading edge, and `Content.Margin` + the floating-title position kept tracking the with-icon state.

## Fix

Three commits:

1. **`323e932` — FIX**: `OnIconChanged` rewrite + invariant tightening.
   - Hide the leading `Image` and clear its `Source` when `Icon` → null; show and repopulate when it becomes non-null. Lazy materialization preserved.
   - Capture the original `Content.Margin` on first call; restore it when `Icon` is cleared, so a `TextField` whose `Icon` was cleared is layout-identical to one that never had an icon (no more `5`/`10` magic numbers).
   - Introduce `HasIcon = Icon != null` and use it in `UpdateState`. `imageIcon.IsValueCreated` was a one-way ratchet on `Lazy<T>` — stale after a clear. `HasIcon` makes the invariant explicit at every site.
   - Trigger `UpdateState()` from `OnIconChanged` so the floating Label repositions when `Icon` toggles at runtime.
   - **Test hook**: adds `SetId(\"IconImage\")` on the leading `Image` so the unit test can find it via the existing `FindByViewQueryIdInVisualTreeDescendants` pattern, matching the convention already used for `RootGrid` / `Border` / `InnerGrid` / `TitleLabel` / `EndIconsContainer`.

2. **`ef78157` — test**: new `Icon_ClearedToNull_CollapsesLeadingIconSlot` in `TextField_Test`. Compares a never-iconed reference `TextField` to one whose `Icon` was set then cleared; asserts `imageIcon.IsVisible` and `Source` track `Icon`, and that `Content.Margin` matches the reference.

3. **`3b9640b` — demo**: new \"Dynamic Icon (toggle via CheckBox)\" section on `TextFieldPage`. A `DataTrigger` toggles `Icon` between a `FontImageSource` and `null` based on a `CheckBox`'s `IsChecked`. A reference `TextField` sits directly below with the same `Title` and the same column width so the layout equivalence is visually obvious.

## Verification

- All 80 existing tests + the new one pass on `net10.0`.
- Visually verified on Windows: cleared-icon field is layout-identical to a never-iconed field (title and entered text both align with the reference's leading edge).

## Note on scope

The issue also mentions an initial-null case (\"`<TextField/>` with no `Icon` attribute looks indented\"). From a code read that case already worked (`OnApplyTemplate` doesn't add the `Image` when `Icon` is null at template time, so the leading `Auto` column collapses), and the demo confirms it. Happy to dig further if there's a specific repro.