### PR TITLE
Add global.json pinning SDK 10.0.100 and bump CI to match

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -13,7 +13,7 @@ steps:
 - task: UseDotNet@2
   displayName: 'Install .NET Core SDK'
   inputs:
-    version: 9.0.100
+    version: 10.0.100
     performMultiLevelLookup: true
     includePreviewVersions: true # Required for preview versions
 

--- a/global.json
+++ b/global.json
@@ -1,0 +1,6 @@
+{
+  "sdk": {
+    "version": "10.0.100",
+    "rollForward": "latestFeature"
+  }
+}


### PR DESCRIPTION
## Summary

- Adds `global.json` at the repo root pinning the build SDK to `10.0.100` with `rollForward: latestFeature`. Local builds use the same SDK as CI by default; new SDK releases can't silently change build semantics for everyone at once.
- Bumps `azure-pipelines.yml` from `9.0.100` to `10.0.100` so CI stays aligned with the new floor.

`latestFeature` lets contributors roll forward within the 10.0.x line (10.0.100 → 10.0.300 etc.) without re-pinning each patch.

## What this prevents

On a machine with a .NET 11.x SDK preview installed, `dotnet` picks the highest installed SDK. SDK 11 flags `net9.0` TFMs (and the `-android` / `-ios` / `-maccatalyst` platform variants) as out of support and breaks the build with `NETSDK1202`. CI didn't hit this because of the explicit `UseDotNet@2` step; local builds did. `global.json` closes that gap.

## Test plan

- [ ] CI passes on `10.0.100` (build + test)
- [ ] Local `dotnet build` on a machine without `10.0.100` rolls forward correctly to an installed 10.0.x feature band
- [ ] Local `dotnet build` on a machine with both `9.0.100` and `10.0.100` installed picks 10.0.100

Closes #1005