### PR TITLE
Add default trailing margin to InputField Attachments slot

### DIFF
--- a/demo/UraniumApp/Pages/InputFields/TextFieldPage.xaml
+++ b/demo/UraniumApp/Pages/InputFields/TextFieldPage.xaml
@@ -45,6 +45,35 @@
             ]]>
         </x:String>
 
+        <x:String x:Key="SourceCode4">
+            <![CDATA[
+<VerticalStackLayout Spacing="12">
+
+    <material:TextField Title="With spinner" Text="Loading something">
+        <material:TextField.Attachments>
+            <ActivityIndicator HeightRequest="20" WidthRequest="20" IsRunning="True" />
+        </material:TextField.Attachments>
+    </material:TextField>
+
+    <material:TextField Title="With two attachments" Text="Some value">
+        <material:TextField.Attachments>
+            <Image HeightRequest="20" WidthRequest="20"
+                Source="{FontImageSource FontFamily=MaterialSharp, Glyph={x:Static m:MaterialSharp.Info}}" />
+            <ActivityIndicator HeightRequest="20" WidthRequest="20" IsRunning="True" />
+        </material:TextField.Attachments>
+    </material:TextField>
+
+    <material:TextField Title="With AllowClear and attachment" Text="Some value" AllowClear="True">
+        <material:TextField.Attachments>
+            <Image HeightRequest="20" WidthRequest="20"
+                Source="{FontImageSource FontFamily=MaterialSharp, Glyph={x:Static m:MaterialSharp.Info}}" />
+        </material:TextField.Attachments>
+    </material:TextField>
+
+</VerticalStackLayout>
+            ]]>
+        </x:String>
+
         <x:String x:Key="DocLink">https://enisn-projects.io/docs/en/uranium/latest/themes/material/components/TextField</x:String>
         <x:String x:Key="SourceLink">https://github.com/enisn/UraniumUI/blob/develop/demo/UraniumApp/Pages/InputFields/TextFieldPage.xaml</x:String>
     </ContentPage.Resources>
@@ -110,6 +139,46 @@
             
             <BoxView StyleClass="Divider" />
             
+            <Border Margin="{OnIdiom 10, Phone=0}" StyleClass="SurfaceContainer, Rounded" StrokeThickness="0">
+                <VerticalStackLayout>
+                    <Label Text="TextField with Attachments" FontSize="Subtitle" Margin="20"/>
+                    <VerticalStackLayout StyleClass="ControlPreview" Spacing="12">
+                        <material:TextField Title="With spinner" Text="Loading something">
+                            <material:TextField.Attachments>
+                                <ActivityIndicator HeightRequest="20" WidthRequest="20" IsRunning="True" />
+                            </material:TextField.Attachments>
+                        </material:TextField>
+
+                        <material:TextField Title="With two attachments" Text="Some value">
+                            <material:TextField.Attachments>
+                                <Image HeightRequest="20" WidthRequest="20"
+                                    Source="{FontImageSource FontFamily=MaterialSharp, Glyph={x:Static m:MaterialSharp.Info}, Color={AppThemeBinding {StaticResource OnBackground}, Dark={StaticResource OnBackgroundDark}}}" />
+                                <ActivityIndicator HeightRequest="20" WidthRequest="20" IsRunning="True" />
+                            </material:TextField.Attachments>
+                        </material:TextField>
+
+                        <material:TextField Title="With AllowClear and attachment" Text="Some value" AllowClear="True">
+                            <material:TextField.Attachments>
+                                <Image HeightRequest="20" WidthRequest="20"
+                                    Source="{FontImageSource FontFamily=MaterialSharp, Glyph={x:Static m:MaterialSharp.Info}, Color={AppThemeBinding {StaticResource OnBackground}, Dark={StaticResource OnBackgroundDark}}}" />
+                            </material:TextField.Attachments>
+                        </material:TextField>
+                    </VerticalStackLayout>
+
+                    <uranium:ExpanderView>
+                        <uranium:ExpanderView.Header>
+                            <Label Text="Source Code (XAML)" Padding="10" />
+                        </uranium:ExpanderView.Header>
+                        <Grid>
+                            <uranium:CodeView Language="xml" SourceCode="{StaticResource SourceCode4}" HeightRequest="240"/>
+                            <local:CopyButton TextToCopy="{StaticResource SourceCode4}" />
+                        </Grid>
+                    </uranium:ExpanderView>
+                </VerticalStackLayout>
+            </Border>
+
+            <BoxView StyleClass="Divider" />
+
             <Border Margin="{OnIdiom 10, Phone=0}" StyleClass="SurfaceContainer, Rounded" StrokeThickness="0">
                 <VerticalStackLayout>
                     <Label Text="Password show/hide Button" FontSize="Subtitle" Margin="20"/>

--- a/src/UraniumUI.Material/AssemblyInfo.cs
+++ b/src/UraniumUI.Material/AssemblyInfo.cs
@@ -4,7 +4,7 @@
 [assembly: XmlnsDefinition(Constants.XamlNamespace, Constants.NamespacePrefix + nameof(UraniumUI.Material.Resources))]
 
 [assembly: Microsoft.Maui.Controls.XmlnsPrefix(Constants.XamlNamespace, "material")]
-
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("UraniumUI.Material.Tests")]
 
 class Constants
 {

--- a/src/UraniumUI.Material/Controls/InputField.Validation.cs
+++ b/src/UraniumUI.Material/Controls/InputField.Validation.cs
@@ -15,8 +15,7 @@ public partial class InputField : IValidatable
     {
         VerticalOptions = LayoutOptions.Center,
         HorizontalOptions = LayoutOptions.End,
-        Padding = new Thickness(5, 0),
-        Margin = new Thickness(0, 0, 5, 0),
+        Padding = new Thickness(BuiltInAttachmentLeftPadding, 0, 0, 0),
         Content = new Path
         {
             StyleClass = new[] { "InputField.ValidationIcon" },

--- a/src/UraniumUI.Material/Controls/InputField.cs
+++ b/src/UraniumUI.Material/Controls/InputField.cs
@@ -11,6 +11,9 @@ public partial class InputField : ContentView
 {
     internal const double FirstDash = 6;
     internal const double MaxCornerRadius = 24;
+    internal const double EdgePadding = 10;                  // gap to the field border (leading Icon margin / trailing Attachments margin)
+    internal const double AttachmentsSpacing = 8;            // gap between sibling attachments
+    internal const double BuiltInAttachmentLeftPadding = 5;  // left tap-area extension on built-in attachments toward the text content
     public virtual new View Content { get => (View)GetValue(ContentProperty); set => SetValue(ContentProperty, value); }
 
     public static readonly new BindableProperty ContentProperty = BindableProperty.Create(
@@ -54,7 +57,7 @@ public partial class InputField : ContentView
             VerticalOptions = LayoutOptions.Center,
             WidthRequest = 20,
             HeightRequest = 20,
-            Margin = new Thickness(10, 0, 0, 0),
+            Margin = new Thickness(EdgePadding, 0, 0, 0),
         };
     });
 
@@ -133,6 +136,8 @@ public partial class InputField : ContentView
         var endIconsContainer = new HorizontalStackLayout
         {
             StyleClass = new[] { "InputField.Attachments" },
+            Margin = new Thickness(0, 0, EdgePadding, 0),
+            Spacing = AttachmentsSpacing,
         };
 
         endIconsContainer.SetId("EndIconsContainer");

--- a/src/UraniumUI.Material/Controls/TextField.cs
+++ b/src/UraniumUI.Material/Controls/TextField.cs
@@ -176,8 +176,7 @@ public partial class TextField : InputField
             VerticalOptions = LayoutOptions.Center,
             HorizontalOptions = LayoutOptions.End,
             IsVisible = true, // this is important; having initial state of false will have SetBinding have no effect, since it will not receive input events
-            Padding = new Thickness(5, 0),
-            Margin = new Thickness(0, 0, 5, 0),
+            Padding = new Thickness(InputField.BuiltInAttachmentLeftPadding, 0, 0, 0),
             TappedCommand = new Command(OnClearTapped),
             Content = new Path
             {

--- a/src/UraniumUI.Material/Controls/TextFieldPasswordShowHideAttachment.cs
+++ b/src/UraniumUI.Material/Controls/TextFieldPasswordShowHideAttachment.cs
@@ -14,8 +14,7 @@ public class TextFieldPasswordShowHideAttachment : StatefulContentView
     public TextFieldPasswordShowHideAttachment()
     {
         VerticalOptions = LayoutOptions.Center;
-        Padding = new Thickness(5, 0);
-        Margin = new Thickness(0, 0, 5, 0);
+        Padding = new Thickness(InputField.BuiltInAttachmentLeftPadding, 0, 0, 0);
         TappedCommand = new Command(SwitchPassword);
     }
 

--- a/test/UraniumUI.Material.Tests/Controls/TextField_Test.cs
+++ b/test/UraniumUI.Material.Tests/Controls/TextField_Test.cs
@@ -103,16 +103,16 @@ public class TextField_Test
         var endIconsContainer = control.FindByViewQueryIdInVisualTreeDescendants<HorizontalStackLayout>("EndIconsContainer");
 
         endIconsContainer.ShouldNotBeNull();
-        endIconsContainer.Margin.ShouldBe(new Thickness(0, 0, 10, 0));
-        endIconsContainer.Spacing.ShouldBe(8);
+        endIconsContainer.Margin.ShouldBe(new Thickness(0, 0, InputField.EdgePadding, 0));
+        endIconsContainer.Spacing.ShouldBe(InputField.AttachmentsSpacing);
 
         var first = new ActivityIndicator { IsRunning = true };
         var second = new ActivityIndicator { IsRunning = true };
         control.Attachments.Add(first);
         control.Attachments.Add(second);
 
-        endIconsContainer.Margin.ShouldBe(new Thickness(0, 0, 10, 0));
-        endIconsContainer.Spacing.ShouldBe(8);
+        endIconsContainer.Margin.ShouldBe(new Thickness(0, 0, InputField.EdgePadding, 0));
+        endIconsContainer.Spacing.ShouldBe(InputField.AttachmentsSpacing);
         control.Attachments.ShouldContain(first);
         control.Attachments.ShouldContain(second);
     }

--- a/test/UraniumUI.Material.Tests/Controls/TextField_Test.cs
+++ b/test/UraniumUI.Material.Tests/Controls/TextField_Test.cs
@@ -94,6 +94,43 @@ public class TextField_Test
     }
 
     [Fact]
+    public void Attachments_Container_HasDefaultSpacingFromBorderAndBetweenChildren()
+    {
+        // The Attachments container provides a default gap to the field border and
+        // between sibling attachments. Container defaults stay independent of children.
+        var control = AnimationReadyHandler.Prepare(new TextField());
+
+        var endIconsContainer = control.FindByViewQueryIdInVisualTreeDescendants<HorizontalStackLayout>("EndIconsContainer");
+
+        endIconsContainer.ShouldNotBeNull();
+        endIconsContainer.Margin.ShouldBe(new Thickness(0, 0, 10, 0));
+        endIconsContainer.Spacing.ShouldBe(8);
+
+        var first = new ActivityIndicator { IsRunning = true };
+        var second = new ActivityIndicator { IsRunning = true };
+        control.Attachments.Add(first);
+        control.Attachments.Add(second);
+
+        endIconsContainer.Margin.ShouldBe(new Thickness(0, 0, 10, 0));
+        endIconsContainer.Spacing.ShouldBe(8);
+        control.Attachments.ShouldContain(first);
+        control.Attachments.ShouldContain(second);
+    }
+
+    [Fact]
+    public void ClearIcon_HasAsymmetricLeftHitPadding()
+    {
+        // Clear X uses asymmetric Padding: right edge flush with the container margin
+        // (matching a user-supplied attachment), left side extended for a wider tap target.
+        var control = AnimationReadyHandler.Prepare(new TextField { AllowClear = true });
+        var clearIcon = control.FindByViewQueryIdInVisualTreeDescendants<StatefulContentView>("ClearIcon");
+
+        clearIcon.ShouldNotBeNull();
+        clearIcon.Margin.ShouldBe(default(Thickness));
+        clearIcon.Padding.ShouldBe(new Thickness(5, 0, 0, 0));
+    }
+
+    [Fact]
     public void TextChanges_ShouldShouldCorrectlyUpdateClearButtonVisibility()
     {
         var control = AnimationReadyHandler.Prepare(new TextField() { AllowClear = true });


### PR DESCRIPTION
## Summary

- Mirrors the leading `Icon`'s default 10px margin (`Controls/InputField.cs:57`) by adding `Margin = new Thickness(0, 0, 10, 0)` to the `EndIconsContainer` `HorizontalStackLayout`.
- Views placed in `material:TextField.Attachments` (e.g. `Image`, `ActivityIndicator`, `ImageButton`) no longer sit flush against the trailing border by default. Consumers can still override `Margin` on their child or on the container.

## Before

```xml
<material:TextField Title="My Field" Text="some value">
    <material:TextField.Attachments>
        <ActivityIndicator HeightRequest="20" WidthRequest="20" IsRunning="True" />
    </material:TextField.Attachments>
</material:TextField>
```

Spinner renders touching the trailing border.

## After

Spinner renders with a 10px gap, matching the leading-Icon side.

## Test plan

- [ ] Visual check on Android: spinner / image in `Attachments` no longer touches the trailing border
- [ ] Existing demo pages (`TextFieldPage`) render unchanged where `Attachments` is unused
- [ ] Custom user `Margin` on an attachment child still takes effect (container margin doesn't override child margin)

Closes #1003