### PR TITLE
Add ShowHeaders option to DataGrid

### DIFF
--- a/src/UraniumUI.Material/Controls/DataGrid.BindableProperties.cs
+++ b/src/UraniumUI.Material/Controls/DataGrid.BindableProperties.cs
@@ -22,6 +22,12 @@ public partial class DataGrid
         BindableProperty.Create(nameof(TitleTemplate), typeof(DataTemplate), typeof(DataGrid), defaultValue: null,
             propertyChanged: (bo, ov, nv) => (bo as DataGrid).OnTitleTemplateChanged());
 
+    public bool ShowHeaders { get => (bool)GetValue(ShowHeadersProperty); set => SetValue(ShowHeadersProperty, value); }
+
+    public static readonly BindableProperty ShowHeadersProperty =
+        BindableProperty.Create(nameof(ShowHeaders), typeof(bool), typeof(DataGrid), defaultValue: true,
+            propertyChanged: (bo, ov, nv) => (bo as DataGrid).Render());
+
     public Color LineSeparatorColor { get => (Color)GetValue(LineSeparatorColorProperty); set => SetValue(LineSeparatorColorProperty, value); }
 
     public static readonly BindableProperty LineSeparatorColorProperty =

--- a/src/UraniumUI.Material/Controls/DataGrid.cs
+++ b/src/UraniumUI.Material/Controls/DataGrid.cs
@@ -77,6 +77,12 @@ public partial class DataGrid : Border
 
     private void ItemsSource_CollectionChanged(object sender, NotifyCollectionChangedEventArgs e)
     {
+        if (!ShowHeaders)
+        {
+            Render();
+            return;
+        }
+
         if (ItemsSource.Count == 0)
         {
             ResetGrid();
@@ -152,7 +158,7 @@ public partial class DataGrid : Border
             return; // Not ready yet.
         }
 
-        var tableHeaderRows = 1;
+        var tableHeaderRows = ShowHeaders ? 1 : 0;
         ResetGrid();
         ConfigureGridColumnDefinitions(Columns.Count);
         ConfigureGridRowDefinitions(ItemsSource.Count + tableHeaderRows);
@@ -187,7 +193,7 @@ public partial class DataGrid : Border
 
     protected virtual void AddTableHeaders(int row = 0)
     {
-        if (Columns is null)
+        if (!ShowHeaders || Columns is null)
         {
             return;
         }
@@ -220,7 +226,10 @@ public partial class DataGrid : Border
     {
         var actualRow = row * 2;
 
-        AddSeparator(actualRow - 1);
+        if (row > 0)
+        {
+            AddSeparator(actualRow - 1);
+        }
 
         for (int columnNumber = 0; columnNumber < Columns.Count; columnNumber++)
         {
@@ -307,7 +316,7 @@ public partial class DataGrid : Border
     private void ConfigureGridRowDefinitions(int rows)
     {
         _rootGrid.RowDefinitions.Clear();
-        var actualRows = (rows * 2) - 1;
+        var actualRows = Math.Max(0, (rows * 2) - 1);
 
         for (int i = 0; i < actualRows; i++)
         {
@@ -361,8 +370,16 @@ public partial class DataGrid : Border
         EmptyView ??= (View)EmptyViewTemplate?.CreateContent() ?? new BoxView { HorizontalOptions = LayoutOptions.Fill, Margin = 40 };
         if (!_rootGrid.Contains(EmptyView))
         {
-            AddSeparator(1);
-            _rootGrid.Add(EmptyView, column: 0, row: 2);
+            if (ShowHeaders)
+            {
+                AddSeparator(1);
+                _rootGrid.Add(EmptyView, column: 0, row: 2);
+            }
+            else
+            {
+                _rootGrid.Add(EmptyView, column: 0, row: 0);
+            }
+
             Grid.SetColumnSpan(EmptyView, Columns.Count);
         }
     }
@@ -379,8 +396,7 @@ public partial class DataGrid : Border
     {
         if (_rootGrid.Children.Any())
         {
-            RemoveRow(0);
-            AddTableHeaders();
+            Render();
         }
     }
 

--- a/test/UraniumUI.Material.Tests/Controls/DataGrid_Test.cs
+++ b/test/UraniumUI.Material.Tests/Controls/DataGrid_Test.cs
@@ -1,9 +1,9 @@
-﻿using Shouldly;
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using Shouldly;
 using UraniumUI.Material.Controls;
 using UraniumUI.Tests.Core;
 
@@ -40,6 +40,63 @@ public class DataGrid_Test
 
         // Assert
         control.LineSeparatorColor.ShouldBe(viewModel.LineSeparatorColor);
+    }
+
+    [Fact]
+    public void ShowHeaders_ShouldHideHeaderViews_AndMoveFirstRowToTop()
+    {
+        var control = AnimationReadyHandler.Prepare(new DataGrid
+        {
+            ShowHeaders = false,
+            Columns =
+            [
+                new DataGridColumn { Title = "Id", ValueBinding = new Binding(nameof(DataGridRow.Id)) },
+                new DataGridColumn { Title = "Name", ValueBinding = new Binding(nameof(DataGridRow.Name)) },
+            ],
+            ItemsSource = new List<DataGridRow>
+            {
+                new() { Id = 1, Name = "One" },
+                new() { Id = 2, Name = "Two" },
+            }
+        });
+
+        var rootGrid = control.Content.ShouldBeOfType<Grid>();
+        rootGrid.Children.OfType<Label>().Count().ShouldBe(0);
+        rootGrid.Children.OfType<ContentView>().Select(Grid.GetRow).Distinct().OrderBy(x => x).ToArray().ShouldBe([0, 2]);
+    }
+
+    [Fact]
+    public void ShowHeaders_ShouldRerender_WhenUpdated()
+    {
+        var control = AnimationReadyHandler.Prepare(new DataGrid
+        {
+            Columns =
+            [
+                new DataGridColumn { Title = "Id", ValueBinding = new Binding(nameof(DataGridRow.Id)) },
+                new DataGridColumn { Title = "Name", ValueBinding = new Binding(nameof(DataGridRow.Name)) },
+            ],
+            ItemsSource = new List<DataGridRow>
+            {
+                new() { Id = 1, Name = "One" },
+            }
+        });
+
+        var rootGrid = control.Content.ShouldBeOfType<Grid>();
+        rootGrid.Children.OfType<Label>().Count().ShouldBe(2);
+        rootGrid.Children.OfType<ContentView>().Select(Grid.GetRow).Distinct().Single().ShouldBe(2);
+
+        control.ShowHeaders = false;
+
+        rootGrid = control.Content.ShouldBeOfType<Grid>();
+        rootGrid.Children.OfType<Label>().Count().ShouldBe(0);
+        rootGrid.Children.OfType<ContentView>().Select(Grid.GetRow).Distinct().Single().ShouldBe(0);
+    }
+
+    private sealed class DataGridRow
+    {
+        public int Id { get; init; }
+
+        public string Name { get; init; }
     }
 
     internal class DataGridTestViewModel : UraniumBindableObject


### PR DESCRIPTION
## Summary
- add a `ShowHeaders` bindable property to `DataGrid` so header rows can be hidden explicitly
- rerender headerless grids on collection changes so row separators stay consistent without a header row
- add DataGrid tests covering headerless rendering and runtime toggling

## Automated Testing
- `dotnet test test/UraniumUI.Material.Tests/UraniumUI.Material.Tests.csproj --filter DataGrid_Test`
- `dotnet test test/UraniumUI.Material.Tests/UraniumUI.Material.Tests.csproj`

## Manual Testing
- run a MAUI sample or app that uses `material:DataGrid`
- set `ShowHeaders="False"` on a grid with at least two columns and rows
- confirm the first data row renders at the top of the grid without the empty header gap
- toggle `ShowHeaders` back to `True` and confirm the header row returns

Closes #943
