### PR TITLE
fix: preserve EditorField text color across theme changes

### DIFF
--- a/src/UraniumUI.Material/Controls/EditorField.BindableProperties.cs
+++ b/src/UraniumUI.Material/Controls/EditorField.BindableProperties.cs
@@ -20,8 +20,7 @@ public partial class EditorField
         nameof(TextColor),
         typeof(Color),
         typeof(EditorField),
-        ColorResource.GetColor("OnBackground", "OnBackgroundDark", Colors.DarkGray),
-        propertyChanged: (bindable, oldValue, newValue) => (bindable as EditorField).EditorView.TextColor = (Color)newValue);
+        ColorResource.GetColor("OnBackground", "OnBackgroundDark", Colors.DarkGray));
 
     public string FontFamily { get => (string)GetValue(FontFamilyProperty); set => SetValue(FontFamilyProperty, value); }
 

--- a/src/UraniumUI.Material/Controls/EditorField.cs
+++ b/src/UraniumUI.Material/Controls/EditorField.cs
@@ -21,6 +21,7 @@ public partial class EditorField : InputField
     {
         base.RegisterForEvents();
         EditorView.SetBinding(Editor.TextProperty, new Binding(nameof(Text), source: this));
+        EditorView.SetBinding(Editor.TextColorProperty, new Binding(nameof(TextColor), BindingMode.OneWay, source: this));
         EditorView.SetBinding(Editor.SelectionLengthProperty, new Binding(nameof(SelectionLength), source: this));
         EditorView.SetBinding(Editor.CursorPositionProperty, new Binding(nameof(CursorPosition), source: this));
     }

--- a/test/UraniumUI.Material.Tests/Controls/EditorField_Test.cs
+++ b/test/UraniumUI.Material.Tests/Controls/EditorField_Test.cs
@@ -58,11 +58,44 @@ public class EditorField_Test
         viewModel.Text.ShouldBe(control.Text);
     }
 
+    [Fact]
+    public void TextColor_ShouldBeSet_FromViewModel()
+    {
+        var control = AnimationReadyHandler.Prepare(new EditorField());
+        var viewModel = new EditorFieldTestViewModel { TextColor = Colors.Blue };
+        control.BindingContext = viewModel;
+
+        // Act
+        control.SetBinding(EditorField.TextColorProperty, new Binding(nameof(EditorFieldTestViewModel.TextColor)));
+
+        // Assert
+        control.EditorView.TextColor.ShouldBe(viewModel.TextColor);
+    }
+
+    [Fact]
+    public void TextColor_ShouldOverride_ExistingThemeBinding_WhenValueMatchesLightTheme()
+    {
+        Application.Current.UserAppTheme = AppTheme.Light;
+
+        var control = AnimationReadyHandler.Prepare(new EditorField());
+        control.EditorView.SetAppThemeColor(Editor.TextColorProperty, Colors.Black, Colors.White);
+
+        // Act
+        control.TextColor = Colors.Black;
+        Application.Current.UserAppTheme = AppTheme.Dark;
+
+        // Assert
+        control.EditorView.TextColor.ShouldBe(Colors.Black);
+    }
+
     internal class EditorFieldTestViewModel : UraniumBindableObject
     {
         private string text;
+        private Color textColor;
 
         public string Text { get => text; set => SetProperty(ref text, value); }
+
+        public Color TextColor { get => textColor; set => SetProperty(ref textColor, value); }
     }
 
     [Fact]

--- a/test/UraniumUI.Material.Tests/Controls/EditorField_Test.cs
+++ b/test/UraniumUI.Material.Tests/Controls/EditorField_Test.cs
@@ -75,17 +75,26 @@ public class EditorField_Test
     [Fact]
     public void TextColor_ShouldOverride_ExistingThemeBinding_WhenValueMatchesLightTheme()
     {
-        Application.Current.UserAppTheme = AppTheme.Light;
+        var originalTheme = Application.Current.UserAppTheme;
 
-        var control = AnimationReadyHandler.Prepare(new EditorField());
-        control.EditorView.SetAppThemeColor(Editor.TextColorProperty, Colors.Black, Colors.White);
+        try
+        {
+            Application.Current.UserAppTheme = AppTheme.Light;
 
-        // Act
-        control.TextColor = Colors.Black;
-        Application.Current.UserAppTheme = AppTheme.Dark;
+            var control = AnimationReadyHandler.Prepare(new EditorField());
+            control.EditorView.SetAppThemeColor(Editor.TextColorProperty, Colors.Black, Colors.White);
 
-        // Assert
-        control.EditorView.TextColor.ShouldBe(Colors.Black);
+            // Act
+            control.TextColor = Colors.Black;
+            Application.Current.UserAppTheme = AppTheme.Dark;
+
+            // Assert
+            control.EditorView.TextColor.ShouldBe(Colors.Black);
+        }
+        finally
+        {
+            Application.Current.UserAppTheme = originalTheme;
+        }
     }
 
     internal class EditorFieldTestViewModel : UraniumBindableObject


### PR DESCRIPTION
## Summary
- bind `EditorField` text color from the control to the inner editor instead of pushing it with a direct assignment
- preserve explicit `#000000` text colors when the app theme changes
- add regression coverage for `EditorField` text color binding and theme-bound override behavior

## Automated Testing
- `dotnet test test/UraniumUI.Material.Tests/UraniumUI.Material.Tests.csproj --filter EditorField_Test`
- `dotnet test test/UraniumUI.Material.Tests/UraniumUI.Material.Tests.csproj`

## Manual Testing
- Environment: Android or iOS emulator/device with theme switching
- Apply a global `material:EditorField` style with `TextColor="#000000"`
- Launch the app in Light mode and confirm the editor text is black
- Switch the device theme to Dark mode
- Confirm the editor text stays black instead of turning white
- Repeat with `TextColor="#000000"` set directly on a single `EditorField` instance

Closes #1010
