### PR TITLE
Support nullable DatePickerField dates

### DIFF
--- a/docs/en/themes/material/components/DatePickerField.md
+++ b/docs/en/themes/material/components/DatePickerField.md
@@ -37,6 +37,8 @@ DatePickerFields support setting an icon on the left side of the control. You ca
 ## AllowClear
 DatePickerFields support clearing the selected date by setting the `AllowClear` property to `true`. Default value is `true`. You can make it `false` to disable clearing.
 
+Clearing the field sets `Date` to `null`. `Date`, `MinimumDate`, and `MaximumDate` support nullable `DateTime` values, so they can be bound to `DateTime?` view-model properties.
+
 ```xml
 <material:DatePickerField 
     Title="Pick a Date (Clearable)"

--- a/src/UraniumUI.Material/Controls/DatePickerField.cs
+++ b/src/UraniumUI.Material/Controls/DatePickerField.cs
@@ -55,7 +55,6 @@ public class DatePickerField : InputField
 #endif
         UpdateClearIconState();
 
-        DatePickerView.SetBinding(DatePicker.DateProperty, new Binding(nameof(Date), source: this));
         DatePickerView.SetBinding(DatePicker.IsEnabledProperty, new Binding(nameof(IsEnabled), source: this));
         DatePickerView.SetBinding(DatePicker.FontSizeProperty, new Binding(nameof(FontSize), source: this));
         DatePickerView.SetBinding(DatePicker.FontAutoScalingEnabledProperty, new Binding(nameof(FontAutoScalingEnabled), source: this));
@@ -80,6 +79,27 @@ public class DatePickerField : InputField
 #endif
     }
 
+    protected override void OnHandlerChanging(HandlerChangingEventArgs args)
+    {
+        base.OnHandlerChanging(args);
+
+        if (args.OldHandler is not null)
+        {
+            DatePickerView.DateSelected -= OnDateSelected;
+        }
+    }
+
+    protected override void OnHandlerChanged()
+    {
+        base.OnHandlerChanged();
+
+        if (Handler is not null)
+        {
+            DatePickerView.DateSelected -= OnDateSelected;
+            DatePickerView.DateSelected += OnDateSelected;
+        }
+    }
+
     protected override object GetValueForValidator()
     {
         return Date;
@@ -91,7 +111,7 @@ public class DatePickerField : InputField
         {
             // Workaround for the selecting the same date again:
 #if WINDOWS
-            if (DatePickerView.Handler.PlatformView is Microsoft.UI.Xaml.Controls.CalendarDatePicker dp)
+            if (DatePickerView.Handler?.PlatformView is Microsoft.UI.Xaml.Controls.CalendarDatePicker dp)
             {
                 dp.Date = null;
             }
@@ -103,12 +123,17 @@ public class DatePickerField : InputField
     #endif
 #endif
         // End of workaround
-        Date = (DateTime)DatePicker.DateProperty.DefaultValue;
+        Date = null;
 
 #if MACCATALYST
         DatePickerView.Unfocus();
 #endif
         }
+    }
+
+    protected virtual void OnDateSelected(object sender, DateChangedEventArgs e)
+    {
+        Date = e.NewDate;
     }
 
 #if WINDOWS
@@ -125,6 +150,11 @@ public class DatePickerField : InputField
     {
         OnPropertyChanged(nameof(Date));
         CheckAndShowValidations();
+
+        if (Date is DateTime date && DatePickerView.Date != date)
+        {
+            DatePickerView.Date = date;
+        }
 
         DatePickerView.Opacity = Date == null ? 0 : 1;
         if (AllowClear)
@@ -170,32 +200,32 @@ public class DatePickerField : InputField
 
     public override void ResetValidation()
     {
-        Date = DateTime.Today;
+        Date = null;
         base.ResetValidation();
     }
 
-    public DateTime Date { get => (DateTime)GetValue(DateProperty); set => SetValue(DateProperty, value); }
+    public DateTime? Date { get => (DateTime?)GetValue(DateProperty); set => SetValue(DateProperty, value); }
 
     public static readonly BindableProperty DateProperty = BindableProperty.Create(
-        nameof(Date), typeof(DateTime), typeof(DatePickerField),
-        defaultValue: DateTime.Today, defaultBindingMode: BindingMode.TwoWay,
+        nameof(Date), typeof(DateTime?), typeof(DatePickerField),
+        defaultValue: null, defaultBindingMode: BindingMode.TwoWay,
         propertyChanged: (bindable, oldValue, newValue) => (bindable as DatePickerField).OnDateChanged()
         );
 
-    public DateTime MaximumDate { get => (DateTime)GetValue(MaximumDateProperty); set => SetValue(MaximumDateProperty, value); }
+    public DateTime? MaximumDate { get => (DateTime?)GetValue(MaximumDateProperty); set => SetValue(MaximumDateProperty, value); }
 
     public static readonly BindableProperty MaximumDateProperty = BindableProperty.Create(
-         nameof(MaximumDate), typeof(DateTime), typeof(DatePickerField),
-         defaultValue: DatePicker.MaximumDateProperty.DefaultValue,
-         propertyChanged: (bindable, oldValue, newValue) => (bindable as DatePickerField).DatePickerView.MaximumDate = (DateTime)newValue
+         nameof(MaximumDate), typeof(DateTime?), typeof(DatePickerField),
+         defaultValue: null,
+         propertyChanged: (bindable, oldValue, newValue) => (bindable as DatePickerField).DatePickerView.MaximumDate = (DateTime)(newValue ?? DatePicker.MaximumDateProperty.DefaultValue)
          );
 
-    public DateTime MinimumDate { get => (DateTime)GetValue(MinimumDateProperty); set => SetValue(MinimumDateProperty, value); }
+    public DateTime? MinimumDate { get => (DateTime?)GetValue(MinimumDateProperty); set => SetValue(MinimumDateProperty, value); }
 
     public static readonly BindableProperty MinimumDateProperty = BindableProperty.Create(
-         nameof(MinimumDate), typeof(DateTime), typeof(DatePickerField),
-         defaultValue: DatePicker.MinimumDateProperty.DefaultValue,
-         propertyChanged: (bindable, oldValue, newValue) => (bindable as DatePickerField).DatePickerView.MinimumDate = (DateTime)newValue
+         nameof(MinimumDate), typeof(DateTime?), typeof(DatePickerField),
+         defaultValue: null,
+         propertyChanged: (bindable, oldValue, newValue) => (bindable as DatePickerField).DatePickerView.MinimumDate = (DateTime)(newValue ?? DatePicker.MinimumDateProperty.DefaultValue)
          );
 
     public string Format { get => (string)GetValue(FormatProperty); set => SetValue(FormatProperty, value); }

--- a/test/UraniumUI.Material.Tests/Controls/DatePickerField_Test.cs
+++ b/test/UraniumUI.Material.Tests/Controls/DatePickerField_Test.cs
@@ -53,6 +53,107 @@ public class DatePickerField_Test
     }
 
     [Fact]
+    public void Date_Binding_ShouldSupportNonNullableDateTime()
+    {
+        var control = AnimationReadyHandler.Prepare(new DatePickerField());
+        var viewModel = new NonNullableDateViewModel { Date = DateTime.Now.AddDays(2) };
+        control.BindingContext = viewModel;
+        control.SetBinding(DatePickerField.DateProperty, new Binding(nameof(NonNullableDateViewModel.Date)));
+
+        // Assert source to control binding.
+        control.Date.ShouldBe(viewModel.Date);
+
+        // Act
+        control.Date = DateTime.Parse("09:05");
+
+        // Assert control to source binding.
+        viewModel.Date.ShouldBe(control.Date.Value);
+    }
+
+    [Fact]
+    public void Date_Binding_ShouldAcceptNull_FromSource()
+    {
+        var control = AnimationReadyHandler.Prepare(new DatePickerField());
+        var viewModel = new TestViewModel { Date = null };
+        control.BindingContext = viewModel;
+
+        // Act
+        control.SetBinding(DatePickerField.DateProperty, new Binding(nameof(TestViewModel.Date)));
+
+        // Assert
+        control.Date.ShouldBeNull();
+        control.HasValue.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void Date_Binding_ShouldAcceptNull_ToSource()
+    {
+        var control = AnimationReadyHandler.Prepare(new DatePickerField());
+        var viewModel = new TestViewModel { Date = DateTime.Now.AddDays(2) };
+        control.BindingContext = viewModel;
+        control.SetBinding(DatePickerField.DateProperty, new Binding(nameof(TestViewModel.Date)));
+
+        // Act
+        control.Date = null;
+
+        // Assert
+        viewModel.Date.ShouldBeNull();
+        control.HasValue.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void Clear_ShouldSetDateToNull()
+    {
+        var control = AnimationReadyHandler.Prepare(new TestDatePickerField { Date = DateTime.Today });
+
+        // Act
+        control.Clear();
+
+        // Assert
+        control.Date.ShouldBeNull();
+        control.HasValue.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void DatePickerView_DateSelected_ShouldUpdateDate()
+    {
+        var control = AnimationReadyHandler.Prepare(new DatePickerField());
+        var date = DateTime.Today.AddDays(2);
+
+        // Act
+        control.DatePickerView.Date = date;
+
+        // Assert
+        control.Date.ShouldBe(date);
+    }
+
+    [Fact]
+    public void MaximumDate_ShouldUseDatePickerDefault_WhenSetToNull()
+    {
+        var control = AnimationReadyHandler.Prepare(new DatePickerField());
+
+        // Act
+        control.MaximumDate = DateTime.Today.AddDays(1);
+        control.MaximumDate = null;
+
+        // Assert
+        control.DatePickerView.MaximumDate.ShouldBe((DateTime)DatePicker.MaximumDateProperty.DefaultValue);
+    }
+
+    [Fact]
+    public void MinimumDate_ShouldUseDatePickerDefault_WhenSetToNull()
+    {
+        var control = AnimationReadyHandler.Prepare(new DatePickerField());
+
+        // Act
+        control.MinimumDate = DateTime.Today.AddDays(-1);
+        control.MinimumDate = null;
+
+        // Assert
+        control.DatePickerView.MinimumDate.ShouldBe((DateTime)DatePicker.MinimumDateProperty.DefaultValue);
+    }
+
+    [Fact]
     public void Format_ShouldBeSet_FromViewModel()
     {
         var control = AnimationReadyHandler.Prepare(new DatePickerField());
@@ -183,7 +284,7 @@ public class DatePickerField_Test
 
     public class TestViewModel : UraniumBindableObject
     {
-        private DateTime time;
+        private DateTime? time;
         private string format;
         private Color textColor;
         private double characterSpacing;
@@ -191,7 +292,7 @@ public class DatePickerField_Test
         private string fontFamily;
         private double fontSize;
 
-        public DateTime Date { get => time; set => SetProperty(ref time, value); }
+        public DateTime? Date { get => time; set => SetProperty(ref time, value); }
 
         public string Format { get => format; set => SetProperty(ref format, value); }
 
@@ -204,5 +305,20 @@ public class DatePickerField_Test
         public string FontFamily { get => fontFamily; set => SetProperty(ref fontFamily, value); }
 
         public double FontSize { get => fontSize; set => SetProperty(ref fontSize, value); }
+    }
+
+    private class TestDatePickerField : DatePickerField
+    {
+        public void Clear()
+        {
+            OnClearTapped(this);
+        }
+    }
+
+    private class NonNullableDateViewModel : UraniumBindableObject
+    {
+        private DateTime date;
+
+        public DateTime Date { get => date; set => SetProperty(ref date, value); }
     }
 }


### PR DESCRIPTION
## Summary
- make `DatePickerField.Date`, `MinimumDate`, and `MaximumDate` nullable
- make the clear action set `Date` to `null`
- keep native `DatePicker` date synchronization explicit and lifecycle-scope the `DateSelected` event subscription
- add nullable binding, clear, min/max fallback, and picker selection regression coverage
- document nullable date support

## Automated Testing
- `dotnet test test/UraniumUI.Material.Tests/UraniumUI.Material.Tests.csproj --no-restore`
- `dotnet build src/UraniumUI.Material/UraniumUI.Material.csproj -f net10.0-windows10.0.19041.0 --no-restore`
- `dotnet build src/UraniumUI.Material/UraniumUI.Material.csproj -f net10.0-android --no-restore`

## Manual Testing
- Not run locally; no MAUI device/simulator UI session was available in this environment.
- Manual platform check: run the demo app on Windows, Android, or iOS and open the `DatePickerField` sample.
- Repro: bind `Date` to a `DateTime?` property initialized to `null`, select a date, then tap the clear icon.
- Expected: the field starts empty, date selection updates the nullable property, clearing sets the property back to `null`, and no crash occurs.
- Repro: bind `MinimumDate` and `MaximumDate` to nullable `DateTime?` properties and set them to `null`.
- Expected: the native picker keeps its default minimum and maximum date limits.

Closes #1001
