### PR TITLE
Migrate DatePickerField to date prompt with CalendarView

### DIFF
--- a/demo/UraniumApp/Pages/InputFields/DatePickerFieldPage.xaml
+++ b/demo/UraniumApp/Pages/InputFields/DatePickerFieldPage.xaml
@@ -14,12 +14,12 @@
             <![CDATA[
  <material:DatePickerField 
     Title="Pick a date"
-    Icon="{FontImageSource FontFamily=MaterialSharp, Glyph={x:Static m:MaterialSharp.Access_time}}"
+    Icon="{FontImageSource FontFamily=MaterialSharp, Glyph={x:Static m:MaterialSharp.Calendar_month}}"
     />
             ]]>
         </x:String>
         <x:String x:Key="DocLink">https://enisn-projects.io/docs/en/uranium/latest/themes/material/components/DatePickerField</x:String>
-        <x:String x:Key="SourceLink">https://github.com/enisn/UraniumUI/blob/develop/demo/UraniumApp/Pages/InputFields/DatePickerFieldPage.xam</x:String>
+        <x:String x:Key="SourceLink">https://github.com/enisn/UraniumUI/blob/develop/demo/UraniumApp/Pages/InputFields/DatePickerFieldPage.xaml</x:String>
     </ContentPage.Resources>
 
     <ScrollView>
@@ -33,7 +33,7 @@
                 <Button Text="Reset" Clicked="Reset" StyleClass="OutlinedButton" ImageSource="{FontImageSource Glyph={x:Static m:MaterialSharp.Refresh}, FontFamily=MaterialSharp, Color={AppThemeBinding {StaticResource OnBackground}, Dark={StaticResource OnBackgroundDark}}}" />
             </HorizontalStackLayout>
 
-            <Label Text="TimePickerField is a control that allows users to select a time. It is a wrapper around the TimePicker control and makes it in line with the material design guidelines." />
+            <Label Text="DatePickerField opens the UraniumUI CalendarView date prompt, supports nullable dates, and keeps Material input-field styling across platforms." />
 
             <VerticalStackLayout Padding="{OnIdiom 10, Phone=0}" Spacing="10">
                 <Border StyleClass="SurfaceContainer, Rounded" StrokeThickness="0">
@@ -41,7 +41,7 @@
                         <ContentView StyleClass="ControlPreview">
                             <material:DatePickerField 
                                 Title="Pick a date"
-                                Icon="{FontImageSource FontFamily=MaterialSharp, Glyph={x:Static m:MaterialSharp.Timer}}"
+                                Icon="{FontImageSource FontFamily=MaterialSharp, Glyph={x:Static m:MaterialSharp.Calendar_month}}"
                                 />
                         </ContentView>
                         <uranium:ExpanderView>

--- a/docs/en/themes/material/components/DatePickerField.md
+++ b/docs/en/themes/material/components/DatePickerField.md
@@ -1,5 +1,5 @@
 # DatePickerField
-DatePickerField is a control that allows users to select a date. It is a wrapper around the DatePicker control and makes it in line with the material design guidelines.
+DatePickerField is a control that allows users to select a date. It opens the UraniumUI date prompt backed by the custom `CalendarView`, so nullable dates, clear, and same-date reselection behave consistently across platforms.
 
 - [Material Design Date Pickers](https://material.io/components/date-pickers)
 
@@ -20,7 +20,7 @@ Then you can use it like this:
 
 | Light | Dark |
 | --- | --- |
-| ![MAUI Material Design TimePicker](../../../../images/datepickerfield-demo-light-android.gif) | ![MAUI Material Design TimePicker](../../../../images/datepickerfield-demo-dark-ios.gif) |
+| ![MAUI Material Design DatePicker](../../../../images/datepickerfield-demo-light-android.gif) | ![MAUI Material Design DatePicker](../../../../images/datepickerfield-demo-dark-ios.gif) |
 
 
 ## Icon
@@ -38,6 +38,8 @@ DatePickerFields support setting an icon on the left side of the control. You ca
 DatePickerFields support clearing the selected date by setting the `AllowClear` property to `true`. Default value is `true`. You can make it `false` to disable clearing.
 
 Clearing the field sets `Date` to `null`. `Date`, `MinimumDate`, and `MaximumDate` support nullable `DateTime` values, so they can be bound to `DateTime?` view-model properties.
+
+`MinimumDate` and `MaximumDate` are passed to the calendar prompt and disable dates outside the allowed range. Cancelling the prompt leaves `Date` unchanged, while selecting Clear returns `null`.
 
 ```xml
 <material:DatePickerField 
@@ -73,7 +75,7 @@ DatePickerField is fully compatible with [FormView](https://enisn-projects.io/do
 
 ```xml
  <input:FormView Spacing="20">
-    <material:DatePickerField Title="Pick a time" Icon="{FontImageSource FontFamily=MaterialOutlined, Glyph={x:Static m:MaterialOutlined.Alarm}}">
+    <material:DatePickerField Title="Pick a date" Icon="{FontImageSource FontFamily=MaterialOutlined, Glyph={x:Static m:MaterialOutlined.Calendar_month}}">
         <validation:MinValueValidation MinValue="9/18/2022"  />
         <validation:MaxValueValidation MaxValue="12/31/2022" />
     </material:DatePickerField>

--- a/src/UraniumUI.Material/Controls/DatePickerField.cs
+++ b/src/UraniumUI.Material/Controls/DatePickerField.cs
@@ -34,7 +34,7 @@ public class DatePickerField : InputField
         LineBreakMode = LineBreakMode.TailTruncation,
         MinimumHeightRequest = 40,
         Margin = new Thickness(10, 0),
-        InputTransparent = true,
+        InputTransparent = false,
     };
 
     protected StatefulContentView iconClear = new StatefulContentView
@@ -60,7 +60,7 @@ public class DatePickerField : InputField
         iconClear.TappedCommand = new Command(OnClearTapped);
         DialogService = UraniumServiceProvider.Current.GetRequiredService<IDialogService>();
 
-        GestureRecognizers.Add(new TapGestureRecognizer
+        Content.GestureRecognizers.Add(new TapGestureRecognizer
         {
             Command = new Command(async () => await OpenDatePromptAsync())
         });
@@ -113,6 +113,7 @@ public class DatePickerField : InputField
         OnPropertyChanged(nameof(Date));
         CheckAndShowValidations();
         UpdateDateText();
+        UpdateDatePickerViewDate();
 
         if (AllowClear)
         {
@@ -146,6 +147,28 @@ public class DatePickerField : InputField
         {
             DateLabel.Text = Date?.ToString(Format, CultureInfo.CurrentCulture) ?? string.Empty;
         }
+    }
+
+    protected virtual void UpdateDatePickerViewDate()
+    {
+        var date = (Date ?? GetDatePickerViewFallbackDate()).Date;
+
+        if (MinimumDate.HasValue && date < MinimumDate.Value.Date)
+        {
+            date = MinimumDate.Value.Date;
+        }
+
+        if (MaximumDate.HasValue && date > MaximumDate.Value.Date)
+        {
+            date = MaximumDate.Value.Date;
+        }
+
+        DatePickerView.Date = date;
+    }
+
+    protected virtual DateTime GetDatePickerViewFallbackDate()
+    {
+        return DatePicker.DateProperty.DefaultValue is DateTime date ? date.Date : DateTime.Today;
     }
 
     protected virtual void UpdateClearIconState()
@@ -187,7 +210,12 @@ public class DatePickerField : InputField
     public static readonly BindableProperty MaximumDateProperty = BindableProperty.Create(
          nameof(MaximumDate), typeof(DateTime?), typeof(DatePickerField),
          defaultValue: null,
-         propertyChanged: (bindable, oldValue, newValue) => (bindable as DatePickerField).DatePickerView.MaximumDate = (DateTime)(newValue ?? DatePicker.MaximumDateProperty.DefaultValue)
+         propertyChanged: (bindable, oldValue, newValue) =>
+         {
+             var datePickerField = bindable as DatePickerField;
+             datePickerField.DatePickerView.MaximumDate = (DateTime)(newValue ?? DatePicker.MaximumDateProperty.DefaultValue);
+             datePickerField.UpdateDatePickerViewDate();
+         }
          );
 
     public DateTime? MinimumDate { get => (DateTime?)GetValue(MinimumDateProperty); set => SetValue(MinimumDateProperty, value); }
@@ -195,7 +223,12 @@ public class DatePickerField : InputField
     public static readonly BindableProperty MinimumDateProperty = BindableProperty.Create(
          nameof(MinimumDate), typeof(DateTime?), typeof(DatePickerField),
          defaultValue: null,
-         propertyChanged: (bindable, oldValue, newValue) => (bindable as DatePickerField).DatePickerView.MinimumDate = (DateTime)(newValue ?? DatePicker.MinimumDateProperty.DefaultValue)
+         propertyChanged: (bindable, oldValue, newValue) =>
+         {
+             var datePickerField = bindable as DatePickerField;
+             datePickerField.DatePickerView.MinimumDate = (DateTime)(newValue ?? DatePicker.MinimumDateProperty.DefaultValue);
+             datePickerField.UpdateDatePickerViewDate();
+         }
          );
 
     public string Format { get => (string)GetValue(FormatProperty); set => SetValue(FormatProperty, value); }

--- a/src/UraniumUI.Material/Controls/DatePickerField.cs
+++ b/src/UraniumUI.Material/Controls/DatePickerField.cs
@@ -29,6 +29,7 @@ public class DatePickerField : InputField
     public override View Content { get; set; } = new Label
     {
         VerticalOptions = LayoutOptions.Center,
+        VerticalTextAlignment = TextAlignment.Center,
         HorizontalOptions = LayoutOptions.Fill,
         LineBreakMode = LineBreakMode.TailTruncation,
         MinimumHeightRequest = 40,

--- a/src/UraniumUI.Material/Controls/DatePickerField.cs
+++ b/src/UraniumUI.Material/Controls/DatePickerField.cs
@@ -1,7 +1,8 @@
-﻿using Microsoft.Maui.Platform;
-using Plainer.Maui.Controls;
+﻿using Plainer.Maui.Controls;
 using System.ComponentModel;
+using System.Globalization;
 using UraniumUI.Controls;
+using UraniumUI.Dialogs;
 using UraniumUI.Pages;
 using UraniumUI.Resources;
 using UraniumUI.Views;
@@ -12,8 +13,9 @@ namespace UraniumUI.Material.Controls;
 [ContentProperty(nameof(Validations))]
 public class DatePickerField : InputField
 {
-    public DatePickerView DatePickerView => Content as DatePickerView;
-    public override View Content { get; set; } = new DatePickerView
+    private bool isDatePromptOpen;
+
+    public DatePickerView DatePickerView { get; } = new DatePickerView
     {
         VerticalOptions = LayoutOptions.Center,
 #if ANDROID
@@ -22,6 +24,16 @@ public class DatePickerField : InputField
         Margin = new Thickness(10, 0),
 #endif
         Opacity = 0,
+    };
+
+    public override View Content { get; set; } = new Label
+    {
+        VerticalOptions = LayoutOptions.Center,
+        HorizontalOptions = LayoutOptions.Fill,
+        LineBreakMode = LineBreakMode.TailTruncation,
+        MinimumHeightRequest = 40,
+        Margin = new Thickness(10, 0),
+        InputTransparent = true,
     };
 
     protected StatefulContentView iconClear = new StatefulContentView
@@ -39,65 +51,29 @@ public class DatePickerField : InputField
 
     public override bool HasValue => Date != null;
 
+    protected IDialogService DialogService { get; }
+
     public DatePickerField()
     {
         base.RegisterForEvents();
         iconClear.TappedCommand = new Command(OnClearTapped);
-#if WINDOWS
-        if (DatePickerView.Parent is Microsoft.Maui.Controls.ContentView cv)
-        {
-            cv.GestureRecognizers.Add(new TapGestureRecognizer
-            {
-                Command = new Command(OnContentTapped)
-            });
-            cv.BackgroundColor = Colors.Transparent; // Workaround for tap gesture recognizer
-        }
-#endif
-        UpdateClearIconState();
+        DialogService = UraniumServiceProvider.Current.GetRequiredService<IDialogService>();
 
-        DatePickerView.SetBinding(DatePicker.IsEnabledProperty, new Binding(nameof(IsEnabled), source: this));
-        DatePickerView.SetBinding(DatePicker.FontSizeProperty, new Binding(nameof(FontSize), source: this));
-        DatePickerView.SetBinding(DatePicker.FontAutoScalingEnabledProperty, new Binding(nameof(FontAutoScalingEnabled), source: this));
-        DatePickerView.SetBinding(DatePicker.FontFamilyProperty, new Binding(nameof(FontFamily), source: this));
-
-#if MACCATALYST || IOS
-        labelTitle.InputTransparent = true;
-        base.border.GestureRecognizers.Add(new TapGestureRecognizer
+        GestureRecognizers.Add(new TapGestureRecognizer
         {
-            Command = new Command(() =>
-            {
-#if MACCATALYST
-                if (!HasValue)
-                {
-                    Date = (DateTime)DatePicker.DateProperty.DefaultValue;
-                }
-#else
-                DatePickerView.Focus();
-#endif
-            })
+            Command = new Command(async () => await OpenDatePromptAsync())
         });
-#endif
+
+        UpdateClearIconState();
     }
 
-    protected override void OnHandlerChanging(HandlerChangingEventArgs args)
+    protected Label DateLabel => Content as Label;
+
+    protected override void OnApplyTemplate()
     {
-        base.OnHandlerChanging(args);
-
-        if (args.OldHandler is not null)
-        {
-            DatePickerView.DateSelected -= OnDateSelected;
-        }
-    }
-
-    protected override void OnHandlerChanged()
-    {
-        base.OnHandlerChanged();
-
-        if (Handler is not null)
-        {
-            DatePickerView.DateSelected -= OnDateSelected;
-            DatePickerView.DateSelected += OnDateSelected;
-        }
+        base.OnApplyTemplate();
+        UpdateClearIconState();
+        UpdateDateText();
     }
 
     protected override object GetValueForValidator()
@@ -109,54 +85,34 @@ public class DatePickerField : InputField
     {
         if (IsEnabled)
         {
-            // Workaround for the selecting the same date again:
-#if WINDOWS
-            if (DatePickerView.Handler?.PlatformView is Microsoft.UI.Xaml.Controls.CalendarDatePicker dp)
-            {
-                dp.Date = null;
-            }
-#elif ANDROID
-    #if NET10_0_OR_GREATER
-        // No workaround needed
-    #else
-        DatePickerView.Date = DatePickerView.Date.AddMonths(-1);
-    #endif
-#endif
-        // End of workaround
-        Date = null;
-
-#if MACCATALYST
-        DatePickerView.Unfocus();
-#endif
+            Date = null;
         }
     }
 
-    protected virtual void OnDateSelected(object sender, DateChangedEventArgs e)
+    protected virtual async Task OpenDatePromptAsync()
     {
-        Date = e.NewDate;
-    }
-
-#if WINDOWS
-    protected virtual void OnContentTapped(object parameter)
-    {
-        if (IsEnabled && DatePickerView.Handler is Microsoft.Maui.Handlers.IDatePickerHandler handler)
+        if (!IsEnabled || isDatePromptOpen)
         {
-            handler.PlatformView.IsCalendarOpen = true;
+            return;
+        }
+
+        try
+        {
+            isDatePromptOpen = true;
+            Date = await DialogService.DisplayDatePromptAsync(Title, Date, MinimumDate, MaximumDate);
+        }
+        finally
+        {
+            isDatePromptOpen = false;
         }
     }
-#endif
 
     protected virtual void OnDateChanged()
     {
         OnPropertyChanged(nameof(Date));
         CheckAndShowValidations();
+        UpdateDateText();
 
-        if (Date is DateTime date && DatePickerView.Date != date)
-        {
-            DatePickerView.Date = date;
-        }
-
-        DatePickerView.Opacity = Date == null ? 0 : 1;
         if (AllowClear)
         {
             iconClear.IsVisible = Date != null;
@@ -183,8 +139,21 @@ public class DatePickerField : InputField
         UpdateClearIconState();
     }
 
+    protected virtual void UpdateDateText()
+    {
+        if (DateLabel is not null)
+        {
+            DateLabel.Text = Date?.ToString(Format, CultureInfo.CurrentCulture) ?? string.Empty;
+        }
+    }
+
     protected virtual void UpdateClearIconState()
     {
+        if (endIconsContainer is null)
+        {
+            return;
+        }
+
         if (AllowClear)
         {
             if (!endIconsContainer.Contains(iconClear))
@@ -232,44 +201,79 @@ public class DatePickerField : InputField
 
     public static readonly BindableProperty FormatProperty = BindableProperty.Create(
             nameof(Format), typeof(string), typeof(DatePickerField), DatePicker.FormatProperty.DefaultValue,
-            propertyChanged: (bindable, oldValue, newValue) => (bindable as DatePickerField).DatePickerView.Format = (string)newValue);
+            propertyChanged: (bindable, oldValue, newValue) =>
+            {
+                var datePickerField = bindable as DatePickerField;
+                datePickerField.DatePickerView.Format = (string)newValue;
+                datePickerField.UpdateDateText();
+            });
 
     public Color TextColor { get => (Color)GetValue(TextColorProperty); set => SetValue(TextColorProperty, value); }
 
     public static readonly BindableProperty TextColorProperty = BindableProperty.Create(
         nameof(TextColor), typeof(Color), typeof(DatePickerField), DatePicker.TextColorProperty.DefaultValue,
-        propertyChanged: (bindable, oldValue, newValue) => (bindable as DatePickerField).DatePickerView.TextColor = (Color)newValue);
+        propertyChanged: (bindable, oldValue, newValue) =>
+        {
+            var datePickerField = bindable as DatePickerField;
+            datePickerField.DatePickerView.TextColor = (Color)newValue;
+            datePickerField.DateLabel?.SetValue(Label.TextColorProperty, newValue);
+        });
 
     public double CharacterSpacing { get => (double)GetValue(CharacterSpacingProperty); set => SetValue(CharacterSpacingProperty, value); }
 
     public static readonly BindableProperty CharacterSpacingProperty = BindableProperty.Create(
         nameof(CharacterSpacing), typeof(double), typeof(DatePickerField), DatePicker.CharacterSpacingProperty.DefaultValue,
-        propertyChanged: (bindable, oldValue, newValue) => (bindable as DatePickerField).DatePickerView.CharacterSpacing = (double)newValue);
+        propertyChanged: (bindable, oldValue, newValue) =>
+        {
+            var datePickerField = bindable as DatePickerField;
+            datePickerField.DatePickerView.CharacterSpacing = (double)newValue;
+            datePickerField.DateLabel?.SetValue(Label.CharacterSpacingProperty, newValue);
+        });
 
     public FontAttributes FontAttributes { get => (FontAttributes)GetValue(FontAttributesProperty); set => SetValue(FontAttributesProperty, value); }
 
     public static readonly BindableProperty FontAttributesProperty = BindableProperty.Create(
         nameof(FontAttributes), typeof(FontAttributes), typeof(DatePickerField), TimePicker.FontAttributesProperty.DefaultValue,
-        propertyChanged: (bindable, oldValue, newValue) => (bindable as DatePickerField).DatePickerView.FontAttributes = (FontAttributes)newValue);
+        propertyChanged: (bindable, oldValue, newValue) =>
+        {
+            var datePickerField = bindable as DatePickerField;
+            datePickerField.DatePickerView.FontAttributes = (FontAttributes)newValue;
+            datePickerField.DateLabel?.SetValue(Label.FontAttributesProperty, newValue);
+        });
 
     public string FontFamily { get => (string)GetValue(FontFamilyProperty); set => SetValue(FontFamilyProperty, value); }
 
     public static readonly BindableProperty FontFamilyProperty = BindableProperty.Create(
         nameof(FontFamily), typeof(string), typeof(DatePickerField), TimePicker.FontFamilyProperty.DefaultValue,
-        propertyChanged: (bindable, oldValue, newValue) => (bindable as DatePickerField).DatePickerView.FontFamily = (string)newValue);
+        propertyChanged: (bindable, oldValue, newValue) =>
+        {
+            var datePickerField = bindable as DatePickerField;
+            datePickerField.DatePickerView.FontFamily = (string)newValue;
+            datePickerField.DateLabel?.SetValue(Label.FontFamilyProperty, newValue);
+        });
 
     [TypeConverter(typeof(FontSizeConverter))]
     public double FontSize { get => (double)GetValue(FontSizeProperty); set => SetValue(FontSizeProperty, value); }
 
     public static readonly BindableProperty FontSizeProperty = BindableProperty.Create(
         nameof(FontSize), typeof(double), typeof(DatePickerField), TimePicker.FontSizeProperty.DefaultValue,
-        propertyChanged: (bindable, oldValue, newValue) => (bindable as DatePickerField).DatePickerView.FontSize = (double)newValue);
+        propertyChanged: (bindable, oldValue, newValue) =>
+        {
+            var datePickerField = bindable as DatePickerField;
+            datePickerField.DatePickerView.FontSize = (double)newValue;
+            datePickerField.DateLabel?.SetValue(Label.FontSizeProperty, newValue);
+        });
 
     public bool FontAutoScalingEnabled { get => (bool)GetValue(FontAutoScalingEnabledProperty); set => SetValue(FontAutoScalingEnabledProperty, value); }
 
     public static readonly BindableProperty FontAutoScalingEnabledProperty = BindableProperty.Create(
         nameof(FontAutoScalingEnabled), typeof(bool), typeof(DatePickerField), TimePicker.FontAutoScalingEnabledProperty.DefaultValue,
-        propertyChanged: (bindable, oldValue, newValue) => (bindable as DatePickerField).DatePickerView.FontAutoScalingEnabled = (bool)newValue);
+        propertyChanged: (bindable, oldValue, newValue) =>
+        {
+            var datePickerField = bindable as DatePickerField;
+            datePickerField.DatePickerView.FontAutoScalingEnabled = (bool)newValue;
+            datePickerField.DateLabel?.SetValue(Label.FontAutoScalingEnabledProperty, newValue);
+        });
     public bool AllowClear { get => (bool)GetValue(AllowClearProperty); set => SetValue(AllowClearProperty, value); }
 
     public static BindableProperty AllowClearProperty = BindableProperty.Create(

--- a/test/UraniumUI.Material.Tests/Controls/DatePickerField_Test.cs
+++ b/test/UraniumUI.Material.Tests/Controls/DatePickerField_Test.cs
@@ -132,6 +132,15 @@ public class DatePickerField_Test
     }
 
     [Fact]
+    public void DateLabel_ShouldCenterTextVertically()
+    {
+        var control = AnimationReadyHandler.Prepare(new DatePickerField());
+
+        // Assert
+        ((Label)control.Content).VerticalTextAlignment.ShouldBe(TextAlignment.Center);
+    }
+
+    [Fact]
     public async Task DatePrompt_ShouldUpdateDate_WhenDialogReturnsDate()
     {
         var dialogService = UseMockDialogService();

--- a/test/UraniumUI.Material.Tests/Controls/DatePickerField_Test.cs
+++ b/test/UraniumUI.Material.Tests/Controls/DatePickerField_Test.cs
@@ -118,6 +118,19 @@ public class DatePickerField_Test
     }
 
     [Fact]
+    public void Clear_ShouldResetDatePickerViewDate()
+    {
+        var fallbackDate = DateTime.Today;
+        var control = AnimationReadyHandler.Prepare(new TestDatePickerField { Date = fallbackDate.AddDays(7) });
+
+        // Act
+        control.Clear();
+
+        // Assert
+        control.DatePickerView.Date.ShouldBe(fallbackDate);
+    }
+
+    [Fact]
     public void Date_ShouldUpdateDisplayText()
     {
         var control = AnimationReadyHandler.Prepare(new DatePickerField());
@@ -132,12 +145,37 @@ public class DatePickerField_Test
     }
 
     [Fact]
+    public void Date_ShouldUpdateDatePickerViewDate()
+    {
+        var control = AnimationReadyHandler.Prepare(new DatePickerField());
+        var date = DateTime.Today.AddDays(2);
+
+        // Act
+        control.Date = date;
+
+        // Assert
+        control.DatePickerView.Date.ShouldBe(date.Date);
+    }
+
+    [Fact]
     public void DateLabel_ShouldCenterTextVertically()
     {
         var control = AnimationReadyHandler.Prepare(new DatePickerField());
 
         // Assert
         ((Label)control.Content).VerticalTextAlignment.ShouldBe(TextAlignment.Center);
+    }
+
+    [Fact]
+    public void DateLabel_ShouldOwnPromptTapGesture()
+    {
+        var control = AnimationReadyHandler.Prepare(new DatePickerField());
+        var dateLabel = (Label)control.Content;
+
+        // Assert
+        control.GestureRecognizers.ShouldBeEmpty();
+        dateLabel.InputTransparent.ShouldBeFalse();
+        dateLabel.GestureRecognizers.Count.ShouldBe(1);
     }
 
     [Fact]

--- a/test/UraniumUI.Material.Tests/Controls/DatePickerField_Test.cs
+++ b/test/UraniumUI.Material.Tests/Controls/DatePickerField_Test.cs
@@ -1,6 +1,9 @@
 ﻿using Shouldly;
 using UraniumUI.Material.Controls;
+using UraniumUI.Material.Tests.Mocks;
+using UraniumUI.Dialogs;
 using UraniumUI.Tests.Core;
+using System.Globalization;
 
 namespace UraniumUI.Material.Tests.Controls;
 public class DatePickerField_Test
@@ -115,16 +118,115 @@ public class DatePickerField_Test
     }
 
     [Fact]
-    public void DatePickerView_DateSelected_ShouldUpdateDate()
+    public void Date_ShouldUpdateDisplayText()
     {
         var control = AnimationReadyHandler.Prepare(new DatePickerField());
         var date = DateTime.Today.AddDays(2);
 
         // Act
-        control.DatePickerView.Date = date;
+        control.Date = date;
 
         // Assert
         control.Date.ShouldBe(date);
+        ((Label)control.Content).Text.ShouldBe(date.ToString(control.Format, CultureInfo.CurrentCulture));
+    }
+
+    [Fact]
+    public async Task DatePrompt_ShouldUpdateDate_WhenDialogReturnsDate()
+    {
+        var dialogService = UseMockDialogService();
+        var selectedDate = new DateTime(2026, 6, 2);
+        dialogService.UseDatePromptResult = true;
+        dialogService.DatePromptResult = selectedDate;
+        var control = AnimationReadyHandler.Prepare(new TestDatePickerField());
+        control.Title = "Birth Date";
+
+        // Act
+        await control.OpenPromptAsync();
+
+        // Assert
+        control.Date.ShouldBe(selectedDate);
+        ((Label)control.Content).Text.ShouldBe(selectedDate.ToString(control.Format, CultureInfo.CurrentCulture));
+    }
+
+    [Fact]
+    public async Task DatePrompt_ShouldPassSelectedDateAndMinMax()
+    {
+        var dialogService = UseMockDialogService();
+        var selectedDate = new DateTime(2026, 6, 2, 13, 45, 0);
+        var minimumDate = new DateTime(2026, 1, 1);
+        var maximumDate = new DateTime(2026, 12, 31);
+        var control = AnimationReadyHandler.Prepare(new TestDatePickerField
+        {
+            Date = selectedDate,
+            MinimumDate = minimumDate,
+            MaximumDate = maximumDate,
+        });
+        control.Title = "Travel Date";
+
+        // Act
+        await control.OpenPromptAsync();
+
+        // Assert
+        dialogService.DatePromptCallCount.ShouldBe(1);
+        dialogService.DatePromptTitle.ShouldBe("Travel Date");
+        dialogService.DatePromptSelectedDate.ShouldBe(selectedDate);
+        dialogService.DatePromptMinimumDate.ShouldBe(minimumDate);
+        dialogService.DatePromptMaximumDate.ShouldBe(maximumDate);
+        control.Date.ShouldBe(selectedDate);
+    }
+
+    [Fact]
+    public async Task DatePrompt_ShouldClearDate_WhenDialogReturnsNull()
+    {
+        var dialogService = UseMockDialogService();
+        dialogService.UseDatePromptResult = true;
+        dialogService.DatePromptResult = null;
+        var control = AnimationReadyHandler.Prepare(new TestDatePickerField { Date = DateTime.Today });
+
+        // Act
+        await control.OpenPromptAsync();
+
+        // Assert
+        control.Date.ShouldBeNull();
+        control.HasValue.ShouldBeFalse();
+    }
+
+    [Fact]
+    public async Task DatePrompt_ShouldNotOpen_WhenDisabled()
+    {
+        var dialogService = UseMockDialogService();
+        var originalDate = DateTime.Today;
+        var control = AnimationReadyHandler.Prepare(new TestDatePickerField
+        {
+            Date = originalDate,
+            IsEnabled = false,
+        });
+
+        // Act
+        await control.OpenPromptAsync();
+
+        // Assert
+        dialogService.DatePromptCallCount.ShouldBe(0);
+        control.Date.ShouldBe(originalDate);
+    }
+
+    [Fact]
+    public async Task DatePrompt_ShouldSelectSameDateAfterClear()
+    {
+        var dialogService = UseMockDialogService();
+        var selectedDate = DateTime.Today;
+        dialogService.UseDatePromptResult = true;
+        dialogService.DatePromptResult = selectedDate;
+        var control = AnimationReadyHandler.Prepare(new TestDatePickerField { Date = selectedDate });
+
+        // Act
+        control.Clear();
+        await control.OpenPromptAsync();
+
+        // Assert
+        control.Date.ShouldBe(selectedDate);
+        control.HasValue.ShouldBeTrue();
     }
 
     [Fact]
@@ -309,10 +411,26 @@ public class DatePickerField_Test
 
     private class TestDatePickerField : DatePickerField
     {
+        public Task OpenPromptAsync()
+        {
+            return OpenDatePromptAsync();
+        }
+
         public void Clear()
         {
             OnClearTapped(this);
         }
+    }
+
+    private static MockDialogService UseMockDialogService()
+    {
+        var dialogService = new MockDialogService();
+        ApplicationExtensions.CreateAndSetMockApplication(builder =>
+        {
+            builder.Services.AddSingleton<IDialogService>(dialogService);
+        });
+
+        return dialogService;
     }
 
     private class NonNullableDateViewModel : UraniumBindableObject

--- a/test/UraniumUI.Material.Tests/Mocks/MockDialogService.cs
+++ b/test/UraniumUI.Material.Tests/Mocks/MockDialogService.cs
@@ -4,6 +4,20 @@ using UraniumUI.Infrastructure;
 namespace UraniumUI.Material.Tests.Mocks;
 internal class MockDialogService : IDialogService
 {
+    public bool UseDatePromptResult { get; set; }
+
+    public DateTime? DatePromptResult { get; set; }
+
+    public int DatePromptCallCount { get; private set; }
+
+    public string DatePromptTitle { get; private set; }
+
+    public DateTime? DatePromptSelectedDate { get; private set; }
+
+    public DateTime? DatePromptMinimumDate { get; private set; }
+
+    public DateTime? DatePromptMaximumDate { get; private set; }
+
     public Task<bool> ConfirmAsync(string title, string message, string okText = "OK", string cancelText = "Cancel")
     {
         return Task.FromResult(default(bool));
@@ -49,7 +63,13 @@ internal class MockDialogService : IDialogService
         string clear = "Clear",
         string today = "Today")
     {
-        return Task.FromResult(selectedDate);
+        DatePromptCallCount++;
+        DatePromptTitle = title;
+        DatePromptSelectedDate = selectedDate;
+        DatePromptMinimumDate = minimumDate;
+        DatePromptMaximumDate = maximumDate;
+
+        return Task.FromResult(UseDatePromptResult ? DatePromptResult : selectedDate);
     }
 
     public Task DisplayViewAsync(string title, View content, string okText = "OK")


### PR DESCRIPTION
## Summary

- Migrate `DatePickerField` from native picker interaction to the shared CalendarView-backed `IDialogService.DisplayDatePromptAsync(...)` flow.
- Keep the existing `DatePickerView` compatibility/styling object while rendering the selected date through a centered label.
- Preserve nullable date behavior, clear support, disabled prompt behavior, same-date reselection after clear, and min/max forwarding.
- Update the DatePickerField demo/docs to describe the CalendarView-backed prompt.

<img width="519" height="748" alt="datepicker-new" src="https://github.com/user-attachments/assets/d9b8d103-6557-4425-bd61-99577927c545" />



## Validation

- `dotnet test test/UraniumUI.Tests/UraniumUI.Tests.csproj --no-restore`
- `dotnet test test/UraniumUI.Material.Tests/UraniumUI.Material.Tests.csproj --no-restore`
- `dotnet build src/UraniumUI.Material/UraniumUI.Material.csproj -f net10.0-windows10.0.19041.0 --no-restore`
- `dotnet build src/UraniumUI.Material/UraniumUI.Material.csproj -f net10.0-android --no-restore`
- `dotnet build demo/UraniumApp/UraniumApp.csproj -f net10.0-windows10.0.19041.0 --no-restore`
- `dotnet build demo/UraniumApp/UraniumApp.csproj -f net10.0-android --no-restore`
