### PR TITLE
Fix picker-family clear icon padding

### DIFF
--- a/src/UraniumUI.Material/Controls/AutoCompleteTextField.cs
+++ b/src/UraniumUI.Material/Controls/AutoCompleteTextField.cs
@@ -24,7 +24,7 @@ public class AutoCompleteTextField : InputField
         VerticalOptions = LayoutOptions.Center,
         HorizontalOptions = LayoutOptions.End,
         IsVisible = false,
-        Padding = 10,
+        Padding = new Thickness(InputField.BuiltInAttachmentLeftPadding, 0, 0, 0),
         Content = new Path
         {
             Data = UraniumShapes.X,

--- a/src/UraniumUI.Material/Controls/DatePickerField.cs
+++ b/src/UraniumUI.Material/Controls/DatePickerField.cs
@@ -42,7 +42,7 @@ public class DatePickerField : InputField
         VerticalOptions = LayoutOptions.Center,
         HorizontalOptions = LayoutOptions.End,
         IsVisible = false,
-        Padding = 10,
+        Padding = new Thickness(InputField.BuiltInAttachmentLeftPadding, 0, 0, 0),
         Content = new Path
         {
             Data = UraniumShapes.X,

--- a/src/UraniumUI.Material/Controls/DropdownField.cs
+++ b/src/UraniumUI.Material/Controls/DropdownField.cs
@@ -28,7 +28,7 @@ public class DropdownField : InputField
         VerticalOptions = LayoutOptions.Center,
         HorizontalOptions = LayoutOptions.End,
         IsVisible = false,
-        Padding = 10,
+        Padding = new Thickness(InputField.BuiltInAttachmentLeftPadding, 0, 0, 0),
         Content = new Path
         {
             Data = UraniumShapes.X,

--- a/src/UraniumUI.Material/Controls/PickerField.cs
+++ b/src/UraniumUI.Material/Controls/PickerField.cs
@@ -231,7 +231,7 @@ public class PickerField : InputField
             VerticalOptions = LayoutOptions.Center,
             HorizontalOptions = LayoutOptions.End,
             IsVisible = false,
-            Padding = 10,
+            Padding = new Thickness(InputField.BuiltInAttachmentLeftPadding, 0, 0, 0),
             TappedCommand = new Command(OnClearTapped),
             ControlTemplate = clearIconPathControlTemplate
         };

--- a/src/UraniumUI.Material/Controls/TimePickerField.cs
+++ b/src/UraniumUI.Material/Controls/TimePickerField.cs
@@ -33,7 +33,7 @@ public class TimePickerField : InputField
         VerticalOptions = LayoutOptions.Center,
         HorizontalOptions = LayoutOptions.End,
         IsVisible = false,
-        Padding = 10,
+        Padding = new Thickness(InputField.BuiltInAttachmentLeftPadding, 0, 0, 0),
         Content = new Path
         {
             Data = UraniumShapes.X,

--- a/test/UraniumUI.Material.Tests/Controls/AutoCompleteTextField_Test.cs
+++ b/test/UraniumUI.Material.Tests/Controls/AutoCompleteTextField_Test.cs
@@ -52,6 +52,19 @@ public class AutoCompleteTextField_Test
         viewModel.Text.ShouldBe(control.Text);
     }
 
+    [Fact]
+    public void ClearIcon_HasAsymmetricLeftHitPadding()
+    {
+        var control = AnimationReadyHandler.Prepare(new AutoCompleteTextField());
+
+        control.AllowClear = true;
+
+        var clearIcon = control.Attachments.OfType<ContentView>().Single();
+
+        clearIcon.Margin.ShouldBe(default(Thickness));
+        clearIcon.Padding.ShouldBe(new Thickness(InputField.BuiltInAttachmentLeftPadding, 0, 0, 0));
+    }
+
     internal class AutoCompleteTextFieldTestViewModel : UraniumBindableObject
     {
         private string text;

--- a/test/UraniumUI.Material.Tests/Controls/DatePickerField_Test.cs
+++ b/test/UraniumUI.Material.Tests/Controls/DatePickerField_Test.cs
@@ -3,6 +3,7 @@ using UraniumUI.Material.Controls;
 using UraniumUI.Material.Tests.Mocks;
 using UraniumUI.Dialogs;
 using UraniumUI.Tests.Core;
+using UraniumUI.Views;
 using System.Globalization;
 
 namespace UraniumUI.Material.Tests.Controls;
@@ -176,6 +177,16 @@ public class DatePickerField_Test
         control.GestureRecognizers.ShouldBeEmpty();
         dateLabel.InputTransparent.ShouldBeFalse();
         dateLabel.GestureRecognizers.Count.ShouldBe(1);
+    }
+
+    [Fact]
+    public void ClearIcon_HasAsymmetricLeftHitPadding()
+    {
+        var control = AnimationReadyHandler.Prepare(new DatePickerField { AllowClear = true });
+        var clearIcon = control.Attachments.OfType<StatefulContentView>().Single();
+
+        clearIcon.Margin.ShouldBe(default(Thickness));
+        clearIcon.Padding.ShouldBe(new Thickness(InputField.BuiltInAttachmentLeftPadding, 0, 0, 0));
     }
 
     [Fact]

--- a/test/UraniumUI.Material.Tests/Controls/DropdownField_Test.cs
+++ b/test/UraniumUI.Material.Tests/Controls/DropdownField_Test.cs
@@ -1,0 +1,27 @@
+using Shouldly;
+using UraniumUI.Material.Controls;
+using UraniumUI.Tests.Core;
+using UraniumUI.Views;
+
+namespace UraniumUI.Material.Tests.Controls;
+
+public class DropdownField_Test
+{
+    public DropdownField_Test()
+    {
+        ApplicationExtensions.CreateAndSetMockApplication();
+    }
+
+    [Fact]
+    public void ClearIcon_HasAsymmetricLeftHitPadding()
+    {
+        var control = AnimationReadyHandler.Prepare(new DropdownField());
+
+        control.AllowClear = true;
+
+        var clearIcon = control.Attachments.OfType<StatefulContentView>().Single();
+
+        clearIcon.Margin.ShouldBe(default(Thickness));
+        clearIcon.Padding.ShouldBe(new Thickness(InputField.BuiltInAttachmentLeftPadding, 0, 0, 0));
+    }
+}

--- a/test/UraniumUI.Material.Tests/Controls/PickerField_Test.cs
+++ b/test/UraniumUI.Material.Tests/Controls/PickerField_Test.cs
@@ -288,6 +288,17 @@ public class PickerField_Test
         clearIcon.ShouldNotBeNull();
     }
 
+    [Fact]
+    public void ClearIcon_HasAsymmetricLeftHitPadding()
+    {
+        var control = AnimationReadyHandler.Prepare(new PickerField { AllowClear = true });
+        var clearIcon = control.FindByViewQueryIdInVisualTreeDescendants<StatefulContentView>("ClearIcon");
+
+        clearIcon.ShouldNotBeNull();
+        clearIcon.Margin.ShouldBe(default(Thickness));
+        clearIcon.Padding.ShouldBe(new Thickness(InputField.BuiltInAttachmentLeftPadding, 0, 0, 0));
+    }
+
     public class TestViewModel : UraniumBindableObject
     {
         private object selectedItem;

--- a/test/UraniumUI.Material.Tests/Controls/TextField_Test.cs
+++ b/test/UraniumUI.Material.Tests/Controls/TextField_Test.cs
@@ -127,7 +127,7 @@ public class TextField_Test
 
         clearIcon.ShouldNotBeNull();
         clearIcon.Margin.ShouldBe(default(Thickness));
-        clearIcon.Padding.ShouldBe(new Thickness(5, 0, 0, 0));
+        clearIcon.Padding.ShouldBe(new Thickness(InputField.BuiltInAttachmentLeftPadding, 0, 0, 0));
     }
   
     [Fact]

--- a/test/UraniumUI.Material.Tests/Controls/TimePickerField_Test.cs
+++ b/test/UraniumUI.Material.Tests/Controls/TimePickerField_Test.cs
@@ -1,6 +1,7 @@
 ﻿using Shouldly;
 using UraniumUI.Material.Controls;
 using UraniumUI.Tests.Core;
+using UraniumUI.Views;
 
 namespace UraniumUI.Material.Tests.Controls;
 public class TimePickerField_Test
@@ -179,6 +180,16 @@ public class TimePickerField_Test
 
         // Assert
         control.TimePickerView.FontSize.ShouldBe(fontSize);
+    }
+
+    [Fact]
+    public void ClearIcon_HasAsymmetricLeftHitPadding()
+    {
+        var control = AnimationReadyHandler.Prepare(new TimePickerField { AllowClear = true });
+        var clearIcon = control.Attachments.OfType<StatefulContentView>().Single();
+
+        clearIcon.Margin.ShouldBe(default(Thickness));
+        clearIcon.Padding.ShouldBe(new Thickness(InputField.BuiltInAttachmentLeftPadding, 0, 0, 0));
     }
 
     public class TestViewModel : UraniumBindableObject


### PR DESCRIPTION
## Summary
- align picker-family clear icons with the shared InputField built-in attachment padding
- replace uniform 10px clear-icon padding in dropdown, date picker, time picker, picker, and autocomplete fields
- add material tests guarding clear-icon padding across the affected controls

## Automated Testing
- `dotnet test test/UraniumUI.Material.Tests/UraniumUI.Material.Tests.csproj --no-restore`

Closes #1008
