### PR TITLE
Stabilize blur platform effects

### DIFF
--- a/src/UraniumUI.Blurs/BlurEffect.cs
+++ b/src/UraniumUI.Blurs/BlurEffect.cs
@@ -13,6 +13,8 @@ public class BlurEffect : RoutingEffect
 
     public float AccentOpacity { get => accentOpacity; set { accentOpacity = value; UpdateEffectCommand?.Execute(this); } }
 
+    internal float EffectiveAccentOpacity => Math.Clamp(AccentOpacity, 0f, 1f);
+
     internal ICommand UpdateEffectCommand { get; set; }
 
     public BlurEffect()

--- a/src/UraniumUI.Blurs/BlurPlatformEffect.Android.cs
+++ b/src/UraniumUI.Blurs/BlurPlatformEffect.Android.cs
@@ -3,7 +3,6 @@ using Android.Content;
 using Android.Graphics.Drawables;
 using Android.Views;
 using Android.Widget;
-using Microsoft.Maui.Controls.Compatibility.Platform.Android;
 using Microsoft.Maui.Controls.Platform;
 using Microsoft.Maui.Platform;
 using Color = Android.Graphics.Color;
@@ -15,6 +14,9 @@ public class BlurPlatformEffect : PlatformEffect
 
     private BlurView _blurView;
     private GradientDrawable _mainDrawable;
+    private Drawable _originalBackground;
+    private ViewGroup _blurRoot;
+    private Command _updateEffectCommand;
 
     public BlurEffect VirtualEffect { get; private set; }
 
@@ -23,11 +25,8 @@ public class BlurPlatformEffect : PlatformEffect
         if (Element.Effects.FirstOrDefault(x => x.ResolveId == this.ResolveId) is BlurEffect blurEffect)
         {
             VirtualEffect = blurEffect;
-            blurEffect.UpdateEffectCommand = new Command(() =>
-            {
-                _blurView.SetBackgroundColor(GetColor());
-                //AlignBlurView();
-            });
+            _updateEffectCommand = new Command(UpdateEffect);
+            blurEffect.UpdateEffectCommand = _updateEffectCommand;
         }
 
         if (Element is Microsoft.Maui.Controls.View view)
@@ -47,7 +46,23 @@ public class BlurPlatformEffect : PlatformEffect
             view.ParentChanged -= View_ParentChanged;
         }
 
-        //TODO: Release drawable
+        if (VirtualEffect?.UpdateEffectCommand == _updateEffectCommand)
+        {
+            VirtualEffect.UpdateEffectCommand = null;
+        }
+
+        ReleaseBlurView();
+
+        if (_mainDrawable != null)
+        {
+            Control.Background = _originalBackground;
+            _mainDrawable.Dispose();
+            _mainDrawable = null;
+            _originalBackground = null;
+        }
+
+        _updateEffectCommand = null;
+        VirtualEffect = null;
     }
 
     private void BlurPlatformEffect_SizeChanged(object sender, EventArgs e)
@@ -62,10 +77,11 @@ public class BlurPlatformEffect : PlatformEffect
 
     protected void UpdateEffect()
     {
-        if (Control is ViewGroup viewGroup)
+        if (Control is ViewGroup viewGroup && Context != null)
         {
             if (_mainDrawable == null)
             {
+                _originalBackground = Control.Background;
                 _mainDrawable = new GradientDrawable();
                 _mainDrawable.SetColor(Colors.Transparent.ToPlatform());
                 Control.Background = _mainDrawable;
@@ -74,73 +90,105 @@ public class BlurPlatformEffect : PlatformEffect
             if (_blurView == null)
             {
                 _blurView = new BlurView(Context);
+                _blurView.SetOverlayColor(Color.Transparent);
+            }
 
-                //var child = viewGroup.GetChildAt(0) ?? new Android.Views.View(Context);
-                //child.RemoveFromParent();
-                //_blurView.AddView(child);
-
-                while (viewGroup.GetChildAt(0) != null)
+            if (_blurView.Parent != viewGroup)
+            {
+                if (_blurView.Parent is ViewGroup previousParent)
                 {
-                    var child = viewGroup.GetChildAt(0);
-                    child.RemoveFromParent();
-                    _blurView.AddView(child);
+                    previousParent.RemoveView(_blurView);
                 }
 
                 viewGroup.AddView(_blurView, 0, new FrameLayout.LayoutParams(
-                        ViewGroup.LayoutParams.FillParent,
-                        ViewGroup.LayoutParams.FillParent,
-                        GravityFlags.NoGravity));
-
-                _blurView.SetOverlayColor(Color.Transparent);
-                AlignBlurView();
+                    ViewGroup.LayoutParams.MatchParent,
+                    ViewGroup.LayoutParams.MatchParent,
+                    GravityFlags.NoGravity));
             }
 
-            var decorView = Microsoft.Maui.ApplicationModel.Platform.CurrentActivity.Window.DecorView;
-            var root = decorView.FindViewById(global::Android.Resource.Id.Content) as global::Android.Views.ViewGroup;
-            var windowBackground = decorView.Background;
+            AlignBlurView();
 
             _blurView.SetBackgroundColor(GetColor());
 
-            _blurView
-               .SetupWith(root as global::Android.Views.ViewGroup, new RenderScriptBlur(Context))
-               .SetFrameClearDrawable(windowBackground) // Optional
-               .SetBlurRadius(24f);
+            var decorView = Microsoft.Maui.ApplicationModel.Platform.CurrentActivity?.Window?.DecorView;
+            var root = decorView?.FindViewById(global::Android.Resource.Id.Content) as ViewGroup;
+            if (root == null)
+            {
+                _blurView.Release();
+                _blurRoot = null;
+                return;
+            }
+
+            if (_blurRoot != root)
+            {
+                _blurRoot = root;
+                _blurView
+                   .SetupWith(root)
+                   .SetFrameClearDrawable(decorView.Background)
+                   .SetBlurRadius(24f);
+            }
         }
         else
         {
-            // Not supported for Standalone Views.
+            ReleaseBlurView();
         }
     }
 
     protected Android.Graphics.Color GetColor()
     {
+        var accentOpacity = VirtualEffect?.EffectiveAccentOpacity ?? .2f;
+
         if (VirtualEffect?.AccentColor != null && VirtualEffect.AccentColor.IsNotDefault())
         {
-            return VirtualEffect.AccentColor.WithAlpha(VirtualEffect.AccentOpacity).ToPlatform();
+            return VirtualEffect.AccentColor.WithAlpha(accentOpacity).ToPlatform();
         }
 
         return VirtualEffect?.Mode == BlurMode.Dark
-            ? Colors.Black.WithAlpha(VirtualEffect.AccentOpacity).ToPlatform()
-            : Colors.White.WithAlpha(VirtualEffect.AccentOpacity).ToPlatform();
+            ? Colors.Black.WithAlpha(accentOpacity).ToPlatform()
+            : Colors.White.WithAlpha(accentOpacity).ToPlatform();
+    }
+
+    private void ReleaseBlurView()
+    {
+        if (_blurView == null)
+        {
+            _blurRoot = null;
+            return;
+        }
+
+        _blurView.Release();
+
+        if (_blurView.Parent is ViewGroup parent)
+        {
+            parent.RemoveView(_blurView);
+        }
+
+        _blurView.Dispose();
+        _blurView = null;
+        _blurRoot = null;
     }
 
     private void AlignBlurView()
     {
         var PlatformView = Control;
 
-        //if (PlatformView.MeasuredWidth == 0 || PlatformView.MeasuredHeight == 0 || _blurView == null)
-        //{
-        //    return;
-        //}       
-        if (_blurView == null)
+        if (PlatformView == null || _blurView == null)
         {
             return;
         }
 
         int width = PlatformView.MeasuredWidth;
         int height = PlatformView.MeasuredHeight;
-        _blurView.Measure(width, height);
+        if (width <= 0 || height <= 0)
+        {
+            return;
+        }
+
+        _blurView.Measure(
+            Android.Views.View.MeasureSpec.MakeMeasureSpec(width, MeasureSpecMode.Exactly),
+            Android.Views.View.MeasureSpec.MakeMeasureSpec(height, MeasureSpecMode.Exactly));
         _blurView.Layout(0, 0, width, height);
+        _blurView.UpdateBlurViewSize();
     }
 }
 

--- a/src/UraniumUI.Blurs/BlurPlatformEffect.Apple.cs
+++ b/src/UraniumUI.Blurs/BlurPlatformEffect.Apple.cs
@@ -10,6 +10,8 @@ public class BlurPlatformEffect : PlatformEffect
     public BlurEffect VirtualEffect { get; private set; }
 
     protected UIVisualEffectView blurView;
+    private UIColor originalBackgroundColor;
+    private Command updateEffectCommand;
 
     protected override void OnAttached()
     {
@@ -18,9 +20,11 @@ public class BlurPlatformEffect : PlatformEffect
         if (Element.Effects.FirstOrDefault(x => x.ResolveId == this.ResolveId) is BlurEffect _effect)
         {
             VirtualEffect = _effect;
-            _effect.UpdateEffectCommand = new Command(UpdateEffect);
+            updateEffectCommand = new Command(UpdateEffect);
+            _effect.UpdateEffectCommand = updateEffectCommand;
         }
 
+        originalBackgroundColor = Control.BackgroundColor;
         Control.BackgroundColor = UIColor.Clear;
 
         blurView = new UIVisualEffectView();
@@ -40,26 +44,46 @@ public class BlurPlatformEffect : PlatformEffect
 
     protected override void OnDetached()
     {
-        Control.Subviews.FirstOrDefault(x => x is UIVisualEffectView)?.RemoveFromSuperview();
+        if (VirtualEffect?.UpdateEffectCommand == updateEffectCommand)
+        {
+            VirtualEffect.UpdateEffectCommand = null;
+        }
+
+        blurView?.RemoveFromSuperview();
+        blurView?.Dispose();
+        blurView = null;
+
+        Control.BackgroundColor = originalBackgroundColor;
+        originalBackgroundColor = null;
+        updateEffectCommand = null;
+        VirtualEffect = null;
     }
 
     protected override void OnElementPropertyChanged(PropertyChangedEventArgs args)
     {
         base.OnElementPropertyChanged(args);
-        if (args.PropertyName == nameof(View.BackgroundColorProperty.PropertyName))
+        if (args.PropertyName == View.BackgroundColorProperty.PropertyName && this.Element is View view)
         {
-            Control.BackgroundColor = (this.Element as View).BackgroundColor.WithAlpha(.2f).ToPlatform();
+            Control.BackgroundColor = view.BackgroundColor?.WithAlpha(VirtualEffect?.EffectiveAccentOpacity ?? .2f).ToPlatform() ?? UIColor.Clear;
         }
     }
 
     protected void UpdateEffect()
     {
+        if (blurView == null)
+        {
+            return;
+        }
+
+        var accentOpacity = VirtualEffect?.EffectiveAccentOpacity ?? .2f;
+
         if (VirtualEffect?.AccentColor != null && VirtualEffect.AccentColor.IsNotDefault())
         {
-            if (this.Element is View view)
-            {
-                Control.BackgroundColor = VirtualEffect.AccentColor.WithAlpha(VirtualEffect.AccentOpacity).ToPlatform();
-            }
+            Control.BackgroundColor = VirtualEffect.AccentColor.WithAlpha(accentOpacity).ToPlatform();
+        }
+        else
+        {
+            Control.BackgroundColor = UIColor.Clear;
         }
 
         blurView.Effect = VirtualEffect?.Mode == BlurMode.Dark ?

--- a/src/UraniumUI.Blurs/BlurPlatformEffect.Windows.cs
+++ b/src/UraniumUI.Blurs/BlurPlatformEffect.Windows.cs
@@ -4,17 +4,27 @@ using Microsoft.Maui.Platform;
 using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Xaml.Media;
 using Microsoft.Maui.Controls.Platform;
+using WinBrush = Microsoft.UI.Xaml.Media.Brush;
 
 namespace UraniumUI.Blurs;
 public class BlurPlatformEffect : PlatformEffect
 {
     public BlurEffect VirtualEffect { get; private set; }
+    private Command updateEffectCommand;
+    private WinBrush originalControlBackground;
+    private WinBrush originalPanelBackground;
+    private WinBrush originalBorderBackground;
+    private bool hasOriginalControlBackground;
+    private bool hasOriginalPanelBackground;
+    private bool hasOriginalBorderBackground;
+
     protected override void OnAttached()
     {
         if (Element.Effects.FirstOrDefault(x => x.ResolveId == this.ResolveId) is BlurEffect blurEffect)
         {
             VirtualEffect = blurEffect;
-            blurEffect.UpdateEffectCommand = new Command(UpdateEffect);
+            updateEffectCommand = new Command(UpdateEffect);
+            blurEffect.UpdateEffectCommand = updateEffectCommand;
         }
 
         UpdateEffect();
@@ -24,28 +34,48 @@ public class BlurPlatformEffect : PlatformEffect
     {
         if (Control is Control control)
         {
+            if (!hasOriginalControlBackground)
+            {
+                originalControlBackground = control.Background;
+                hasOriginalControlBackground = true;
+            }
+
             control.Background = GetBrush();
         }
 
         if (Control is Panel panel)
         {
+            if (!hasOriginalPanelBackground)
+            {
+                originalPanelBackground = panel.Background;
+                hasOriginalPanelBackground = true;
+            }
+
             panel.Background = GetBrush();
         }
 
         if (Control is Microsoft.UI.Xaml.Controls.Border border)
         {
+            if (!hasOriginalBorderBackground)
+            {
+                originalBorderBackground = border.Background;
+                hasOriginalBorderBackground = true;
+            }
+
             border.Background = GetBrush();
         }
     }
 
     protected AcrylicBrush GetBrush()
     {
+        var accentOpacity = VirtualEffect?.EffectiveAccentOpacity ?? .2f;
+
         if (VirtualEffect?.AccentColor != null && VirtualEffect.AccentColor.IsNotDefault())
         {
             return new AcrylicBrush
             {
                 TintColor = VirtualEffect.AccentColor.ToWindowsColor(),
-                TintOpacity =  VirtualEffect.AccentOpacity,
+                TintOpacity =  accentOpacity,
                 TintLuminosityOpacity = .4
             };
         }
@@ -53,22 +83,41 @@ public class BlurPlatformEffect : PlatformEffect
         return new AcrylicBrush
         {
             TintColor = VirtualEffect?.Mode == BlurMode.Dark ? Colors.Black.ToWindowsColor() : Colors.DimGray.ToWindowsColor(),
-            TintOpacity = VirtualEffect.AccentOpacity,
+            TintOpacity = accentOpacity,
             TintLuminosityOpacity = .4
         };
     }
 
     protected override void OnDetached()
     {
+        if (VirtualEffect?.UpdateEffectCommand == updateEffectCommand)
+        {
+            VirtualEffect.UpdateEffectCommand = null;
+        }
+
         if (Control is Control control)
         {
-            control.Background = null;
+            control.Background = hasOriginalControlBackground ? originalControlBackground : null;
         }
 
         if (Control is Panel panel)
         {
-            panel.Background = null;
+            panel.Background = hasOriginalPanelBackground ? originalPanelBackground : null;
         }
+
+        if (Control is Microsoft.UI.Xaml.Controls.Border border)
+        {
+            border.Background = hasOriginalBorderBackground ? originalBorderBackground : null;
+        }
+
+        updateEffectCommand = null;
+        originalControlBackground = null;
+        originalPanelBackground = null;
+        originalBorderBackground = null;
+        hasOriginalControlBackground = false;
+        hasOriginalPanelBackground = false;
+        hasOriginalBorderBackground = false;
+        VirtualEffect = null;
     }
 }
 

--- a/src/UraniumUI.Blurs/Platforms/Android/BlurView.cs
+++ b/src/UraniumUI.Blurs/Platforms/Android/BlurView.cs
@@ -1,4 +1,4 @@
-﻿using Android.Content;
+using Android.Content;
 using Android.Graphics;
 using Android.OS;
 using Android.Util;
@@ -103,7 +103,6 @@ public class BlurView : FrameLayout
     *                 It uses RenderEffectBlur on API 31+, and RenderScriptBlur on older versions.
     * @return {@link BlurView} to setup needed params.
     */
-
     [RequiresApi(Value = (int)BuildVersionCodes.JellyBeanMr1)]
     public IBlurViewFacade SetupWith(ViewGroup rootView)
     {

--- a/src/UraniumUI.Blurs/Platforms/Android/BlurView.cs
+++ b/src/UraniumUI.Blurs/Platforms/Android/BlurView.cs
@@ -43,6 +43,11 @@ public class BlurView : FrameLayout
         blurController.UpdateBlurViewSize();
     }
 
+    public void UpdateBlurViewSize()
+    {
+        blurController.UpdateBlurViewSize();
+    }
+
     protected override void OnAttachedToWindow()
     {
         base.OnAttachedToWindow();
@@ -56,6 +61,18 @@ public class BlurView : FrameLayout
         }
     }
 
+    protected override void OnDetachedFromWindow()
+    {
+        blurController.SetBlurAutoUpdate(false);
+        base.OnDetachedFromWindow();
+    }
+
+    public void Release()
+    {
+        blurController.Destroy();
+        blurController = new NoOpController();
+    }
+
     /**
    * @param rootView  root to start blur from.
    *                  Can be Activity's root content layout (android.R.id.content)
@@ -65,18 +82,23 @@ public class BlurView : FrameLayout
    */
     public IBlurViewFacade SetupWith(ViewGroup rootView, IBlurAlgorithm algorithm)
     {
-        this.blurController.Destroy();
-        var blurController = new PreDrawBlurController(this, rootView, overlayColor, algorithm);
-        this.blurController = blurController;
+        if (rootView == null || algorithm == null)
+        {
+            Release();
+            return blurController;
+        }
 
-        return blurController;
+        this.blurController.Destroy();
+        var controller = new PreDrawBlurController(this, rootView, overlayColor, algorithm);
+        this.blurController = controller;
+
+        return controller;
     }
 
     /**
     * @param rootView root to start blur from.
     *                 Can be Activity's root content layout (android.R.id.content)
     *                 or (preferably) some of your layouts. The lower amount of Views are in the root, the better for performance.
-    *                 <p>
     *                 BlurAlgorithm is automatically picked based on the API version.
     *                 It uses RenderEffectBlur on API 31+, and RenderScriptBlur on older versions.
     * @return {@link BlurView} to setup needed params.

--- a/src/UraniumUI.Blurs/Platforms/Android/PreDrawBlurController.cs
+++ b/src/UraniumUI.Blurs/Platforms/Android/PreDrawBlurController.cs
@@ -24,6 +24,7 @@ public class PreDrawBlurController : IBlurController
 
     private bool blurEnabled = true;
     private bool initialized;
+    private bool destroyed;
 
     private Drawable frameClearDrawable;
 
@@ -52,17 +53,33 @@ public class PreDrawBlurController : IBlurController
 
     void Init(int measuredWidth, int measuredHeight)
     {
+        if (destroyed)
+        {
+            return;
+        }
+
         SetBlurAutoUpdate(true);
         SizeScaler sizeScaler = new SizeScaler(blurAlgorithm.ScaleFactor);
         if (sizeScaler.IsZeroSized(measuredWidth, measuredHeight))
         {
             // Will be initialized later when the View reports a size change
+            initialized = false;
             blurView.SetWillNotDraw(true);
+            ReleaseBitmap();
             return;
         }
 
         blurView.SetWillNotDraw(false);
         SizeScaler.Size bitmapSize = sizeScaler.scale(measuredWidth, measuredHeight);
+
+        if (initialized && internalBitmap != null && !internalBitmap.IsRecycled &&
+            internalBitmap.Width == bitmapSize.width && internalBitmap.Height == bitmapSize.height)
+        {
+            UpdateBlur();
+            return;
+        }
+
+        ReleaseBitmap();
         internalBitmap = Bitmap.CreateBitmap(bitmapSize.width, bitmapSize.height, blurAlgorithm.SupportedBitmapConfig);
         internalCanvas = new BlurViewCanvas(internalBitmap);
         initialized = true;
@@ -75,7 +92,7 @@ public class PreDrawBlurController : IBlurController
 
     void UpdateBlur()
     {
-        if (!blurEnabled || !initialized)
+        if (destroyed || !blurEnabled || !initialized || internalBitmap == null || internalCanvas == null || rootView == null)
         {
             return;
         }
@@ -120,7 +137,7 @@ public class PreDrawBlurController : IBlurController
 
     public bool Draw(Canvas canvas)
     {
-        if (!blurEnabled || !initialized)
+        if (destroyed || !blurEnabled || !initialized || internalBitmap == null)
         {
             return true;
         }
@@ -147,7 +164,20 @@ public class PreDrawBlurController : IBlurController
 
     private void BlurAndSave()
     {
-        internalBitmap = blurAlgorithm.Blur(internalBitmap, blurRadius);
+        var blurredBitmap = blurAlgorithm.Blur(internalBitmap, blurRadius);
+        if (blurredBitmap != internalBitmap)
+        {
+            var previousBitmap = internalBitmap;
+            internalBitmap = blurredBitmap;
+
+            if (previousBitmap != null && !previousBitmap.IsRecycled)
+            {
+                previousBitmap.Recycle();
+            }
+
+            previousBitmap?.Dispose();
+        }
+
         if (!blurAlgorithm.CanModifyBitmap)
         {
             internalCanvas.SetBitmap(internalBitmap);
@@ -164,9 +194,19 @@ public class PreDrawBlurController : IBlurController
 
     public void Destroy()
     {
+        if (destroyed)
+        {
+            return;
+        }
+
+        destroyed = true;
         SetBlurAutoUpdate(false);
         blurAlgorithm.Destroy();
+        ReleaseBitmap();
+        frameClearDrawable = null;
+        rootView = null;
         initialized = false;
+        blurView.SetWillNotDraw(true);
     }
 
     public IBlurViewFacade SetBlurRadius(float radius)
@@ -191,10 +231,16 @@ public class PreDrawBlurController : IBlurController
 
     public IBlurViewFacade SetBlurAutoUpdate(bool enabled)
     {
-        rootView.ViewTreeObserver.RemoveOnPreDrawListener(drawListener);
+        var viewTreeObserver = rootView?.ViewTreeObserver;
+        if (viewTreeObserver == null || !viewTreeObserver.IsAlive)
+        {
+            return this;
+        }
+
+        viewTreeObserver.RemoveOnPreDrawListener(drawListener);
         if (enabled)
         {
-            rootView.ViewTreeObserver.AddOnPreDrawListener(drawListener);
+            viewTreeObserver.AddOnPreDrawListener(drawListener);
         }
         return this;
     }
@@ -207,5 +253,19 @@ public class PreDrawBlurController : IBlurController
             blurView.Invalidate();
         }
         return this;
+    }
+
+    private void ReleaseBitmap()
+    {
+        internalCanvas?.Dispose();
+        internalCanvas = null;
+
+        if (internalBitmap != null && !internalBitmap.IsRecycled)
+        {
+            internalBitmap.Recycle();
+        }
+
+        internalBitmap?.Dispose();
+        internalBitmap = null;
     }
 }

--- a/src/UraniumUI.Blurs/Platforms/Android/RenderEffectBlur.cs
+++ b/src/UraniumUI.Blurs/Platforms/Android/RenderEffectBlur.cs
@@ -1,20 +1,28 @@
 ﻿using Android.Content;
 using Android.Graphics;
+using Paint = Android.Graphics.Paint;
 
 namespace UraniumUI.Blurs;
 
 public class RenderEffectBlur : IBlurAlgorithm
 {
     private readonly RenderNode node = new RenderNode("BlurViewNode");
+    private readonly Paint paint = new Paint(PaintFlags.FilterBitmap);
 
     private int height, width;
     private float lastBlurRadius = 1f;
+    private bool destroyed;
 
     public IBlurAlgorithm fallbackAlgorithm;
     private Context context;
 
     public Bitmap Blur(Bitmap bitmap, float blurRadius)
     {
+        if (destroyed)
+        {
+            return bitmap;
+        }
+
         lastBlurRadius = blurRadius;
 
         if (bitmap.Height != height || bitmap.Width != width)
@@ -33,10 +41,17 @@ public class RenderEffectBlur : IBlurAlgorithm
 
     public void Destroy()
     {
+        if (destroyed)
+        {
+            return;
+        }
+
+        destroyed = true;
         node.DiscardDisplayList();
         if (fallbackAlgorithm != null)
         {
             fallbackAlgorithm.Destroy();
+            fallbackAlgorithm = null;
         }
     }
 
@@ -48,12 +63,24 @@ public class RenderEffectBlur : IBlurAlgorithm
 
     public void Render(Canvas canvas, Bitmap bitmap)
     {
+        if (destroyed)
+        {
+            canvas.DrawBitmap(bitmap, 0f, 0f, paint);
+            return;
+        }
+
         if (canvas.IsHardwareAccelerated)
         {
             canvas.DrawRenderNode(node);
         }
         else
         {
+            if (context == null)
+            {
+                canvas.DrawBitmap(bitmap, 0f, 0f, paint);
+                return;
+            }
+
             if (fallbackAlgorithm == null)
             {
                 fallbackAlgorithm = new RenderScriptBlur(context);

--- a/src/UraniumUI.Blurs/Platforms/Android/RenderScriptBlur.cs
+++ b/src/UraniumUI.Blurs/Platforms/Android/RenderScriptBlur.cs
@@ -1,4 +1,4 @@
-﻿using Android.OS;
+using Android.OS;
 using Android.Renderscripts;
 using Android.Graphics;
 using Android.Content;
@@ -35,7 +35,6 @@ public class RenderScriptBlur : IBlurAlgorithm
      * @param blurRadius blur radius (1..25)
      * @return blurred bitmap
      */
-
     [RequiresApi(Value = (int)BuildVersionCodes.JellyBeanMr1)]
     public Bitmap Blur(Bitmap bitmap, float blurRadius)
     {

--- a/src/UraniumUI.Blurs/Platforms/Android/RenderScriptBlur.cs
+++ b/src/UraniumUI.Blurs/Platforms/Android/RenderScriptBlur.cs
@@ -17,6 +17,7 @@ public class RenderScriptBlur : IBlurAlgorithm
 
     private int lastBitmapWidth = -1;
     private int lastBitmapHeight = -1;
+    private bool destroyed;
 
     public RenderScriptBlur(Context context)
     {
@@ -38,6 +39,11 @@ public class RenderScriptBlur : IBlurAlgorithm
     [RequiresApi(Value = (int)BuildVersionCodes.JellyBeanMr1)]
     public Bitmap Blur(Bitmap bitmap, float blurRadius)
     {
+        if (destroyed)
+        {
+            return bitmap;
+        }
+
         //Allocation will use the same backing array of pixels as bitmap if created with USAGE_SHARED flag
         Allocation inAllocation = Allocation.CreateFromBitmap(renderScript, bitmap);
 
@@ -64,11 +70,18 @@ public class RenderScriptBlur : IBlurAlgorithm
 
     public void Destroy()
     {
+        if (destroyed)
+        {
+            return;
+        }
+
+        destroyed = true;
         blurScript.Destroy();
         renderScript.Destroy();
         if (outAllocation != null)
         {
             outAllocation.Destroy();
+            outAllocation = null;
         }
     }
 


### PR DESCRIPTION
## Summary

- Stabilizes `UraniumUI.Blurs` platform effect cleanup across Android, iOS/Mac Catalyst, and Windows.
- Removes Android child reparenting from the blur effect while preserving real backdrop blur rendering.
- Lets Android select the native `RenderEffectBlur` path on API 31+ instead of always forcing RenderScript.
- Cleans up Android blur controllers, pre-draw listeners, bitmaps, and native views on detach.
- Restores original platform backgrounds on detach and clears effect update commands.
- Clamps effective accent opacity to the valid `0..1` range.

## Notes

- Android still uses the existing capture-based blur pipeline. This PR is an urgent stabilization pass, not the performance redesign.
- A follow-up issue will track replacing the Android default with lighter native/material strategies.

## Verification

- `dotnet build src\UraniumUI.Blurs\UraniumUI.Blurs.csproj -f net10.0-android --no-restore -v:q -clp:ErrorsOnly`
- `dotnet build src\UraniumUI.Blurs\UraniumUI.Blurs.csproj -f net9.0-android --no-restore -v:q -clp:ErrorsOnly`
- `dotnet build src\UraniumUI.Blurs\UraniumUI.Blurs.csproj -f net10.0-windows10.0.19041.0 --no-restore -v:q -clp:ErrorsOnly`
- `dotnet build src\UraniumUI.Blurs\UraniumUI.Blurs.csproj -f net10.0-ios --no-restore -v:q -clp:ErrorsOnly`
- Manual Android test by Enisn confirmed remote images render and blur is visible again after the measurement fix.
