### PR TITLE
Add cancellable custom view dialogs

### DIFF
--- a/docs/en/dialogs/Index.md
+++ b/docs/en/dialogs/Index.md
@@ -282,6 +282,54 @@ Manual verification steps for each dialog provider:
 
 ---
 
+### View
+
+View dialogs can display custom MAUI content. Use the one-button overload when the dialog is informational. Use the OK/Cancel overload when the caller needs to know whether the user accepted or discarded changes.
+
+```csharp
+private async void Button_Clicked(object sender, EventArgs e)
+{
+    var content = new VerticalStackLayout
+    {
+        Children =
+        {
+            new HorizontalStackLayout
+            {
+                Children =
+                {
+                    new CheckBox(),
+                    new Label { Text = "Yes" }
+                }
+            },
+            new HorizontalStackLayout
+            {
+                Children =
+                {
+                    new CheckBox(),
+                    new Label { Text = "No" }
+                }
+            },
+            new Button { Text = "Open Camera" }
+        }
+    };
+
+    var accepted = await DialogService.DisplayViewAsync(
+        "Custom Content",
+        content,
+        "Save",
+        "Cancel");
+
+    if (accepted)
+    {
+        // Save changes from the custom content.
+    }
+}
+```
+
+`DisplayViewAsync(title, content, okText, cancelText)` returns `true` when the OK button is pressed and `false` when the Cancel button is pressed. The button labels are explicit to avoid ambiguity with the existing one-button overload.
+
+---
+
 ### Progress
 
 Progress dialog can be used to show a progress dialog to the user. There are 2 types of progress dialogs in UraniumUI. They are blocking and cancellable. Blocking progress dialog will block the UI until it's closed. Cancellable progress dialog will have a cancel button to allow user to cancel the operation. It returns an `IDisposable` and it'll be visible until you dispose it. You can use it with `using` statement to show a progress dialog.

--- a/src/UraniumUI.Dialogs.CommunityToolkit/CommunityToolkitDialogExtensions.cs
+++ b/src/UraniumUI.Dialogs.CommunityToolkit/CommunityToolkitDialogExtensions.cs
@@ -94,6 +94,12 @@ public static class CommunityToolkitDialogExtensions
             .DisplayViewAsync(title, content, okText);
     }
 
+    public static Task<bool> DisplayViewAsync(this Page page, string title, View content, string okText, string cancelText)
+    {
+        return GetService().WithPage(page)
+            .DisplayViewAsync(title, content, okText, cancelText);
+    }
+
     public static Task<TViewModel> DisplayFormViewAsync<TViewModel>(this Page page, string title, TViewModel viewModel = null, string submit = "OK", string cancel = "Cancel") where TViewModel : class
     {
         return GetService().WithPage(page)

--- a/src/UraniumUI.Dialogs.CommunityToolkit/CommunityToolkitDialogService.cs
+++ b/src/UraniumUI.Dialogs.CommunityToolkit/CommunityToolkitDialogService.cs
@@ -582,6 +582,72 @@ public class CommunityToolkitDialogService : CommunityToolkitDialogServiceBase, 
         return tcs.Task;
     }
 
+    public Task<bool> DisplayViewAsync(string title, View content, string okText, string cancelText)
+    {
+        var tcs = new TaskCompletionSource<bool>();
+        var calculatedSize = CalculateSize(Page);
+        var rootContainer = new VerticalStackLayout();
+
+#if IOS || MACCATALYST
+        var popup = new Popup
+        {
+            WidthRequest = calculatedSize.Width,
+            HeightRequest = 230,
+            BackgroundColor = ColorResource.GetColor("Surface", "SurfaceDark", Colors.Transparent),
+            CanBeDismissedByTappingOutsideOfPopup = false,
+            Padding = 0,
+            Content = rootContainer,
+        };
+        rootContainer.VerticalOptions = LayoutOptions.Center;
+#else
+        var popup = new Popup()
+        {
+            WidthRequest = calculatedSize.Width,
+            HeightRequest = calculatedSize.Height,
+            BackgroundColor = Colors.Transparent,
+            Padding = 0,
+            CanBeDismissedByTappingOutsideOfPopup = false,
+            Content = new ContentView
+            {
+                BackgroundColor = Colors.Transparent,
+                Content = GetFrame(calculatedSize.Width, rootContainer)
+            }
+        };
+#endif
+
+        var footer = GetFooter(new Dictionary<string, Command>
+        {
+            { okText, new Command(async () =>
+            {
+                tcs.TrySetResult(true);
+                await popup.CloseAsync();
+            }) },
+            { cancelText, new Command(async () =>
+            {
+                tcs.TrySetResult(false);
+                await popup.CloseAsync();
+            }) }
+        });
+
+        rootContainer.Add(GetHeader(title));
+        rootContainer.Add(new ScrollView
+        {
+            Content = content,
+            VerticalOptions = LayoutOptions.Start,
+#if IOS || MACCATALYST
+            //MaximumHeightRequest = calculatedSize.Height
+#else
+            MaximumHeightRequest = calculatedSize.Height
+#endif
+        });
+        rootContainer.Add(GetDivider());
+        rootContainer.Add(footer);
+
+        Page.ShowPopup(popup, new PopupOptions { Shape = null });
+
+        return tcs.Task;
+    }
+
     public Task<TViewModel> DisplayFormViewAsync<TViewModel>(string title, TViewModel viewModel = null, string submit = "OK", string cancel = "Cancel") where TViewModel : class
     {
         var tcs = new TaskCompletionSource<TViewModel>();

--- a/src/UraniumUI.Dialogs.Mopups/MopupsDialogExtensions.cs
+++ b/src/UraniumUI.Dialogs.Mopups/MopupsDialogExtensions.cs
@@ -81,6 +81,11 @@ public static class MopupsDialogExtensions
         return GetService().WithPage(page).DisplayViewAsync(title, content, okText);
     }
 
+    public static Task<bool> DisplayViewAsync(this Page page, string title, View content, string okText, string cancelText)
+    {
+        return GetService().WithPage(page).DisplayViewAsync(title, content, okText, cancelText);
+    }
+
     public static Task<TViewModel> DisplayFormViewAsync<TViewModel>(this Page page, string title, TViewModel viewModel = null, string submit = "OK", string cancel = "Cancel") where TViewModel : class
     {
         return GetService().WithPage(page)

--- a/src/UraniumUI.Dialogs.Mopups/MopupsDialogService.cs
+++ b/src/UraniumUI.Dialogs.Mopups/MopupsDialogService.cs
@@ -398,6 +398,43 @@ public class MopupsDialogService : IDialogService
         return MopupService.Instance.PushAsync(popup);
     }
 
+    public virtual async Task<bool> DisplayViewAsync(string title, View content, string okText, string cancelText)
+    {
+        var tcs = new TaskCompletionSource<bool>();
+        var popup = new PopupPage
+        {
+            BackgroundColor = DialogOptions.GetBackdropColor(),
+            CloseWhenBackgroundIsClicked = false,
+        };
+
+        popup.Content = GetFrame(Page.Width, new VerticalStackLayout
+        {
+            Children =
+                {
+                    GetHeader(title),
+                    content,
+                    GetDivider(),
+                    GetFooter(new Dictionary<string, Command>
+                    {
+                        { okText, new Command(() =>
+                        {
+                            tcs.TrySetResult(true);
+                            MopupService.Instance.RemovePageAsync(popup);
+                        }) },
+                        { cancelText, new Command(() =>
+                        {
+                            tcs.TrySetResult(false);
+                            MopupService.Instance.RemovePageAsync(popup);
+                        }) }
+                    })
+                }
+        });
+
+        await MopupService.Instance.PushAsync(popup);
+
+        return await tcs.Task;
+    }
+
     public Task<TViewModel> DisplayFormViewAsync<TViewModel>(string title, TViewModel viewModel = null, string submit = "OK", string cancel = "Cancel") where TViewModel : class
     {
         var tcs = new TaskCompletionSource<TViewModel>();

--- a/src/UraniumUI/Dialogs/DefaultDialogService.cs
+++ b/src/UraniumUI/Dialogs/DefaultDialogService.cs
@@ -59,6 +59,44 @@ public class DefaultDialogService : IDialogService
         return tcs.Task;
     }
 
+    public Task<bool> DisplayViewAsync(string title, View content, string okText, string cancelText)
+    {
+        var tcs = new TaskCompletionSource<bool>();
+
+        var popupPage = new DefaultDialogAnimatedContentPage
+        {
+            BackgroundColor = GetBackdropColor(),
+            Content = GetFrame(Page.Width, new VerticalStackLayout
+            {
+                Children =
+                {
+                    GetHeader(title),
+                    content,
+                    GetDivider(),
+                    GetFooter(new Dictionary<string, Command>
+                    {
+                        {
+                            okText, new Command(async () =>
+                            {
+                                await ClosePopupAndSetResult(tcs, true);
+                            })
+                        },
+                        {
+                            cancelText, new Command(async () =>
+                            {
+                                await ClosePopupAndSetResult(tcs, false);
+                            })
+                        }
+                    })
+                }
+            })
+        };
+
+        Page.Navigation.PushModalAsync(ConfigurePopupPage(popupPage), animated: false);
+
+        return tcs.Task;
+    }
+
     public Task<IDisposable> DisplayProgressAsync(string title, string message)
     {
         return DisplayProgressCancellableAsync(title, message, cancelText: null);

--- a/src/UraniumUI/Dialogs/IDialogService.cs
+++ b/src/UraniumUI/Dialogs/IDialogService.cs
@@ -9,6 +9,15 @@ public interface IDialogService
         View content,
         string okText = "OK");
 
+    Task<bool> DisplayViewAsync(
+        string title,
+        View content,
+        string okText,
+        string cancelText)
+    {
+        throw new NotSupportedException("The active dialog service does not support cancellable custom view dialogs.");
+    }
+
     Task<IDisposable> DisplayProgressAsync(
         string title,
         string message);

--- a/test/UraniumUI.Material.Tests/Mocks/MockDialogService.cs
+++ b/test/UraniumUI.Material.Tests/Mocks/MockDialogService.cs
@@ -77,6 +77,11 @@ internal class MockDialogService : IDialogService
         return Task.CompletedTask;
     }
 
+    public Task<bool> DisplayViewAsync(string title, View content, string okText, string cancelText)
+    {
+        return Task.FromResult(true);
+    }
+
     public Task<TViewModel> DisplayFormViewAsync<TViewModel>(string title, TViewModel viewModel = null, string submit = "OK", string cancel = "Cancel") where TViewModel : class
     {
         return Task.FromResult(default(TViewModel));


### PR DESCRIPTION
## Summary
- add an OK/Cancel custom view dialog overload that returns `true` for OK and `false` for Cancel
- implement the overload in the default, CommunityToolkit, and Mopups dialog services and page extensions
- document custom view dialogs that need accept/discard semantics

## Automated Testing
- `dotnet build "src/UraniumUI.Dialogs.CommunityToolkit/UraniumUI.Dialogs.CommunityToolkit.csproj" -f net9.0`
- `dotnet build "src/UraniumUI.Dialogs.Mopups/UraniumUI.Dialogs.Mopups.csproj" -f net9.0`
- `dotnet build "src/UraniumUI.Dialogs.CommunityToolkit/UraniumUI.Dialogs.CommunityToolkit.csproj" -f net10.0`
- `dotnet build "src/UraniumUI.Dialogs.Mopups/UraniumUI.Dialogs.Mopups.csproj" -f net10.0`
- `dotnet test "test/UraniumUI.Material.Tests/UraniumUI.Material.Tests.csproj"`

## Manual Testing
- Environment: a .NET MAUI app using each dialog provider: Default, CommunityToolkit, and Mopups.
- Add a custom content dialog with `await DialogService.DisplayViewAsync("Custom Content", view, "Save", "Cancel")`.
- Press Save and verify the task completes with `true` after the dialog closes.
- Reopen the dialog, press Cancel, and verify the task completes with `false` after the dialog closes.
- Verify existing one-button calls, `DisplayViewAsync(title, content)` and `DisplayViewAsync(title, content, okText)`, still show a single OK-style button.

Closes #876
