### PR TITLE
Fix DropdownField selected item binding

### DIFF
--- a/src/UraniumUI.Material/Controls/DropdownField.cs
+++ b/src/UraniumUI.Material/Controls/DropdownField.cs
@@ -133,6 +133,7 @@ public class DropdownField : InputField
         nameof(SelectedItem),
         typeof(object),
         typeof(DropdownField),
+        defaultBindingMode: BindingMode.TwoWay,
         propertyChanged: (bindable, oldValue, newValue) => (bindable as DropdownField).OnSelectedItemChanged());
 
     public bool AllowClear { get => (bool)GetValue(AllowClearProperty); set => SetValue(AllowClearProperty, value); }

--- a/test/UraniumUI.Material.Tests/Controls/DropdownField_Test.cs
+++ b/test/UraniumUI.Material.Tests/Controls/DropdownField_Test.cs
@@ -24,4 +24,24 @@ public class DropdownField_Test
         clearIcon.Margin.ShouldBe(default(Thickness));
         clearIcon.Padding.ShouldBe(new Thickness(InputField.BuiltInAttachmentLeftPadding, 0, 0, 0));
     }
+
+    [Fact]
+    public void SelectedItem_Binding_ToSource_UsesTwoWayByDefault()
+    {
+        var control = AnimationReadyHandler.Prepare(new DropdownField());
+        var viewModel = new TestViewModel { SelectedItem = "http://" };
+        control.BindingContext = viewModel;
+        control.SetBinding(DropdownField.SelectedItemProperty, new Binding(nameof(TestViewModel.SelectedItem)));
+
+        control.SelectedItem = "https://";
+
+        viewModel.SelectedItem.ShouldBe(control.SelectedItem);
+    }
+
+    public class TestViewModel : UraniumBindableObject
+    {
+        private object selectedItem;
+
+        public object SelectedItem { get => selectedItem; set => SetProperty(ref selectedItem, value); }
+    }
 }


### PR DESCRIPTION
## Summary
- make `DropdownField.SelectedItem` use two-way binding by default
- add regression coverage for updating the bound source property without requiring `Mode=TwoWay`

## Automated Testing
- `dotnet test "test\\UraniumUI.Material.Tests\\UraniumUI.Material.Tests.csproj" --filter DropdownField_Test`

Closes #859
