### PR TITLE
Fix DataAnnotations behavior with compiled bindings

### DIFF
--- a/src/UraniumUI.Validations.DataAnnotations/Validations/DataAnnotationsBehavior.cs
+++ b/src/UraniumUI.Validations.DataAnnotations/Validations/DataAnnotationsBehavior.cs
@@ -1,4 +1,6 @@
 using InputKit.Shared.Abstraction;
+using Microsoft.Maui.Controls.Internals;
+using System.Collections;
 using System.ComponentModel.DataAnnotations;
 using System.Reflection;
 
@@ -44,23 +46,93 @@ public class DataAnnotationsBehavior : Behavior<View>
             return;
         }
 
-        if (Binding is Binding newBinding)
+        var (source, path) = GetSourceAndPath();
+
+        if (source is null || string.IsNullOrWhiteSpace(path))
         {
-            var source = newBinding.Source ?? bindable.BindingContext;
-
-            if (source is null)
-            {
-                return;
-            }
-
-            var propertyInfo = source.GetType().GetProperty(newBinding.Path);
-            var validationAttributes = propertyInfo.GetCustomAttributes<ValidationAttribute>(true);
-            var displayAttribute = propertyInfo.GetCustomAttribute<DisplayAttribute>(true);
-
-            foreach (var attribute in validationAttributes)
-            {
-                validatable.Validations.Add(new DataAnnotationValidation(attribute, displayAttribute?.GetName() ?? propertyInfo.Name));
-            }
+            return;
         }
+
+        var propertyInfo = GetProperty(source.GetType(), path);
+
+        if (propertyInfo is null)
+        {
+            return;
+        }
+
+        var validationAttributes = propertyInfo.GetCustomAttributes<ValidationAttribute>(true);
+        var displayAttribute = propertyInfo.GetCustomAttribute<DisplayAttribute>(true);
+
+        foreach (var attribute in validationAttributes)
+        {
+            validatable.Validations.Add(new DataAnnotationValidation(attribute, displayAttribute?.GetName() ?? propertyInfo.Name));
+        }
+    }
+
+    (object Source, string Path) GetSourceAndPath()
+    {
+        return Binding switch
+        {
+            Binding binding => (binding.Source ?? bindable.BindingContext, binding.Path),
+            TypedBindingBase typedBinding => (typedBinding.Source ?? bindable.BindingContext, GetTypedBindingPath(typedBinding)),
+            _ => default
+        };
+    }
+
+    static string GetTypedBindingPath(TypedBindingBase typedBinding)
+    {
+        var handlersField = typedBinding.GetType().GetField("_handlers", BindingFlags.Instance | BindingFlags.NonPublic);
+
+        if (handlersField?.GetValue(typedBinding) is not IEnumerable handlers)
+        {
+            return null;
+        }
+
+        var propertyNames = new List<string>();
+
+        foreach (var handler in handlers)
+        {
+            if (handler is null)
+            {
+                continue;
+            }
+
+            var propertyName = handler.GetType()
+                .GetProperty("PropertyName", BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic)
+                ?.GetValue(handler) as string;
+
+            if (string.IsNullOrWhiteSpace(propertyName))
+            {
+                return null;
+            }
+
+            propertyNames.Add(propertyName);
+        }
+
+        return propertyNames.Count == 0 ? null : string.Join('.', propertyNames);
+    }
+
+    static PropertyInfo GetProperty(Type type, string propertyName)
+    {
+        var propertyNames = propertyName.Split('.');
+
+        for (var i = 0; i < propertyNames.Length; i++)
+        {
+            var propertyInfo = type.GetProperty(propertyNames[i]);
+
+            if (propertyInfo is null)
+            {
+                return null;
+            }
+
+            if (i == propertyNames.Length - 1)
+            {
+                return propertyInfo;
+            }
+
+            type = propertyInfo.PropertyType;
+        }
+
+        return null;
     }
 }

--- a/src/UraniumUI.Validations.DataAnnotations/Validations/DataAnnotationsBehavior.cs
+++ b/src/UraniumUI.Validations.DataAnnotations/Validations/DataAnnotationsBehavior.cs
@@ -11,6 +11,8 @@ public class DataAnnotationsBehavior : Behavior<View>
     public BindingBase Binding { get; set; }
 
     protected BindableObject bindable;
+    readonly List<DataAnnotationValidation> appliedValidations = new();
+    IValidatable appliedValidatable;
 
     protected override void OnAttachedTo(BindableObject bindable)
     {
@@ -32,6 +34,7 @@ public class DataAnnotationsBehavior : Behavior<View>
     {
         base.OnDetachingFrom(bindable);
         bindable.BindingContextChanged -= Bindable_BindingContextChanged;
+        RemoveAppliedValidations();
     }
 
     private void Bindable_BindingContextChanged(object sender, EventArgs e)
@@ -41,6 +44,8 @@ public class DataAnnotationsBehavior : Behavior<View>
 
     void Apply()
     {
+        RemoveAppliedValidations();
+
         if (bindable is not IValidatable validatable)
         {
             return;
@@ -65,8 +70,29 @@ public class DataAnnotationsBehavior : Behavior<View>
 
         foreach (var attribute in validationAttributes)
         {
-            validatable.Validations.Add(new DataAnnotationValidation(attribute, displayAttribute?.GetName() ?? propertyInfo.Name));
+            var validation = new DataAnnotationValidation(attribute, displayAttribute?.GetName() ?? propertyInfo.Name);
+            validatable.Validations.Add(validation);
+            appliedValidations.Add(validation);
         }
+
+        appliedValidatable = validatable;
+    }
+
+    void RemoveAppliedValidations()
+    {
+        if (appliedValidatable is null)
+        {
+            appliedValidations.Clear();
+            return;
+        }
+
+        foreach (var validation in appliedValidations)
+        {
+            appliedValidatable.Validations.Remove(validation);
+        }
+
+        appliedValidations.Clear();
+        appliedValidatable = null;
     }
 
     (object Source, string Path) GetSourceAndPath()

--- a/test/UraniumUI.Tests/UraniumUI.Tests.csproj
+++ b/test/UraniumUI.Tests/UraniumUI.Tests.csproj
@@ -24,6 +24,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\src\UraniumUI\UraniumUI.csproj" />
+    <ProjectReference Include="..\..\src\UraniumUI.Validations.DataAnnotations\UraniumUI.Validations.DataAnnotations.csproj" />
     <ProjectReference Include="..\UraniumUI.Tests.Core\UraniumUI.Tests.Core.csproj" />
   </ItemGroup>
 

--- a/test/UraniumUI.Tests/Validations/DataAnnotationsBehavior_Test.cs
+++ b/test/UraniumUI.Tests/Validations/DataAnnotationsBehavior_Test.cs
@@ -1,0 +1,81 @@
+using InputKit.Shared.Abstraction;
+using InputKit.Shared.Validations;
+using Microsoft.Maui.Controls.Internals;
+using System.ComponentModel.DataAnnotations;
+using UraniumUI.Tests.Core;
+using UraniumUI.Validations;
+
+namespace UraniumUI.Tests.Validations;
+
+public class DataAnnotationsBehavior_Test
+{
+    public DataAnnotationsBehavior_Test()
+    {
+        ApplicationExtensions.CreateAndSetMockApplication();
+    }
+
+    [Fact]
+    public void Binding_ShouldAddValidation_FromDataAnnotations()
+    {
+        var view = new ValidatableView
+        {
+            BindingContext = new TestViewModel()
+        };
+
+        view.Behaviors.Add(new DataAnnotationsBehavior
+        {
+            Binding = new Binding(nameof(TestViewModel.Email))
+        });
+
+        var validation = Assert.Single(view.Validations);
+        var dataAnnotationValidation = Assert.IsType<DataAnnotationValidation>(validation);
+        Assert.IsType<RequiredAttribute>(dataAnnotationValidation.Attribute);
+        Assert.Equal(nameof(TestViewModel.Email), dataAnnotationValidation.PropertyName);
+    }
+
+    [Fact]
+    public void TypedBinding_ShouldAddValidation_FromDataAnnotations()
+    {
+        var view = new ValidatableView
+        {
+            BindingContext = new TestViewModel()
+        };
+
+        view.Behaviors.Add(new DataAnnotationsBehavior
+        {
+            Binding = new TypedBinding<TestViewModel, string>(
+                source => (source.Email, true),
+                (source, value) => source.Email = value,
+                new Tuple<Func<TestViewModel, object>, string>[]
+                {
+                    new(static source => source, nameof(TestViewModel.Email))
+                })
+        });
+
+        var validation = Assert.Single(view.Validations);
+        var dataAnnotationValidation = Assert.IsType<DataAnnotationValidation>(validation);
+        Assert.IsType<RequiredAttribute>(dataAnnotationValidation.Attribute);
+        Assert.Equal(nameof(TestViewModel.Email), dataAnnotationValidation.PropertyName);
+    }
+
+    class ValidatableView : ContentView, IValidatable
+    {
+        public List<IValidation> Validations { get; } = new();
+
+        public bool IsValid => Validations.All(validation => validation.Validate(null));
+
+        public void DisplayValidation()
+        {
+        }
+
+        public void ResetValidation()
+        {
+        }
+    }
+
+    class TestViewModel
+    {
+        [Required]
+        public string Email { get; set; }
+    }
+}

--- a/test/UraniumUI.Tests/Validations/DataAnnotationsBehavior_Test.cs
+++ b/test/UraniumUI.Tests/Validations/DataAnnotationsBehavior_Test.cs
@@ -58,6 +58,30 @@ public class DataAnnotationsBehavior_Test
         Assert.Equal(nameof(TestViewModel.Email), dataAnnotationValidation.PropertyName);
     }
 
+    [Fact]
+    public void BindingContextChanged_ShouldNotDuplicateValidations()
+    {
+        var view = new ValidatableView
+        {
+            BindingContext = new TestViewModel()
+        };
+        var existingValidation = new TestValidation();
+        view.Validations.Add(existingValidation);
+
+        view.Behaviors.Add(new DataAnnotationsBehavior
+        {
+            Binding = new Binding(nameof(TestViewModel.Email))
+        });
+
+        Assert.Equal(2, view.Validations.Count);
+
+        view.BindingContext = new TestViewModel();
+
+        Assert.Equal(2, view.Validations.Count);
+        Assert.Contains(existingValidation, view.Validations);
+        Assert.Single(view.Validations.OfType<DataAnnotationValidation>());
+    }
+
     class ValidatableView : ContentView, IValidatable
     {
         public List<IValidation> Validations { get; } = new();
@@ -70,6 +94,16 @@ public class DataAnnotationsBehavior_Test
 
         public void ResetValidation()
         {
+        }
+    }
+
+    class TestValidation : IValidation
+    {
+        public string Message { get; set; }
+
+        public bool Validate(object value)
+        {
+            return true;
         }
     }
 


### PR DESCRIPTION
## Summary
- support MAUI compiled `TypedBindingBase` bindings in `DataAnnotationsBehavior`
- keep normal `Binding` support and safely ignore unsupported or unresolved binding paths
- add unit coverage for both normal bindings and compiled typed bindings

## Automated Testing
- `dotnet test "test\UraniumUI.Tests\UraniumUI.Tests.csproj" --no-restore`
- `dotnet build "src\UraniumUI.Validations.DataAnnotations\UraniumUI.Validations.DataAnnotations.csproj" -c Release --no-restore`

## Manual Testing
- Not run on an Android release APK locally.
- Scenario to verify: build a Release app that uses `x:DataType`/compiled binding with `DataAnnotationsBehavior`, leave a required field empty, and confirm the validation error label/icon appears.

Closes #850
