### PR TITLE
Fix CommunityToolkit form dialog validation

### DIFF
--- a/src/UraniumUI.Dialogs.CommunityToolkit/CommunityToolkitDialogService.cs
+++ b/src/UraniumUI.Dialogs.CommunityToolkit/CommunityToolkitDialogService.cs
@@ -660,7 +660,7 @@ public class CommunityToolkitDialogService : CommunityToolkitDialogServiceBase, 
             ShowResetButton = false,
             ShowSubmitButton = false,
             ShowMissingProperties = false,
-            Source = viewModel,
+            Source = viewModel ?? UraniumServiceProvider.Current.GetRequiredService<TViewModel>(),
         };
 
 #if IOS || MACCATALYST
@@ -694,8 +694,12 @@ public class CommunityToolkitDialogService : CommunityToolkitDialogServiceBase, 
         {
             { submit, new Command(async () =>
             {
-                tcs.TrySetResult(viewModel);
-                await popup.CloseAsync();
+                formView.Submit();
+                if (formView.IsValidated)
+                {
+                    tcs.TrySetResult((TViewModel)formView.Source);
+                    await popup.CloseAsync();
+                }
             }) },
             { cancel, new Command(async () =>
             {


### PR DESCRIPTION
## Summary
- Validate the generated `AutoFormView` before closing CommunityToolkit form dialogs.
- Keep the popup open when validation fails so validation messages can be shown.
- Use the same view-model source fallback as the default dialog implementation when no instance is provided.

## Testing
- `dotnet build src/UraniumUI.Dialogs.CommunityToolkit/UraniumUI.Dialogs.CommunityToolkit.csproj` (passed; existing warnings only)

Refs #1027
