### PR TITLE
Add async form validation support

### DIFF
--- a/demo/UraniumApp/Pages/ValidationsPage.xaml
+++ b/demo/UraniumApp/Pages/ValidationsPage.xaml
@@ -2,6 +2,7 @@
 <ContentPage x:Class="UraniumApp.Pages.ValidationsPage"
              xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
              xmlns:material="http://schemas.enisn-projects.io/dotnet/maui/uraniumui/material"
+             xmlns:uranium="http://schemas.enisn-projects.io/dotnet/maui/uraniumui"
              xmlns:input="clr-namespace:InputKit.Shared.Controls;assembly=InputKit.Maui"
              xmlns:validation="clr-namespace:InputKit.Shared.Validations;assembly=InputKit.Maui"
              xmlns:v="clr-namespace:UraniumUI.Validations;assembly=UraniumUI.Validations.DataAnnotations"
@@ -88,6 +89,41 @@
                             Command="{Binding FillCommand}"
                             StyleClass="FilledTonalButton"/>
                 </input:FormView>
+
+                <BoxView HeightRequest="1"
+                         Margin="0,30,0,10"
+                         BackgroundColor="{StaticResource OutlineVariant}" />
+
+                <Label Text="Async form validation"
+                       FontSize="Title"
+                       FontAttributes="Bold" />
+
+                <Label Text="Type 'admin', 'root', or 'taken' to simulate a server-side username conflict. Validation intentionally waits 2.5 seconds so the busy indicator is visible."
+                       Opacity=".7" />
+
+                <uranium:FormView Validator="{Binding .}"
+                                  SubmitCommand="{Binding AsyncSubmitCommand}"
+                                  Spacing="16">
+                    <material:TextField Title="Username"
+                                        Text="{Binding AsyncUserName}"
+                                        uranium:FormView.ValidationPath="AsyncUserName"
+                                        Icon="{FontImage FontFamily=MaterialSharp, Glyph={x:Static m:MaterialSharp.Person}}">
+                        <validation:RequiredValidation />
+                        <validation:MinLengthValidation MinLength="3" />
+                    </material:TextField>
+
+                    <ActivityIndicator uranium:FormView.IsBusyIndicator="True"
+                                       HorizontalOptions="Center"
+                                       Color="{StaticResource Primary}" />
+
+                    <Button Text="Check availability"
+                            uranium:FormView.IsSubmitButton="True"
+                            StyleClass="FilledButton" />
+
+                    <Label Text="{Binding AsyncValidationResult}"
+                           TextColor="{StaticResource Primary}"
+                           FontAttributes="Bold" />
+                </uranium:FormView>
             </StackLayout>
         </ScrollView>
     </ContentPage.Content>

--- a/demo/UraniumApp/ViewModels/ValidationsPageViewModel.cs
+++ b/demo/UraniumApp/ViewModels/ValidationsPageViewModel.cs
@@ -9,12 +9,15 @@ using System.Threading.Tasks;
 using System.Windows.Input;
 using UraniumUI;
 using UraniumUI.Resources;
+using UraniumUI.Validations;
 
 namespace UraniumApp.ViewModels;
-public class ValidationsPageViewModel : UraniumBindableObject
+public class ValidationsPageViewModel : UraniumBindableObject, IFormValidator
 {
     private string email = string.Empty;
     private string fullName = string.Empty;
+    private string asyncUserName = string.Empty;
+    private string asyncValidationResult = string.Empty;
     private Gender? gender;
     private DateTime? birthDate;
     private TimeSpan? meetingTime;
@@ -46,6 +49,8 @@ public class ValidationsPageViewModel : UraniumBindableObject
             MeetingTime = default;
             NumberOfSeats = default;
             IsTermsAndConditionsAccepted = default;
+            AsyncUserName = string.Empty;
+            AsyncValidationResult = string.Empty;
         });
 
         FillCommand = new Command(() =>
@@ -58,6 +63,11 @@ public class ValidationsPageViewModel : UraniumBindableObject
             NumberOfSeats = 2;
             IsTermsAndConditionsAccepted = true;
         });
+
+        AsyncSubmitCommand = new Command(() =>
+        {
+            AsyncValidationResult = $"Username '{AsyncUserName}' is available.";
+        });
     }
 
     public ICommand SubmitCommand { get; set; }
@@ -65,6 +75,8 @@ public class ValidationsPageViewModel : UraniumBindableObject
     public ICommand ClearCommand { get; set; }
 
     public ICommand FillCommand { get; set; }
+
+    public ICommand AsyncSubmitCommand { get; set; }
 
     [EmailAddress]
     [Required]
@@ -74,11 +86,39 @@ public class ValidationsPageViewModel : UraniumBindableObject
     [Required]
     [MinLength(3)]
     public string FullName { get => fullName; set => SetProperty(ref fullName, value); }
+    public string AsyncUserName
+    {
+        get => asyncUserName;
+        set
+        {
+            SetProperty(ref asyncUserName, value);
+            AsyncValidationResult = string.Empty;
+        }
+    }
+
+    public string AsyncValidationResult { get => asyncValidationResult; set => SetProperty(ref asyncValidationResult, value); }
+
     public Gender? Gender { get => gender; set => SetProperty(ref gender, value); }
     public DateTime? BirthDate { get => birthDate; set => SetProperty(ref birthDate, value); }
     public TimeSpan? MeetingTime { get => meetingTime; set => SetProperty(ref meetingTime, value); }
     public int? NumberOfSeats { get => numberOfSeats; set => SetProperty(ref numberOfSeats, value); }
     public bool IsTermsAndConditionsAccepted { get => isTermsAndConditionsAccepted; set => SetProperty(ref isTermsAndConditionsAccepted, value); }
+
+    public async Task<FormValidationResult> ValidateAsync(FormValidationContext context)
+    {
+        AsyncValidationResult = string.Empty;
+        await Task.Delay(2500, context.CancellationToken);
+
+        var reservedNames = new[] { "admin", "root", "taken" };
+        if (reservedNames.Contains(AsyncUserName?.Trim(), StringComparer.OrdinalIgnoreCase))
+        {
+            return FormValidationResult.PropertyError(
+                nameof(AsyncUserName),
+                "This username is already taken. Try 'uranium'.");
+        }
+
+        return FormValidationResult.Success();
+    }
 }
 public enum Gender
 {

--- a/docs/en/infrastructure/AutoFormView.md
+++ b/docs/en/infrastructure/AutoFormView.md
@@ -61,6 +61,38 @@ builder.Services.Configure<AutoFormViewOptions>(options =>
 });
 ```
 
+### Async Form Validation
+
+`AutoFormView` inherits from `uranium:FormView`, so it supports async form validation through `Validator` or `ValidationHandler`. It automatically uses `Source` as the validation model and assigns validation paths for generated editors.
+
+```xml
+<uranium:AutoFormView Source="{Binding .}"
+                      Validator="{Binding .}" />
+```
+
+```csharp
+using UraniumUI.Validations;
+
+public class RegisterViewModel : IFormValidator
+{
+    public string UserName { get; set; }
+
+    public async Task<FormValidationResult> ValidateAsync(FormValidationContext context)
+    {
+        if (await userService.UsernameExistsAsync(UserName))
+        {
+            return FormValidationResult.PropertyError(
+                nameof(UserName),
+                "The username has already been taken.");
+        }
+
+        return FormValidationResult.Success();
+    }
+}
+```
+
+For busy UI, place your own indicator in the form and mark it with `uranium:FormView.IsBusyIndicator="True"`. The form shows it while async validation is running.
+
 ### EditorMapping
 You can configure the `AutoFormView` to use a specific editor for a type. For example, you can configure the `AutoFormViewOptions` to use a `Editor` for `string` properties.
 

--- a/docs/en/infrastructure/AutoFormView.md
+++ b/docs/en/infrastructure/AutoFormView.md
@@ -93,6 +93,9 @@ public class RegisterViewModel : IFormValidator
 
 For busy UI, place your own indicator in the form and mark it with `uranium:FormView.IsBusyIndicator="True"`. The form shows it while async validation is running.
 
+> [!NOTE]
+> Unlike manually created `uranium:FormView` fields, `AutoFormView` assigns `uranium:FormView.ValidationPath` automatically for generated editors. Property errors returned with `FormValidationResult.PropertyError(nameof(UserName), "...")` can therefore map to the generated field without extra XAML.
+
 ### EditorMapping
 You can configure the `AutoFormView` to use a specific editor for a type. For example, you can configure the `AutoFormViewOptions` to use a `Editor` for `string` properties.
 

--- a/docs/en/themes/material/Validations.md
+++ b/docs/en/themes/material/Validations.md
@@ -70,6 +70,53 @@ There are some built-in validations that can be used in your application. They a
   * `DigitsOnlyValidation` - Checks if the value contains only digits.
   * `LettersOnlyValidation` - Checks if the value contains only letters.
 
+## Async Form Validation
+
+Use `uranium:FormView` when the whole form needs an async validation step, such as checking if a username already exists on the server. The form still runs local `IValidation` rules first. If they pass, it invokes the assigned validator and maps returned errors to the form or to specific fields.
+
+```xml
+<uranium:FormView Validator="{Binding .}">
+    <material:TextField Title="Username"
+                        Text="{Binding UserName}"
+                        uranium:FormView.ValidationPath="UserName">
+        <validation:RequiredValidation />
+    </material:TextField>
+
+    <ActivityIndicator uranium:FormView.IsBusyIndicator="True" />
+
+    <Button Text="Register"
+            uranium:FormView.IsSubmitButton="True"
+            StyleClass="FilledButton" />
+</uranium:FormView>
+```
+
+The view model can implement `IFormValidator`:
+
+```csharp
+using UraniumUI.Validations;
+
+public class RegisterViewModel : IFormValidator
+{
+    public string UserName { get; set; }
+
+    public async Task<FormValidationResult> ValidateAsync(FormValidationContext context)
+    {
+        if (await userService.UsernameExistsAsync(UserName))
+        {
+            return FormValidationResult.PropertyError(
+                nameof(UserName),
+                "The username has already been taken.");
+        }
+
+        return FormValidationResult.Success();
+    }
+}
+```
+
+Return `FormValidationResult.Error("message")` for a generic form-level error. Return `FormValidationResult.PropertyError("PropertyName", "message")` to show the error on a field marked with `uranium:FormView.ValidationPath`.
+
+`uranium:FormView.IsBusyIndicator="True"` marks any view as the form busy indicator. The form shows it while async validation is running. If the marked view is an `ActivityIndicator`, the form also toggles `IsRunning`.
+
 ## Creating Custom Validation
 
 You can create your own validation by implementing `IValidation` interface. It has a `Validate` method that takes a `object` as parameter and returns `bool` as result. The parameter is the value of the control that the validation is applied to. The result is the validation result. If the result is `false`, the validation message will be shown.

--- a/docs/en/themes/material/Validations.md
+++ b/docs/en/themes/material/Validations.md
@@ -115,6 +115,9 @@ public class RegisterViewModel : IFormValidator
 
 Return `FormValidationResult.Error("message")` for a generic form-level error. Return `FormValidationResult.PropertyError("PropertyName", "message")` to show the error on a field marked with `uranium:FormView.ValidationPath`.
 
+> [!IMPORTANT]
+> `ValidationPath` has no default value on manually created forms. `FormView` does not infer it from `{Binding UserName}`. If a property error is returned for a field without a matching `ValidationPath`, the error is shown in the form-level validation summary instead of on the field.
+
 `uranium:FormView.IsBusyIndicator="True"` marks any view as the form busy indicator. The form shows it while async validation is running. If the marked view is an `ActivityIndicator`, the form also toggles `IsRunning`.
 
 ## Creating Custom Validation

--- a/src/UraniumUI.Dialogs.CommunityToolkit/CommunityToolkitDialogService.cs
+++ b/src/UraniumUI.Dialogs.CommunityToolkit/CommunityToolkitDialogService.cs
@@ -660,7 +660,7 @@ public class CommunityToolkitDialogService : CommunityToolkitDialogServiceBase, 
             ShowResetButton = false,
             ShowSubmitButton = false,
             ShowMissingProperties = false,
-            Source = viewModel,
+            Source = viewModel ?? UraniumServiceProvider.Current.GetRequiredService<TViewModel>(),
         };
 
 #if IOS || MACCATALYST
@@ -694,8 +694,11 @@ public class CommunityToolkitDialogService : CommunityToolkitDialogServiceBase, 
         {
             { submit, new Command(async () =>
             {
-                tcs.TrySetResult(viewModel);
-                await popup.CloseAsync();
+                if (await formView.SubmitAsync())
+                {
+                    tcs.TrySetResult((TViewModel)formView.Source);
+                    await popup.CloseAsync();
+                }
             }) },
             { cancel, new Command(async () =>
             {

--- a/src/UraniumUI.Dialogs.Mopups/MopupsDialogService.cs
+++ b/src/UraniumUI.Dialogs.Mopups/MopupsDialogService.cs
@@ -462,13 +462,12 @@ public class MopupsDialogService : IDialogService
                 GetDivider(),
                 GetFooter( new Dictionary<string, Command>
                 {
-                    { submit, new Command(() =>
+                    { submit, new Command(async () =>
                     {
-                        formView.Submit();
-                        if (formView.IsValidated)
+                        if (await formView.SubmitAsync())
                         {
-                            tcs.TrySetResult(viewModel);
-                            MopupService.Instance.RemovePageAsync(popup);
+                            tcs.TrySetResult((TViewModel)formView.Source);
+                            await MopupService.Instance.RemovePageAsync(popup);
                         }
                     }) },
                     { cancel, new Command(() =>

--- a/src/UraniumUI.Dialogs.Mopups/MopupsDialogService.cs
+++ b/src/UraniumUI.Dialogs.Mopups/MopupsDialogService.cs
@@ -470,10 +470,10 @@ public class MopupsDialogService : IDialogService
                             await MopupService.Instance.RemovePageAsync(popup);
                         }
                     }) },
-                    { cancel, new Command(() =>
+                    { cancel, new Command(async () =>
                     {
                         tcs.TrySetResult(null);
-                        MopupService.Instance.RemovePageAsync(popup);
+                        await MopupService.Instance.RemovePageAsync(popup);
                     }) }
                 })
             }

--- a/src/UraniumUI/AssemblyInfo.cs
+++ b/src/UraniumUI/AssemblyInfo.cs
@@ -6,6 +6,7 @@
 [assembly: XmlnsDefinition(Constants.XamlNamespace, Constants.NamespacePrefix + nameof(UraniumUI.Resources))]
 [assembly: XmlnsDefinition(Constants.XamlNamespace, Constants.NamespacePrefix + nameof(UraniumUI.Theming))]
 [assembly: XmlnsDefinition(Constants.XamlNamespace, Constants.NamespacePrefix + nameof(UraniumUI.Triggers))]
+[assembly: XmlnsDefinition(Constants.XamlNamespace, Constants.NamespacePrefix + nameof(UraniumUI.Validations))]
 [assembly: XmlnsDefinition(Constants.XamlNamespace, Constants.NamespacePrefix + nameof(UraniumUI.Views))]
 [assembly: XmlnsDefinition(Constants.XamlNamespace, Constants.NamespacePrefix + nameof(UraniumUI.ViewExtensions))]
 

--- a/src/UraniumUI/Controls/AutoFormView.cs
+++ b/src/UraniumUI/Controls/AutoFormView.cs
@@ -109,6 +109,8 @@ public class AutoFormView : FormView
 
     protected void OnSourceChanged()
     {
+        ValidationModel = Source;
+
         var flags = BindingFlags.Public | BindingFlags.Instance;
         if (Hierarchical)
         {
@@ -140,6 +142,7 @@ public class AutoFormView : FormView
                 if (createEditor != null)
                 {
                     var editor = createEditor(property, Options.PropertyNameFactory, Source);
+                    SetEditorValidationPath(editor, property.Name);
 
                     foreach (var action in Options.PostEditorActions)
                     {
@@ -185,6 +188,7 @@ public class AutoFormView : FormView
                     StyleClass = new[] { "FilledButton" },
                     Command = buttonSubmitCommand,
                 };
+                SetIsSubmitButton(submitButton, true);
                 _footerLayout.Children.Insert(0, submitButton);
             }
         }
@@ -211,6 +215,7 @@ public class AutoFormView : FormView
                     StyleClass = new[] { "OutlinedButton" },
                     Command = buttonResetCommand,
                 };
+                SetIsResetButton(resetButton, true);
                 _footerLayout.Children.Add(resetButton);
             }
         }
@@ -237,6 +242,45 @@ public class AutoFormView : FormView
         if (resetButton != null)
         {
             resetButton.Text = ResetButtonText;
+        }
+    }
+
+    private static void SetEditorValidationPath(Element editor, string validationPath)
+    {
+        if (editor is BindableObject bindableObject)
+        {
+            SetValidationPath(bindableObject, validationPath);
+        }
+
+        foreach (var child in GetEditorChildren(editor))
+        {
+            SetEditorValidationPath(child, validationPath);
+        }
+    }
+
+    private static IEnumerable<Element> GetEditorChildren(Element editor)
+    {
+        if (editor is Layout layout)
+        {
+            foreach (var child in layout.Children.OfType<Element>())
+            {
+                yield return child;
+            }
+        }
+
+        if (editor is ContentView contentView && contentView.Content is Element content)
+        {
+            yield return content;
+        }
+
+        if (editor is ScrollView scrollView && scrollView.Content is Element scrollContent)
+        {
+            yield return scrollContent;
+        }
+
+        if (editor is Border border && border.Content is Element borderContent)
+        {
+            yield return borderContent;
         }
     }
 

--- a/src/UraniumUI/Controls/FormView.cs
+++ b/src/UraniumUI/Controls/FormView.cs
@@ -409,6 +409,11 @@ public class FormView : InputKitFormView
 
     private void ApplyBusyState()
     {
+        if (!IsBusy)
+        {
+            RestoreBusyDisabledViews();
+        }
+
         foreach (var bindable in GetChildBindableObjects(this))
         {
             if (bindable is not View view)
@@ -421,11 +426,21 @@ public class FormView : InputKitFormView
                 ApplyBusyIndicatorState(view, IsBusy);
             }
 
-            if (IsSubmitElement(view) || IsResetElement(view))
+            if (IsBusy && (IsSubmitElement(view) || IsResetElement(view)))
             {
                 ApplyBusyEnabledState(view);
             }
         }
+    }
+
+    private void RestoreBusyDisabledViews()
+    {
+        foreach (var (view, wasEnabled) in busyDisabledViews)
+        {
+            view.IsEnabled = wasEnabled;
+        }
+
+        busyDisabledViews.Clear();
     }
 
     private void ApplyBusyEnabledState(View view)
@@ -441,11 +456,7 @@ public class FormView : InputKitFormView
             return;
         }
 
-        if (busyDisabledViews.TryGetValue(view, out var wasEnabled))
-        {
-            view.IsEnabled = wasEnabled;
-            busyDisabledViews.Remove(view);
-        }
+        RestoreBusyDisabledViews();
     }
 
     private static void ApplyBusyIndicatorState(View view, bool isBusy)
@@ -505,7 +516,7 @@ public class FormView : InputKitFormView
 
     private void OnChildRemoved(object sender, ElementEventArgs e)
     {
-        if (e.Element is View view)
+        if (!IsBusy && e.Element is View view)
         {
             busyDisabledViews.Remove(view);
         }

--- a/src/UraniumUI/Controls/FormView.cs
+++ b/src/UraniumUI/Controls/FormView.cs
@@ -1,0 +1,513 @@
+using InputKit.Shared.Abstraction;
+using UraniumUI.Validations;
+using InputKitFormView = InputKit.Shared.Controls.FormView;
+
+namespace UraniumUI.Controls;
+
+public class FormView : InputKitFormView
+{
+    private readonly Label validationSummaryLabel;
+    private readonly Dictionary<View, bool> busyDisabledViews = new();
+
+    public FormView()
+    {
+        validationSummaryLabel = CreateValidationSummaryLabel();
+        Children.Insert(0, validationSummaryLabel);
+        ChildAdded += OnChildAdded;
+        ChildRemoved += OnChildRemoved;
+    }
+
+    public IFormValidator Validator { get => (IFormValidator)GetValue(ValidatorProperty); set => SetValue(ValidatorProperty, value); }
+
+    public static readonly BindableProperty ValidatorProperty = BindableProperty.Create(
+        nameof(Validator),
+        typeof(IFormValidator),
+        typeof(FormView));
+
+    public FormValidationHandler ValidationHandler { get => (FormValidationHandler)GetValue(ValidationHandlerProperty); set => SetValue(ValidationHandlerProperty, value); }
+
+    public static readonly BindableProperty ValidationHandlerProperty = BindableProperty.Create(
+        nameof(ValidationHandler),
+        typeof(FormValidationHandler),
+        typeof(FormView));
+
+    public object ValidationModel { get => GetValue(ValidationModelProperty); set => SetValue(ValidationModelProperty, value); }
+
+    public static readonly BindableProperty ValidationModelProperty = BindableProperty.Create(
+        nameof(ValidationModel),
+        typeof(object),
+        typeof(FormView));
+
+    public bool ShowValidationSummary { get => (bool)GetValue(ShowValidationSummaryProperty); set => SetValue(ShowValidationSummaryProperty, value); }
+
+    public static readonly BindableProperty ShowValidationSummaryProperty = BindableProperty.Create(
+        nameof(ShowValidationSummary),
+        typeof(bool),
+        typeof(FormView),
+        true,
+        propertyChanged: (bindable, oldValue, newValue) => ((FormView)bindable).ApplyValidationSummaryVisibility());
+
+    private static readonly BindablePropertyKey IsBusyPropertyKey = BindableProperty.CreateReadOnly(
+        nameof(IsBusy),
+        typeof(bool),
+        typeof(FormView),
+        false,
+        propertyChanged: (bindable, oldValue, newValue) => ((FormView)bindable).ApplyBusyState());
+
+    public static readonly BindableProperty IsBusyProperty = IsBusyPropertyKey.BindableProperty;
+
+    public bool IsBusy => (bool)GetValue(IsBusyProperty);
+
+    private static readonly BindablePropertyKey IsValidatingPropertyKey = BindableProperty.CreateReadOnly(
+        nameof(IsValidating),
+        typeof(bool),
+        typeof(FormView),
+        false);
+
+    public static readonly BindableProperty IsValidatingProperty = IsValidatingPropertyKey.BindableProperty;
+
+    public bool IsValidating => (bool)GetValue(IsValidatingProperty);
+
+    private static readonly BindablePropertyKey FormValidationResultPropertyKey = BindableProperty.CreateReadOnly(
+        nameof(FormValidationResult),
+        typeof(FormValidationResult),
+        typeof(FormView),
+        null);
+
+    public static readonly BindableProperty FormValidationResultProperty = FormValidationResultPropertyKey.BindableProperty;
+
+    public FormValidationResult FormValidationResult => (FormValidationResult)GetValue(FormValidationResultProperty);
+
+    public new static readonly BindableProperty IsSubmitButtonProperty = BindableProperty.CreateAttached(
+        "IsSubmitButton",
+        typeof(bool),
+        typeof(FormView),
+        false,
+        propertyChanged: (bindable, oldValue, newValue) => InputKitFormView.SetIsSubmitButton(bindable, (bool)newValue));
+
+    public new static bool GetIsSubmitButton(BindableObject view) => (bool)view.GetValue(IsSubmitButtonProperty);
+
+    public new static void SetIsSubmitButton(BindableObject view, bool value) => view.SetValue(IsSubmitButtonProperty, value);
+
+    public new static readonly BindableProperty IsResetButtonProperty = BindableProperty.CreateAttached(
+        "IsResetButton",
+        typeof(bool),
+        typeof(FormView),
+        false,
+        propertyChanged: (bindable, oldValue, newValue) => InputKitFormView.SetIsResetButton(bindable, (bool)newValue));
+
+    public new static bool GetIsResetButton(BindableObject view) => (bool)view.GetValue(IsResetButtonProperty);
+
+    public new static void SetIsResetButton(BindableObject view, bool value) => view.SetValue(IsResetButtonProperty, value);
+
+    public static readonly BindableProperty ValidationPathProperty = BindableProperty.CreateAttached(
+        "ValidationPath",
+        typeof(string),
+        typeof(FormView),
+        null);
+
+    public static string GetValidationPath(BindableObject view) => (string)view.GetValue(ValidationPathProperty);
+
+    public static void SetValidationPath(BindableObject view, string value) => view.SetValue(ValidationPathProperty, value);
+
+    public static readonly BindableProperty IsBusyIndicatorProperty = BindableProperty.CreateAttached(
+        "IsBusyIndicator",
+        typeof(bool),
+        typeof(FormView),
+        false,
+        propertyChanged: OnIsBusyIndicatorChanged);
+
+    public static bool GetIsBusyIndicator(BindableObject view) => (bool)view.GetValue(IsBusyIndicatorProperty);
+
+    public static void SetIsBusyIndicator(BindableObject view, bool value) => view.SetValue(IsBusyIndicatorProperty, value);
+
+    public override async void Submit()
+    {
+        await SubmitAsync();
+    }
+
+    public virtual async Task<bool> SubmitAsync(CancellationToken cancellationToken = default)
+    {
+        if (IsBusy)
+        {
+            return false;
+        }
+
+        var result = await ValidateFormAsync(cancellationToken);
+        if (!result.IsValid)
+        {
+            return false;
+        }
+
+        SetIsValidated(true);
+
+        if (SubmitCommand?.CanExecute(true) ?? true)
+        {
+            SubmitCommand?.Execute(true);
+        }
+
+        return true;
+    }
+
+    public virtual async Task<FormValidationResult> ValidateFormAsync(CancellationToken cancellationToken = default)
+    {
+        ClearFormValidationMessages();
+
+        if (!InputKitFormView.CheckValidation(this))
+        {
+            DisplayChildValidations();
+            var invalidResult = FormValidationResult.Invalid();
+            SetFormValidationResult(invalidResult);
+            SetIsValidated(false);
+            return invalidResult;
+        }
+
+        if (Validator is null && ValidationHandler is null)
+        {
+            var successResult = FormValidationResult.Success();
+            SetFormValidationResult(successResult);
+            SetIsValidated(true);
+            return successResult;
+        }
+
+        SetBusy(true);
+
+        try
+        {
+            var result = await RunFormValidatorAsync(cancellationToken) ?? FormValidationResult.Success();
+            ApplyFormValidationResult(result);
+            SetIsValidated(result.IsValid);
+            return result;
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            var result = FormValidationResult.Invalid();
+            SetFormValidationResult(result);
+            SetIsValidated(false);
+            return result;
+        }
+        catch (Exception ex)
+        {
+            var result = FormValidationResult.Error(ex.Message);
+            ApplyFormValidationResult(result);
+            SetIsValidated(false);
+            return result;
+        }
+        finally
+        {
+            SetBusy(false);
+        }
+    }
+
+    public override void Reset()
+    {
+        ClearFormValidationMessages();
+        base.Reset();
+    }
+
+    protected virtual FormValidationContext CreateValidationContext(CancellationToken cancellationToken)
+    {
+        return new FormValidationContext(this, ValidationModel ?? BindingContext, GetServiceProvider(), cancellationToken);
+    }
+
+    protected virtual IServiceProvider GetServiceProvider()
+    {
+        if (Handler?.MauiContext?.Services is { } services)
+        {
+            return services;
+        }
+
+        try
+        {
+            return UraniumServiceProvider.Current;
+        }
+        catch
+        {
+            return null;
+        }
+    }
+
+    protected virtual Label CreateValidationSummaryLabel()
+    {
+        return new Label
+        {
+            IsVisible = false,
+            TextColor = Colors.Red,
+            StyleClass = new[] { "FormView.ValidationSummary" },
+        };
+    }
+
+    private Task<FormValidationResult> RunFormValidatorAsync(CancellationToken cancellationToken)
+    {
+        var context = CreateValidationContext(cancellationToken);
+
+        if (Validator is not null)
+        {
+            return Validator.ValidateAsync(context);
+        }
+
+        return ValidationHandler(context);
+    }
+
+    private void ApplyFormValidationResult(FormValidationResult result)
+    {
+        SetFormValidationResult(result);
+
+        if (result.IsValid)
+        {
+            HideValidationSummary();
+            return;
+        }
+
+        var summaryMessages = new List<string>();
+
+        foreach (var error in result.Errors)
+        {
+            if (error.IsFormLevel)
+            {
+                summaryMessages.Add(error.Message);
+                continue;
+            }
+
+            var matched = false;
+
+            foreach (var memberName in error.MemberNames)
+            {
+                foreach (var (validatable, _) in GetValidatablesByPath(memberName))
+                {
+                    validatable.Validations.Add(new FormValidationMessage(error.Message));
+                    validatable.DisplayValidation();
+                    matched = true;
+                }
+            }
+
+            if (!matched)
+            {
+                summaryMessages.Add(error.Message);
+            }
+        }
+
+        ShowValidationSummaryMessages(summaryMessages);
+    }
+
+    private void ClearFormValidationMessages()
+    {
+        foreach (var (validatable, _) in GetChildValidatables())
+        {
+            validatable.Validations.RemoveAll(x => x is FormValidationMessage);
+        }
+
+        HideValidationSummary();
+        SetFormValidationResult(null);
+    }
+
+    private void DisplayChildValidations()
+    {
+        foreach (var (validatable, _) in GetChildValidatables())
+        {
+            validatable.DisplayValidation();
+        }
+    }
+
+    private IEnumerable<(IValidatable validatable, BindableObject bindable)> GetValidatablesByPath(string validationPath)
+    {
+        foreach (var (validatable, bindable) in GetChildValidatables())
+        {
+            if (string.Equals(GetValidationPath(bindable), validationPath, StringComparison.Ordinal))
+            {
+                yield return (validatable, bindable);
+            }
+        }
+    }
+
+    private IEnumerable<(IValidatable validatable, BindableObject bindable)> GetChildValidatables()
+    {
+        foreach (var bindable in GetChildBindableObjects(this))
+        {
+            if (bindable is IValidatable validatable)
+            {
+                yield return (validatable, bindable);
+            }
+        }
+    }
+
+    private static IEnumerable<BindableObject> GetChildBindableObjects(Element parent)
+    {
+        foreach (var child in GetDirectChildElements(parent))
+        {
+            if (child is BindableObject bindableObject)
+            {
+                yield return bindableObject;
+            }
+
+            foreach (var descendant in GetChildBindableObjects(child))
+            {
+                yield return descendant;
+            }
+        }
+    }
+
+    private static IEnumerable<Element> GetDirectChildElements(Element parent)
+    {
+        if (parent is Layout layout)
+        {
+            foreach (var child in layout.Children.OfType<Element>())
+            {
+                yield return child;
+            }
+        }
+
+        if (parent is ContentView contentView && contentView.Content is Element content)
+        {
+            yield return content;
+        }
+
+        if (parent is ScrollView scrollView && scrollView.Content is Element scrollContent)
+        {
+            yield return scrollContent;
+        }
+
+        if (parent is Border border && border.Content is Element borderContent)
+        {
+            yield return borderContent;
+        }
+    }
+
+    private void ShowValidationSummaryMessages(IEnumerable<string> messages)
+    {
+        var distinctMessages = messages.Where(x => !string.IsNullOrWhiteSpace(x)).Distinct().ToArray();
+        validationSummaryLabel.Text = string.Join(Environment.NewLine, distinctMessages);
+        ApplyValidationSummaryVisibility();
+    }
+
+    private void HideValidationSummary()
+    {
+        validationSummaryLabel.Text = string.Empty;
+        validationSummaryLabel.IsVisible = false;
+    }
+
+    private void ApplyValidationSummaryVisibility()
+    {
+        validationSummaryLabel.IsVisible = ShowValidationSummary && !string.IsNullOrWhiteSpace(validationSummaryLabel.Text);
+    }
+
+    private void SetBusy(bool isBusy)
+    {
+        SetValue(IsValidatingPropertyKey, isBusy);
+        SetValue(IsBusyPropertyKey, isBusy);
+    }
+
+    private void SetFormValidationResult(FormValidationResult result)
+    {
+        SetValue(FormValidationResultPropertyKey, result);
+    }
+
+    private void SetIsValidated(bool isValidated)
+    {
+        SetValue(InputKitFormView.IsValidatedProperty, isValidated);
+    }
+
+    private void ApplyBusyState()
+    {
+        foreach (var bindable in GetChildBindableObjects(this))
+        {
+            if (bindable is not View view)
+            {
+                continue;
+            }
+
+            if (GetIsBusyIndicator(view))
+            {
+                ApplyBusyIndicatorState(view, IsBusy);
+            }
+
+            if (IsSubmitElement(view) || IsResetElement(view))
+            {
+                ApplyBusyEnabledState(view);
+            }
+        }
+    }
+
+    private void ApplyBusyEnabledState(View view)
+    {
+        if (IsBusy)
+        {
+            if (!busyDisabledViews.ContainsKey(view))
+            {
+                busyDisabledViews[view] = view.IsEnabled;
+            }
+
+            view.IsEnabled = false;
+            return;
+        }
+
+        if (busyDisabledViews.TryGetValue(view, out var wasEnabled))
+        {
+            view.IsEnabled = wasEnabled;
+            busyDisabledViews.Remove(view);
+        }
+    }
+
+    private static void ApplyBusyIndicatorState(View view, bool isBusy)
+    {
+        view.IsVisible = isBusy;
+
+        if (view is ActivityIndicator activityIndicator)
+        {
+            activityIndicator.IsRunning = isBusy;
+        }
+    }
+
+    private static bool IsSubmitElement(BindableObject view)
+    {
+        return GetIsSubmitButton(view) || InputKitFormView.GetIsSubmitButton(view);
+    }
+
+    private static bool IsResetElement(BindableObject view)
+    {
+        return GetIsResetButton(view) || InputKitFormView.GetIsResetButton(view);
+    }
+
+    private static void OnIsBusyIndicatorChanged(BindableObject bindable, object oldValue, object newValue)
+    {
+        if (bindable is not View view)
+        {
+            return;
+        }
+
+        if ((bool)newValue)
+        {
+            ApplyBusyIndicatorState(view, FindParentFormView(view)?.IsBusy ?? false);
+        }
+    }
+
+    private static FormView FindParentFormView(Element element)
+    {
+        var parent = element.Parent;
+
+        while (parent is not null)
+        {
+            if (parent is FormView formView)
+            {
+                return formView;
+            }
+
+            parent = parent.Parent;
+        }
+
+        return null;
+    }
+
+    private void OnChildAdded(object sender, ElementEventArgs e)
+    {
+        ApplyBusyState();
+    }
+
+    private void OnChildRemoved(object sender, ElementEventArgs e)
+    {
+        if (e.Element is View view)
+        {
+            busyDisabledViews.Remove(view);
+        }
+    }
+}

--- a/src/UraniumUI/Dialogs/DefaultDialogService.cs
+++ b/src/UraniumUI/Dialogs/DefaultDialogService.cs
@@ -528,10 +528,9 @@ await ClosePopupAndSetResult(tcs, selected);
                         {
                             submit, new Command(async () =>
                             {
-                                formView.Submit();
-                                if (formView.IsValidated)
+                                if (await formView.SubmitAsync())
                                 {
-await ClosePopupAndSetResult(tcs, (TViewModel)formView.Source);
+                                    await ClosePopupAndSetResult(tcs, (TViewModel)formView.Source);
                                 }
                             })
                         },

--- a/src/UraniumUI/Validations/FormValidationContext.cs
+++ b/src/UraniumUI/Validations/FormValidationContext.cs
@@ -1,0 +1,32 @@
+using UraniumUI.Controls;
+
+namespace UraniumUI.Validations;
+
+public sealed class FormValidationContext
+{
+    public FormValidationContext(FormView formView, object model, IServiceProvider services, CancellationToken cancellationToken)
+    {
+        FormView = formView;
+        Model = model;
+        Services = services;
+        CancellationToken = cancellationToken;
+    }
+
+    public FormView FormView { get; }
+
+    public object Model { get; }
+
+    public IServiceProvider Services { get; }
+
+    public CancellationToken CancellationToken { get; }
+
+    public TModel GetModel<TModel>()
+    {
+        if (Model is TModel model)
+        {
+            return model;
+        }
+
+        throw new InvalidOperationException($"The validation model is not assignable to {typeof(TModel).FullName}.");
+    }
+}

--- a/src/UraniumUI/Validations/FormValidationError.cs
+++ b/src/UraniumUI/Validations/FormValidationError.cs
@@ -1,0 +1,26 @@
+namespace UraniumUI.Validations;
+
+public sealed class FormValidationError
+{
+    public FormValidationError(string message)
+        : this(message, Array.Empty<string>())
+    {
+    }
+
+    public FormValidationError(string message, string memberName)
+        : this(message, new[] { memberName })
+    {
+    }
+
+    public FormValidationError(string message, IEnumerable<string> memberNames)
+    {
+        Message = message;
+        MemberNames = memberNames?.Where(x => !string.IsNullOrWhiteSpace(x)).ToArray() ?? Array.Empty<string>();
+    }
+
+    public string Message { get; }
+
+    public IReadOnlyList<string> MemberNames { get; }
+
+    public bool IsFormLevel => MemberNames.Count == 0;
+}

--- a/src/UraniumUI/Validations/FormValidationHandler.cs
+++ b/src/UraniumUI/Validations/FormValidationHandler.cs
@@ -1,0 +1,3 @@
+namespace UraniumUI.Validations;
+
+public delegate Task<FormValidationResult> FormValidationHandler(FormValidationContext context);

--- a/src/UraniumUI/Validations/FormValidationMessage.cs
+++ b/src/UraniumUI/Validations/FormValidationMessage.cs
@@ -1,0 +1,15 @@
+using InputKit.Shared.Validations;
+
+namespace UraniumUI.Validations;
+
+internal sealed class FormValidationMessage : IValidation
+{
+    public FormValidationMessage(string message)
+    {
+        Message = message;
+    }
+
+    public string Message { get; }
+
+    public bool Validate(object value) => false;
+}

--- a/src/UraniumUI/Validations/FormValidationResult.cs
+++ b/src/UraniumUI/Validations/FormValidationResult.cs
@@ -1,0 +1,27 @@
+namespace UraniumUI.Validations;
+
+public sealed class FormValidationResult
+{
+    private FormValidationResult(bool isValid, IEnumerable<FormValidationError> errors)
+    {
+        Errors = errors?.Where(x => x is not null).ToArray() ?? Array.Empty<FormValidationError>();
+        IsValid = isValid && Errors.Count == 0;
+    }
+
+    public bool IsValid { get; }
+
+    public IReadOnlyList<FormValidationError> Errors { get; }
+
+    public static FormValidationResult Success() => new(true, Array.Empty<FormValidationError>());
+
+    public static FormValidationResult Invalid() => new(false, Array.Empty<FormValidationError>());
+
+    public static FormValidationResult Error(string message) => FromErrors(new FormValidationError(message));
+
+    public static FormValidationResult PropertyError(string propertyName, string message)
+        => FromErrors(new FormValidationError(message, propertyName));
+
+    public static FormValidationResult FromErrors(params FormValidationError[] errors) => FromErrors((IEnumerable<FormValidationError>)errors);
+
+    public static FormValidationResult FromErrors(IEnumerable<FormValidationError> errors) => new(false, errors);
+}

--- a/src/UraniumUI/Validations/IFormValidator.cs
+++ b/src/UraniumUI/Validations/IFormValidator.cs
@@ -1,0 +1,6 @@
+namespace UraniumUI.Validations;
+
+public interface IFormValidator
+{
+    Task<FormValidationResult> ValidateAsync(FormValidationContext context);
+}

--- a/test/UraniumUI.Tests/Controls/FormView_Test.cs
+++ b/test/UraniumUI.Tests/Controls/FormView_Test.cs
@@ -70,6 +70,30 @@ public class FormView_Test
     }
 
     [Fact]
+    public async Task SubmitAsync_ShouldRestoreBusyDisabledViews_WhenRemovedWhileBusy()
+    {
+        var validationCompletion = new TaskCompletionSource<FormValidationResult>();
+        var formView = new FormView
+        {
+            Validator = new TestFormValidator(_ => validationCompletion.Task)
+        };
+
+        var submitButton = new Button();
+        FormView.SetIsSubmitButton(submitButton, true);
+        formView.Children.Add(submitButton);
+
+        var submitTask = formView.SubmitAsync();
+
+        Assert.False(submitButton.IsEnabled);
+
+        formView.Children.Remove(submitButton);
+        validationCompletion.SetResult(FormValidationResult.Success());
+
+        Assert.True(await submitTask);
+        Assert.True(submitButton.IsEnabled);
+    }
+
+    [Fact]
     public async Task SubmitAsync_ShouldNotRunAsyncValidator_WhenLocalValidationFails()
     {
         var validatorCalled = false;

--- a/test/UraniumUI.Tests/Controls/FormView_Test.cs
+++ b/test/UraniumUI.Tests/Controls/FormView_Test.cs
@@ -1,0 +1,172 @@
+using InputKit.Shared.Abstraction;
+using InputKit.Shared.Validations;
+using UraniumUI.Controls;
+using UraniumUI.Tests.Core;
+using UraniumUI.Validations;
+
+namespace UraniumUI.Tests.Controls;
+
+public class FormView_Test
+{
+    public FormView_Test()
+    {
+        ApplicationExtensions.CreateAndSetMockApplication();
+    }
+
+    [Fact]
+    public async Task ValidateFormAsync_ShouldMapPropertyErrors_ToValidationPath()
+    {
+        var formView = new FormView
+        {
+            ValidationModel = new RegisterModel { UserName = "admin" },
+            Validator = new TestFormValidator(_ => Task.FromResult(FormValidationResult.PropertyError(
+                nameof(RegisterModel.UserName),
+                "The username has already been taken.")))
+        };
+
+        var field = new ValidatableView();
+        FormView.SetValidationPath(field, nameof(RegisterModel.UserName));
+        formView.Children.Add(field);
+
+        var result = await formView.ValidateFormAsync();
+
+        Assert.False(result.IsValid);
+        Assert.False(field.IsValid);
+        Assert.True(field.DisplayValidationCalled);
+        Assert.Single(field.Validations);
+        Assert.Equal("The username has already been taken.", field.Validations[0].Message);
+    }
+
+    [Fact]
+    public async Task SubmitAsync_ShouldToggleBusyIndicator_WhileValidatorRuns()
+    {
+        var validationCompletion = new TaskCompletionSource<FormValidationResult>();
+        var submitted = false;
+        var formView = new FormView
+        {
+            Validator = new TestFormValidator(_ => validationCompletion.Task),
+            SubmitCommand = new Command(() => submitted = true)
+        };
+
+        var busyIndicator = new ActivityIndicator();
+        FormView.SetIsBusyIndicator(busyIndicator, true);
+        formView.Children.Add(busyIndicator);
+
+        var submitTask = formView.SubmitAsync();
+
+        Assert.True(formView.IsBusy);
+        Assert.True(formView.IsValidating);
+        Assert.True(busyIndicator.IsVisible);
+        Assert.True(busyIndicator.IsRunning);
+
+        validationCompletion.SetResult(FormValidationResult.Success());
+
+        Assert.True(await submitTask);
+        Assert.True(submitted);
+        Assert.False(formView.IsBusy);
+        Assert.False(formView.IsValidating);
+        Assert.False(busyIndicator.IsVisible);
+        Assert.False(busyIndicator.IsRunning);
+    }
+
+    [Fact]
+    public async Task SubmitAsync_ShouldNotRunAsyncValidator_WhenLocalValidationFails()
+    {
+        var validatorCalled = false;
+        var formView = new FormView
+        {
+            Validator = new TestFormValidator(_ =>
+            {
+                validatorCalled = true;
+                return Task.FromResult(FormValidationResult.Success());
+            })
+        };
+
+        var field = new ValidatableView();
+        field.Validations.Add(new FailingValidation("Local validation failed."));
+        formView.Children.Add(field);
+
+        var result = await formView.SubmitAsync();
+
+        Assert.False(result);
+        Assert.False(validatorCalled);
+        Assert.True(field.DisplayValidationCalled);
+    }
+
+    [Fact]
+    public async Task InheritedSubmitCommand_ShouldUseAsyncSubmitOverride()
+    {
+        var validatorCalled = new TaskCompletionSource();
+        var formView = new CommandProbeFormView
+        {
+            Validator = new TestFormValidator(_ =>
+            {
+                validatorCalled.SetResult();
+                return Task.FromResult(FormValidationResult.Success());
+            })
+        };
+
+        formView.ExecuteInheritedSubmitCommand();
+
+        await validatorCalled.Task.WaitAsync(TimeSpan.FromSeconds(1));
+    }
+
+    private sealed class TestFormValidator : IFormValidator
+    {
+        private readonly Func<FormValidationContext, Task<FormValidationResult>> validate;
+
+        public TestFormValidator(Func<FormValidationContext, Task<FormValidationResult>> validate)
+        {
+            this.validate = validate;
+        }
+
+        public Task<FormValidationResult> ValidateAsync(FormValidationContext context)
+        {
+            return validate(context);
+        }
+    }
+
+    private sealed class ValidatableView : ContentView, IValidatable
+    {
+        public List<IValidation> Validations { get; } = new();
+
+        public bool IsValid => Validations.All(validation => validation.Validate(null));
+
+        public bool DisplayValidationCalled { get; private set; }
+
+        public void DisplayValidation()
+        {
+            DisplayValidationCalled = true;
+        }
+
+        public void ResetValidation()
+        {
+            DisplayValidationCalled = false;
+        }
+    }
+
+    private sealed class CommandProbeFormView : FormView
+    {
+        public void ExecuteInheritedSubmitCommand()
+        {
+            buttonSubmitCommand.Execute(null);
+        }
+    }
+
+    private sealed class FailingValidation : IValidation
+    {
+        public FailingValidation(string message)
+        {
+            Message = message;
+        }
+
+        public string Message { get; }
+
+        public bool Validate(object value) => false;
+    }
+
+    private sealed class RegisterModel
+    {
+        public string UserName { get; set; }
+    }
+}


### PR DESCRIPTION
## Summary
- add a UraniumUI-owned `FormView` layer with async validation support on top of InputKit `FormView`
- add framework-neutral form validation context/result APIs, field error mapping, and busy indicator support
- wire `AutoFormView` and dialog form submissions through `SubmitAsync()` and document MVVM usage
- add a DemoApp sample that demonstrates long-running async validation and busy indicators

## Testing
- `dotnet test test\UraniumUI.Tests\UraniumUI.Tests.csproj -f net10.0`
- `dotnet test test\UraniumUI.Material.Tests\UraniumUI.Material.Tests.csproj -f net10.0`
- `dotnet build src\UraniumUI\UraniumUI.csproj -f net10.0`
- `dotnet build src\UraniumUI\UraniumUI.csproj -f net9.0`
- `dotnet build src\UraniumUI.Material\UraniumUI.Material.csproj -f net10.0`
- `dotnet build src\UraniumUI.Dialogs.Mopups\UraniumUI.Dialogs.Mopups.csproj -f net10.0`
- `dotnet build src\UraniumUI.Dialogs.CommunityToolkit\UraniumUI.Dialogs.CommunityToolkit.csproj -f net10.0`
- `dotnet build src\UraniumUI.Dialogs.Mopups\UraniumUI.Dialogs.Mopups.csproj -f net9.0`
- `dotnet build src\UraniumUI.Dialogs.CommunityToolkit\UraniumUI.Dialogs.CommunityToolkit.csproj -f net9.0`
- `dotnet build demo\UraniumApp\UraniumApp.csproj -f net10.0-windows10.0.19041.0`

Closes #1027
