### PR TITLE
Fix TabView content binding context

### DIFF
--- a/src/UraniumUI.Material/Controls/TabView.cs
+++ b/src/UraniumUI.Material/Controls/TabView.cs
@@ -185,7 +185,6 @@ public partial class TabView : Grid
                     this.RowDefinitions.Add(new RowDefinition(GridLength.Star));
                     this.RowDefinitions.Add(new RowDefinition(GridLength.Auto));
 
-
                     Grid.SetRow(_headerScrollView, 1);
                     Grid.SetColumn(_headerScrollView, 0);
 
@@ -197,7 +196,6 @@ public partial class TabView : Grid
                 {
                     this.ColumnDefinitions.Add(new ColumnDefinition(GridLength.Auto));
                     this.ColumnDefinitions.Add(new ColumnDefinition(GridLength.Star));
-
 
                     Grid.SetRow(_headerScrollView, 0);
                     Grid.SetColumn(_headerScrollView, 0);
@@ -473,43 +471,7 @@ public partial class TabView : Grid
             oldValue.Content = null; // Make it null, in the next visit of this method, a new instance will be created.
         }
 
-        if (CachingStrategy == TabViewCachingStrategy.CacheOnLayout)
-        {
-            if (_contentContainer.Content is not Layout layout)
-            {
-                layout = new Grid();
-                _contentContainer.Content = layout;
-            }
-
-            var existing = layout.Children.FirstOrDefault(x => x == content);
-            if (existing == null)
-            {
-                layout.Children.Add(content);
-            }
-
-            foreach (var child in layout.Children)
-            {
-                (child as View).IsVisible = content == child;
-            }
-        }
-        else
-        {
-            if (_contentContainer.Content != null)
-            {
-                if (UseAnimation)
-                {
-                    await _contentContainer.Content?.FadeToSafely(0, 60);
-                }
-            }
-
-            content.Opacity = 0;
-
-            _contentContainer.Content = content;
-            if (UseAnimation)
-            {
-                await content.FadeToSafely(1, 60);
-            }
-        }
+        await PresentContentAsync(content);
 
         content.Opacity = 1;
 
@@ -520,6 +482,47 @@ public partial class TabView : Grid
 
         SelectedTabChanged?.Invoke(this, newValue);
         ExecuteCommandIfCan(SelectedTabChangedCommand, newValue);
+    }
+
+    private async Task PresentContentAsync(View content)
+    {
+        if (CachingStrategy == TabViewCachingStrategy.CacheOnLayout)
+        {
+            PresentContentOnLayout(content);
+            return;
+        }
+
+        if (_contentContainer.Content != null && UseAnimation)
+        {
+            await _contentContainer.Content?.FadeToSafely(0, 60);
+        }
+
+        content.Opacity = 0;
+
+        _contentContainer.Content = content;
+        if (UseAnimation)
+        {
+            await content.FadeToSafely(1, 60);
+        }
+    }
+
+    private void PresentContentOnLayout(View content)
+    {
+        if (_contentContainer.Content is not Layout layout)
+        {
+            layout = new Grid();
+            _contentContainer.Content = layout;
+        }
+
+        if (!layout.Children.Any(x => x == content))
+        {
+            layout.Children.Add(content);
+        }
+
+        foreach (var child in layout.Children)
+        {
+            (child as View).IsVisible = content == child;
+        }
     }
 
     private void ApplyContentBindingContext(TabItem tabItem, View content)

--- a/src/UraniumUI.Material/Controls/TabView.cs
+++ b/src/UraniumUI.Material/Controls/TabView.cs
@@ -461,10 +461,7 @@ public partial class TabView : Grid
             ((View)newValue.ContentTemplate?.CreateContent()
                 ?? (View)ItemTemplate?.CreateContent());
 
-        if (content.BindingContext is null && newValue.Data is not null && content.BindingContext != newValue.Data)
-        {
-            content.BindingContext = newValue.Data;
-        }
+        ApplyContentBindingContext(newValue, content);
 
         foreach (var item in Tabs)
         {
@@ -523,6 +520,25 @@ public partial class TabView : Grid
 
         SelectedTabChanged?.Invoke(this, newValue);
         ExecuteCommandIfCan(SelectedTabChangedCommand, newValue);
+    }
+
+    private void ApplyContentBindingContext(TabItem tabItem, View content)
+    {
+        if (tabItem.Data is not null)
+        {
+            if (content.BindingContext is null)
+            {
+                content.RemoveBinding(BindingContextProperty);
+                content.BindingContext = tabItem.Data;
+            }
+
+            return;
+        }
+
+        if (content.BindingContext is null)
+        {
+            content.SetBinding(BindingContextProperty, new Binding(nameof(BindingContext), source: this));
+        }
     }
 
     protected virtual void OnTabPlacementChanged()

--- a/test/UraniumUI.Material.Tests/Controls/TabView_Test.cs
+++ b/test/UraniumUI.Material.Tests/Controls/TabView_Test.cs
@@ -1,0 +1,124 @@
+using Shouldly;
+using System.Collections.ObjectModel;
+using System.Linq;
+using UraniumUI.Dialogs;
+using UraniumUI.Material.Controls;
+using UraniumUI.Material.Tests.Mocks;
+using UraniumUI.Tests.Core;
+
+namespace UraniumUI.Material.Tests.Controls;
+
+public class TabView_Test
+{
+    public TabView_Test()
+    {
+        ApplicationExtensions.CreateAndSetMockApplication(builder =>
+        {
+            builder.Services.AddSingleton<IDialogService, MockDialogService>();
+        });
+    }
+
+    [Fact]
+    public void CacheOnCodeBehind_ShouldKeepMultiplePickerFieldSelection_WhenSwitchingTabs()
+    {
+        var viewModel = new MultiplePickerViewModel();
+        viewModel.SelectedItems.Add(viewModel.ItemsSource[0]);
+
+        var pickerField = AnimationReadyHandler.Prepare(new TestMultiplePickerField());
+        pickerField.SetBinding(MultiplePickerField.ItemsSourceProperty, new Binding(nameof(MultiplePickerViewModel.ItemsSource)));
+        pickerField.SetBinding(MultiplePickerField.SelectedItemsProperty, new Binding(nameof(MultiplePickerViewModel.SelectedItems)));
+
+        var firstTabContent = new VerticalStackLayout();
+        firstTabContent.Add(pickerField);
+
+        var tabView = AnimationReadyHandler.Prepare(new TabView
+        {
+            BindingContext = viewModel,
+            TabHeaderItemTemplate = CreateTestHeaderTemplate(),
+            UseAnimation = false,
+        });
+
+        tabView.Tabs.Add(new TabItem { Title = "Picker", Content = firstTabContent });
+        tabView.Tabs.Add(new TabItem { Title = "Other", Content = new Label { Text = "Other" } });
+
+        pickerField.GetChipTexts().ShouldBe(new[] { "Option 1" });
+
+        tabView.SelectedTab = tabView.Tabs[1];
+        tabView.SelectedTab = tabView.Tabs[0];
+
+        pickerField.SelectedItems.ShouldBeSameAs(viewModel.SelectedItems);
+        pickerField.GetChipTexts().ShouldBe(new[] { "Option 1" });
+
+        viewModel.SelectedItems.Add(viewModel.ItemsSource[1]);
+
+        pickerField.GetChipTexts().ShouldBe(new[] { "Option 1", "Option 2" });
+    }
+
+    [Fact]
+    public void CacheOnCodeBehind_ShouldKeepPickerFieldSelectedIndex_WhenSwitchingTabs()
+    {
+        var viewModel = new PickerViewModel { SelectedIndex = 1 };
+
+        var pickerField = AnimationReadyHandler.Prepare(new PickerField());
+        pickerField.SetBinding(PickerField.ItemsSourceProperty, new Binding(nameof(PickerViewModel.ItemsSource)));
+        pickerField.SetBinding(PickerField.SelectedIndexProperty, new Binding(nameof(PickerViewModel.SelectedIndex)));
+
+        var firstTabContent = new VerticalStackLayout();
+        firstTabContent.Add(pickerField);
+
+        var tabView = AnimationReadyHandler.Prepare(new TabView
+        {
+            BindingContext = viewModel,
+            TabHeaderItemTemplate = CreateTestHeaderTemplate(),
+            UseAnimation = false,
+        });
+
+        tabView.Tabs.Add(new TabItem { Title = "Picker", Content = firstTabContent });
+        tabView.Tabs.Add(new TabItem { Title = "Other", Content = new Label { Text = "Other" } });
+
+        pickerField.SelectedIndex.ShouldBe(1);
+
+        tabView.SelectedTab = tabView.Tabs[1];
+        tabView.SelectedTab = tabView.Tabs[0];
+
+        pickerField.SelectedIndex.ShouldBe(1);
+        viewModel.SelectedIndex.ShouldBe(1);
+    }
+
+    private sealed class TestMultiplePickerField : MultiplePickerField
+    {
+        public string[] GetChipTexts()
+        {
+            return chipsHolderLayout.Children.OfType<Chip>().Select(chip => chip.Text).ToArray();
+        }
+    }
+
+    private static DataTemplate CreateTestHeaderTemplate()
+    {
+        return new DataTemplate(() => new Label());
+    }
+
+    private sealed class MultiplePickerViewModel
+    {
+        public ObservableCollection<string> ItemsSource { get; } = new()
+        {
+            "Option 1",
+            "Option 2",
+            "Option 3",
+        };
+
+        public ObservableCollection<string> SelectedItems { get; } = new();
+    }
+
+    private sealed class PickerViewModel
+    {
+        public ObservableCollection<string> ItemsSource { get; } = new()
+        {
+            "Option 1",
+            "Option 2",
+            "Option 3",
+        };
+
+        public int SelectedIndex { get; set; }
+    }
+}


### PR DESCRIPTION
## Summary

- Fix `TabView` content binding context for cached tab content without `TabItem.Data`.
- Preserve existing `TabItem.Data` binding-context behavior.
- Add regression coverage for `MultiplePickerField.SelectedItems` and `PickerField.SelectedIndex` across tab switches.

## Tests

- `dotnet test "test\UraniumUI.Material.Tests\UraniumUI.Material.Tests.csproj"`

Closes #677
