### PR TITLE
Fix InputField formatted title support

### DIFF
--- a/docs/en/themes/material/components/InputField.md
+++ b/docs/en/themes/material/components/InputField.md
@@ -24,6 +24,20 @@ InputField can be used in XAML like any other control. You can pass an existing 
 </material:InputField>
 ```
 
+You can use `TitleFormattedText` when the floating title needs styled spans:
+
+```xml
+<material:InputField HasValue="True">
+    <material:InputField.TitleFormattedText>
+        <FormattedString>
+            <Span Text="Pick a Time" FontAttributes="Bold" />
+            <Span Text=" *" TextColor="Red" />
+        </FormattedString>
+    </material:InputField.TitleFormattedText>
+    <TimePicker BackgroundColor="Transparent" />
+</material:InputField>
+```
+
 ![MAUI Material Design Picker](../../../../images/inputfield-demo-timepicker.png)
 
 ### Inherit from InputField
@@ -100,6 +114,7 @@ InputField has the following style classes that can be used to style the control
 
 ## Properties
 - `Title`: The floating label text
+- `TitleFormattedText`: The floating label formatted text
 - `AccentColor`: The color used for focused state and validation
 - `TitleColor`: The color of the floating label
 - `BorderColor`: The color of the input border

--- a/src/UraniumUI.Material/Controls/InputField.cs
+++ b/src/UraniumUI.Material/Controls/InputField.cs
@@ -467,10 +467,21 @@ public partial class InputField : ContentView
     private void ApplyTitleFormattedText()
     {
         var currentLabelTitle = labelTitle;
-        if (currentLabelTitle is not null)
+        if (currentLabelTitle is null)
         {
-            currentLabelTitle.FormattedText = TitleFormattedText;
+            return;
         }
+
+        if (TitleFormattedText is null)
+        {
+            currentLabelTitle.FormattedText = null;
+            currentLabelTitle.SetBinding(Label.TextProperty, GetRelativeBinding(nameof(Title)));
+            return;
+        }
+
+        currentLabelTitle.RemoveBinding(Label.TextProperty);
+        currentLabelTitle.Text = null;
+        currentLabelTitle.FormattedText = TitleFormattedText;
     }
 
     protected override void OnApplyTemplate()

--- a/src/UraniumUI.Material/Controls/InputField.cs
+++ b/src/UraniumUI.Material/Controls/InputField.cs
@@ -464,6 +464,15 @@ public partial class InputField : ContentView
         InitializeBorder();
     }
 
+    private void ApplyTitleFormattedText()
+    {
+        var currentLabelTitle = labelTitle;
+        if (currentLabelTitle is not null)
+        {
+            currentLabelTitle.FormattedText = TitleFormattedText;
+        }
+    }
+
     protected override void OnApplyTemplate()
     {
         base.OnApplyTemplate();
@@ -471,6 +480,8 @@ public partial class InputField : ContentView
         isTemplateApplied = true;
 
         ResetTemplateParts();
+
+        ApplyTitleFormattedText();
 
         if (Icon != null)
         {
@@ -558,6 +569,20 @@ public partial class InputField : ContentView
         typeof(InputField),
         string.Empty,
         propertyChanged: (bo, ov, nv) => (bo as InputField).InitializeBorder());
+
+    public FormattedString TitleFormattedText { get => (FormattedString)GetValue(TitleFormattedTextProperty); set => SetValue(TitleFormattedTextProperty, value); }
+
+    public static readonly BindableProperty TitleFormattedTextProperty = BindableProperty.Create(
+        nameof(TitleFormattedText),
+        typeof(FormattedString),
+        typeof(InputField),
+        default(FormattedString),
+        propertyChanged: (bo, ov, nv) =>
+        {
+            var inputField = bo as InputField;
+            inputField.ApplyTitleFormattedText();
+            inputField.InitializeBorder();
+        });
 
     public Color AccentColor { get => (Color)GetValue(AccentColorProperty); set => SetValue(AccentColorProperty, value); }
 

--- a/test/UraniumUI.Material.Tests/Controls/TextField_Test.cs
+++ b/test/UraniumUI.Material.Tests/Controls/TextField_Test.cs
@@ -106,6 +106,21 @@ public class TextField_Test
 
         titleLabel.ShouldNotBeNull();
         titleLabel.FormattedText.ShouldBeSameAs(formattedTitle);
+        titleLabel.Text.ShouldBeNull();
+
+        control.Title = "Updated plain title";
+
+        titleLabel.FormattedText.ShouldBeSameAs(formattedTitle);
+        titleLabel.Text.ShouldBeNull();
+
+        control.TitleFormattedText = null;
+
+        titleLabel.FormattedText.ShouldBeNull();
+        titleLabel.Text.ShouldBe(control.Title);
+
+        control.Title = "Restored plain title";
+
+        titleLabel.Text.ShouldBe(control.Title);
     }
 
     [Fact]

--- a/test/UraniumUI.Material.Tests/Controls/TextField_Test.cs
+++ b/test/UraniumUI.Material.Tests/Controls/TextField_Test.cs
@@ -94,6 +94,21 @@ public class TextField_Test
     }
 
     [Fact]
+    public void TitleFormattedText_ShouldBind_ToTitleLabel()
+    {
+        var formattedTitle = new FormattedString();
+        formattedTitle.Spans.Add(new Span { Text = "Name", FontAttributes = FontAttributes.Bold });
+        formattedTitle.Spans.Add(new Span { Text = " *", TextColor = Colors.Red });
+
+        var control = AnimationReadyHandler.Prepare(new TextField { TitleFormattedText = formattedTitle });
+
+        var titleLabel = control.FindByViewQueryIdInVisualTreeDescendants<Label>("TitleLabel");
+
+        titleLabel.ShouldNotBeNull();
+        titleLabel.FormattedText.ShouldBeSameAs(formattedTitle);
+    }
+
+    [Fact]
     public void Attachments_Container_HasDefaultSpacingFromBorderAndBetweenChildren()
     {
         // The Attachments container provides a default gap to the field border and


### PR DESCRIPTION
## Summary
- Adds `TitleFormattedText` to `InputField` so floating titles can use formatted spans without reaching into template internals.
- Applies the formatted title when the template is applied and when the property changes.
- Documents the XAML usage and adds a regression test for the title label.

## Testing
- `dotnet test "test\UraniumUI.Tests.sln"`
