### PR TITLE
Add spell check toggle to TextField

### DIFF
--- a/docs/en/themes/material/components/TextField.md
+++ b/docs/en/themes/material/components/TextField.md
@@ -31,6 +31,7 @@ Then you can use it like this:
 - `IsPassword` - Gets or sets whether the TextField should mask its text
 - `MaxLength` - Gets or sets the maximum length of text allowed
 - `IsTextPredictionEnabled` - Gets or sets whether text prediction is enabled
+- `IsSpellCheckEnabled` - Gets or sets whether spell checking is enabled
 - `CharacterSpacing` - Gets or sets the spacing between characters
 - `HorizontalTextAlignment` - Gets or sets the horizontal alignment of the text
 

--- a/src/UraniumUI.Material/Controls/TextField.BindableProperties.cs
+++ b/src/UraniumUI.Material/Controls/TextField.BindableProperties.cs
@@ -139,6 +139,18 @@ public partial class TextField
             (bindable as TextField).EntryView.IsTextPredictionEnabled = (bool)newValue;
         });
 
+    public bool IsSpellCheckEnabled { get => (bool)GetValue(IsSpellCheckEnabledProperty); set => SetValue(IsSpellCheckEnabledProperty, value); }
+
+    public static readonly BindableProperty IsSpellCheckEnabledProperty = BindableProperty.Create(
+        nameof(IsSpellCheckEnabled),
+        typeof(bool),
+        typeof(TextField),
+        Entry.IsSpellCheckEnabledProperty.DefaultValue,
+        propertyChanged: (bindable, oldValue, newValue) =>
+        {
+            (bindable as TextField).EntryView.IsSpellCheckEnabled = (bool)newValue;
+        });
+
     public int MaxLength { get => (int)GetValue(MaxLengthProperty); set => SetValue(MaxLengthProperty, value); }
 
     public static readonly BindableProperty MaxLengthProperty = BindableProperty.Create(

--- a/test/UraniumUI.Material.Tests/Controls/TextField_Test.cs
+++ b/test/UraniumUI.Material.Tests/Controls/TextField_Test.cs
@@ -268,6 +268,37 @@ public class TextField_Test
     }
 
     [Fact]
+    public void IsSpellCheckEnabled_ShouldBeSet_FromViewModel()
+    {
+        var control = AnimationReadyHandler.Prepare(new TextField());
+        var viewModel = new TestViewModel { IsSpellCheckEnabled = false };
+        control.BindingContext = viewModel;
+
+        // Act
+        control.SetBinding(TextField.IsSpellCheckEnabledProperty, new Binding(nameof(TestViewModel.IsSpellCheckEnabled)));
+
+        // Assert
+        control.IsSpellCheckEnabled.ShouldBeFalse();
+        control.EntryView.IsSpellCheckEnabled.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void IsSpellCheckEnabled_ShouldBeUpdated_FromViewModel()
+    {
+        var control = AnimationReadyHandler.Prepare(new TextField());
+        var viewModel = new TestViewModel { IsSpellCheckEnabled = true };
+        control.BindingContext = viewModel;
+        control.SetBinding(TextField.IsSpellCheckEnabledProperty, new Binding(nameof(TestViewModel.IsSpellCheckEnabled)));
+
+        // Act
+        viewModel.IsSpellCheckEnabled = false;
+
+        // Assert
+        control.IsSpellCheckEnabled.ShouldBeFalse();
+        control.EntryView.IsSpellCheckEnabled.ShouldBeFalse();
+    }
+
+    [Fact]
     public void Keyboard_ShouldBeSet_FromViewModel()
     {
         var control = AnimationReadyHandler.Prepare(new TextField());
@@ -440,6 +471,7 @@ public class TextField_Test
         private ICommand command;
         private int selectionLength;
         private bool isPassword;
+        private bool isSpellCheckEnabled;
         private Keyboard keyboard;
         private ClearButtonVisibility clearButtonVisibility;
         private double characterSpacing;
@@ -455,6 +487,8 @@ public class TextField_Test
         public int SelectionLength { get => selectionLength; set => SetProperty(ref selectionLength, value); }
 
         public bool IsPassword { get => isPassword; set => SetProperty(ref isPassword, value); }
+
+        public bool IsSpellCheckEnabled { get => isSpellCheckEnabled; set => SetProperty(ref isSpellCheckEnabled, value); }
 
         public Keyboard Keyboard { get => keyboard; set => SetProperty(ref keyboard, value); }
 


### PR DESCRIPTION
## Summary

- Exposes `IsSpellCheckEnabled` on Material `TextField`
- Forwards the value to the inner MAUI `EntryView`
- Documents the property and adds binding regression tests

## Tests

- `dotnet test "test\UraniumUI.Material.Tests\UraniumUI.Material.Tests.csproj" --no-restore`
- `dotnet test "test\UraniumUI.Tests.sln" --no-restore`
