### PR TITLE
Fix DatePickerField icon spacing

### DIFF
--- a/src/UraniumUI.Material/Controls/DatePickerField.cs
+++ b/src/UraniumUI.Material/Controls/DatePickerField.cs
@@ -124,7 +124,14 @@ public class DatePickerField : InputField
 
     protected override void OnIconChanged()
     {
+        var dateLabelMargin = Content?.Margin ?? default;
+
         base.OnIconChanged();
+
+        if (Icon != null && Content != null)
+        {
+            Content.Margin = dateLabelMargin;
+        }
 
         if (Icon == null)
         {

--- a/test/UraniumUI.Material.Tests/Controls/DatePickerField_Test.cs
+++ b/test/UraniumUI.Material.Tests/Controls/DatePickerField_Test.cs
@@ -190,6 +190,21 @@ public class DatePickerField_Test
     }
 
     [Fact]
+    public void Icon_ShouldPreserveDateLabelLeadingMargin()
+    {
+        var control = AnimationReadyHandler.Prepare(new DatePickerField
+        {
+            Icon = new FontImageSource
+            {
+                FontFamily = "MaterialSharp",
+                Glyph = "A",
+            },
+        });
+
+        control.Content.Margin.ShouldBe(new Thickness(10, 0));
+    }
+
+    [Fact]
     public async Task DatePrompt_ShouldUpdateDate_WhenDialogReturnsDate()
     {
         var dialogService = UseMockDialogService();

--- a/test/UraniumUI.Material.Tests/Controls/DatePickerField_Test.cs
+++ b/test/UraniumUI.Material.Tests/Controls/DatePickerField_Test.cs
@@ -201,7 +201,7 @@ public class DatePickerField_Test
             },
         });
 
-        control.Content.Margin.ShouldBe(new Thickness(10, 0));
+        control.Content.Margin.ShouldBe(new Thickness(InputField.EdgePadding, 0));
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
- preserve DatePickerField label leading margin when a leading icon is present
- keep the existing DatePickerView icon-specific margin behavior unchanged
- add a regression test for icon-enabled DatePickerField spacing

## Testing
- dotnet test test/UraniumUI.Material.Tests/UraniumUI.Material.Tests.csproj --filter FullyQualifiedName~DatePickerField_Test
