### PR TITLE
Fix DataGrid Android release crash

### DIFF
--- a/src/UraniumUI.Material/Controls/DataGridValueBindingExtension.cs
+++ b/src/UraniumUI.Material/Controls/DataGridValueBindingExtension.cs
@@ -3,6 +3,7 @@
 public class DataGridValueBindingExtension : IMarkupExtension, IMarkupExtension<BindingBase>
 {
     public BindingMode Mode { get; set; }
+
     public object ProvideValue(IServiceProvider serviceProvider)
     {
         var targetObject = serviceProvider.GetRequiredService<IProvideValueTarget>()
@@ -25,6 +26,7 @@ public class DataGridValueBindingExtension : IMarkupExtension, IMarkupExtension<
 
     BindingBase IMarkupExtension<BindingBase>.ProvideValue(IServiceProvider serviceProvider)
     {
-        return (this as IMarkupExtension<BindingBase>).ProvideValue(serviceProvider);
+        ProvideValue(serviceProvider);
+        return default;
     }
 }

--- a/test/UraniumUI.Material.Tests/Controls/DataGrid_Test.cs
+++ b/test/UraniumUI.Material.Tests/Controls/DataGrid_Test.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using Microsoft.Maui.Controls.Xaml;
 using Shouldly;
 using UraniumUI.Material.Controls;
 using UraniumUI.Tests.Core;
@@ -168,11 +169,49 @@ public class DataGrid_Test
         rootGrid.RowDefinitions.Any(x => x.Height.IsStar).ShouldBeFalse();
     }
 
+    [Fact]
+    public void DataGridValueBinding_GenericProvideValue_ShouldAttachBinding_WhenBindingContextBecomesBinding()
+    {
+        var target = AnimationReadyHandler.Prepare(new Entry());
+        var source = new DataGridEditableRow { Name = "One" };
+        var extension = new DataGridValueBindingExtension { Mode = BindingMode.TwoWay };
+
+        var binding = ((IMarkupExtension<BindingBase>)extension)
+            .ProvideValue(new DataGridValueBindingServiceProvider(target, Entry.TextProperty));
+
+        binding.ShouldBeNull();
+
+        target.BindingContext = new Binding(nameof(DataGridEditableRow.Name), source: source);
+
+        target.Text.ShouldBe("One");
+
+        target.Text = "Two";
+
+        source.Name.ShouldBe("Two");
+    }
+
     private sealed class DataGridRow
     {
         public int Id { get; init; }
 
         public string Name { get; init; }
+    }
+
+    private sealed class DataGridEditableRow
+    {
+        public string Name { get; set; }
+    }
+
+    private sealed class DataGridValueBindingServiceProvider(View targetObject, BindableProperty targetProperty) : IServiceProvider, IProvideValueTarget
+    {
+        public object TargetObject { get; } = targetObject;
+
+        public object TargetProperty { get; } = targetProperty;
+
+        public object GetService(Type serviceType)
+        {
+            return serviceType == typeof(IProvideValueTarget) ? this : null;
+        }
     }
 
     internal class DataGridTestViewModel : UraniumBindableObject


### PR DESCRIPTION
## Summary
- fix `DataGridValueBindingExtension` so the generic `IMarkupExtension<BindingBase>` path no longer recurses into itself
- keep `DataGrid` cell-template binding hookup working when XAML compiled/release paths use the generic markup extension interface
- add a focused regression test for the generic `ProvideValue` path

## Automated Testing
- `dotnet test test/UraniumUI.Material.Tests/UraniumUI.Material.Tests.csproj --filter FullyQualifiedName~DataGrid_Test`
- `dotnet build demo/UraniumApp/UraniumApp.csproj -f net10.0-android -c Release`

## Manual Testing
- Environment: Android 14 release build
- Add a `DataGrid` that uses a custom `CellItemTemplate` with `{material:DataGridValueBinding}` inside the cell view
- Open the page in a Release Android build
- Expected result: the page renders without crashing and the cell content binds normally

Closes #847
