### PR TITLE
fix: validate FormView bindable layout children

### DIFF
--- a/src/UraniumUI/Controls/FormView.cs
+++ b/src/UraniumUI/Controls/FormView.cs
@@ -153,7 +153,7 @@ public class FormView : InputKitFormView
     {
         ClearFormValidationMessages();
 
-        if (!InputKitFormView.CheckValidation(this))
+        if (!CheckChildValidation())
         {
             DisplayChildValidations();
             var invalidResult = FormValidationResult.Invalid();
@@ -307,6 +307,19 @@ public class FormView : InputKitFormView
         {
             validatable.DisplayValidation();
         }
+    }
+
+    private bool CheckChildValidation()
+    {
+        foreach (var (validatable, _) in GetChildValidatables())
+        {
+            if (!validatable.IsValid)
+            {
+                return false;
+            }
+        }
+
+        return true;
     }
 
     private IEnumerable<(IValidatable validatable, BindableObject bindable)> GetValidatablesByPath(string validationPath)

--- a/test/UraniumUI.Tests/Controls/FormView_Test.cs
+++ b/test/UraniumUI.Tests/Controls/FormView_Test.cs
@@ -118,6 +118,40 @@ public class FormView_Test
     }
 
     [Fact]
+    public async Task SubmitAsync_ShouldValidateBindableLayoutChildren()
+    {
+        var validatorCalled = false;
+        var formView = new FormView
+        {
+            Validator = new TestFormValidator(_ =>
+            {
+                validatorCalled = true;
+                return Task.FromResult(FormValidationResult.Success());
+            })
+        };
+
+        var itemsHost = new VerticalStackLayout();
+        ValidatableView field = null;
+
+        BindableLayout.SetItemTemplate(itemsHost, new DataTemplate(() =>
+        {
+            field = new ValidatableView();
+            field.Validations.Add(new FailingValidation("Local validation failed."));
+            return field;
+        }));
+        BindableLayout.SetItemsSource(itemsHost, new[] { "item" });
+
+        formView.Children.Add(itemsHost);
+
+        var result = await formView.SubmitAsync();
+
+        Assert.NotNull(field);
+        Assert.False(result);
+        Assert.False(validatorCalled);
+        Assert.True(field.DisplayValidationCalled);
+    }
+
+    [Fact]
     public async Task InheritedSubmitCommand_ShouldUseAsyncSubmitOverride()
     {
         var validatorCalled = new TaskCompletionSource();


### PR DESCRIPTION
## Summary
- validate nested `FormView` fields by traversing UraniumUI child validatables instead of relying on the InputKit form-level check
- add regression coverage for `BindableLayout` items inside `FormView`

## Automated Testing
- `dotnet test test/UraniumUI.Tests/UraniumUI.Tests.csproj --filter FullyQualifiedName~FormView_Test`
- `dotnet build src/UraniumUI/UraniumUI.csproj -f net10.0`

Closes #858
