### PR TITLE
feat: add TreeView selection change events

### DIFF
--- a/docs/en/themes/material/components/TreeView.md
+++ b/docs/en/themes/material/components/TreeView.md
@@ -154,11 +154,20 @@ If the node object contain its children in a different property, you can set `Ch
 ## Selection
 TreeView supports single selection and multiple selection. You can set `SelectionMode` property of the TreeView to `Single` or `Multiple` to enable selection. Default value is `None`. You can bind `SelectedItem` or `SelectedItems` property of the TreeView to a property in your ViewModel to get the selected item or items.
 
+If you prefer event or command-based handling instead of binding to a reactive property, `TreeView` also provides `SelectedItemChanged` / `SelectedItemChangedCommand` for single selection and `SelectedItemsChanged` / `SelectedItemsChangedCommand` for multiple selection.
+
 <iframe width="560" height="315" src="https://www.youtube.com/embed/OUPiPGqotMc?si=c47cssoVKtnXdXtL" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
 
 ### Single Selection
 ```xml
 <material:TreeView ItemsSource="{Binding Nodes}" SelectionMode="Single" SelectedItem="{Binding SelectedNode}" />
+```
+
+```xml
+<material:TreeView
+    ItemsSource="{Binding Nodes}"
+    SelectionMode="Single"
+    SelectedItemChangedCommand="{Binding NodeSelectedCommand}" />
 ```
 
 | Light | Dark |
@@ -169,6 +178,13 @@ TreeView supports single selection and multiple selection. You can set `Selectio
 
 ```xml
 <material:TreeView ItemsSource="{Binding Nodes}" SelectionMode="Multiple" SelectedItems="{Binding SelectedNodes}" />
+```
+
+```xml
+<material:TreeView
+    ItemsSource="{Binding Nodes}"
+    SelectionMode="Multiple"
+    SelectedItemsChangedCommand="{Binding SelectedNodesChangedCommand}" />
 ```
 
 | Light | Dark |

--- a/src/UraniumUI.Material/Controls/TreeView.cs
+++ b/src/UraniumUI.Material/Controls/TreeView.cs
@@ -25,6 +25,10 @@ public partial class TreeView : ContentView
     private long checkStateVersion;
     private bool isSelectedItemsUpdating;
 
+    public event EventHandler<object> SelectedItemChanged;
+
+    public event EventHandler<IList> SelectedItemsChanged;
+
     public TreeView()
     {
         dataController = new TreeViewDataController
@@ -58,7 +62,7 @@ public partial class TreeView : ContentView
 
         if (SelectedItems is INotifyCollectionChanged observableSelectedItems)
         {
-            observableSelectedItems.CollectionChanged -= SelectedItemsChanged;
+            observableSelectedItems.CollectionChanged -= OnSelectedItemsCollectionChanged;
 
             if (Handler is null)
             {
@@ -66,7 +70,7 @@ public partial class TreeView : ContentView
             }
             else
             {
-                observableSelectedItems.CollectionChanged += SelectedItemsChanged;
+                observableSelectedItems.CollectionChanged += OnSelectedItemsCollectionChanged;
                 dataController.Attach();
             }
         }
@@ -163,6 +167,15 @@ public partial class TreeView : ContentView
         nameof(SelectedItem), typeof(object), typeof(TreeView), default, BindingMode.TwoWay,
         propertyChanged: (bindable, oldValue, newValue) => (bindable as TreeView)?.OnSelectedItemChanged(oldValue, newValue));
 
+    public ICommand SelectedItemChangedCommand
+    {
+        get => (ICommand)GetValue(SelectedItemChangedCommandProperty);
+        set => SetValue(SelectedItemChangedCommandProperty, value);
+    }
+
+    public static readonly BindableProperty SelectedItemChangedCommandProperty = BindableProperty.Create(
+        nameof(SelectedItemChangedCommand), typeof(ICommand), typeof(TreeView));
+
     public IList SelectedItems
     {
         get => (IList)GetValue(SelectedItemsProperty);
@@ -173,6 +186,15 @@ public partial class TreeView : ContentView
         nameof(SelectedItems), typeof(IList), typeof(TreeView),
         defaultValueCreator: _ => new ObservableCollection<object>(),
         propertyChanged: (bindable, oldValue, newValue) => (bindable as TreeView)?.OnSelectedItemsChanged((IList)oldValue, (IList)newValue));
+
+    public ICommand SelectedItemsChangedCommand
+    {
+        get => (ICommand)GetValue(SelectedItemsChangedCommandProperty);
+        set => SetValue(SelectedItemsChangedCommandProperty, value);
+    }
+
+    public static readonly BindableProperty SelectedItemsChangedCommandProperty = BindableProperty.Create(
+        nameof(SelectedItemsChangedCommand), typeof(ICommand), typeof(TreeView));
 
     public DataTemplate ExpanderTemplate
     {
@@ -519,40 +541,53 @@ public partial class TreeView : ContentView
         dataController.RefreshAllSelection();
     }
 
+    private void NotifySelectedItemChanged(object selectedItem)
+    {
+        SelectedItemChanged?.Invoke(this, selectedItem);
+        SelectedItemChangedCommand?.Execute(selectedItem);
+    }
+
+    private void NotifySelectedItemsChanged(IList selectedItems)
+    {
+        SelectedItemsChanged?.Invoke(this, selectedItems);
+        SelectedItemsChangedCommand?.Execute(selectedItems);
+    }
+
     private void OnSelectedItemChanged(object oldValue, object newValue)
     {
-        if (SelectionMode != SelectionMode.Single)
+        if (SelectionMode == SelectionMode.Single)
         {
-            return;
+            if (oldValue is not null)
+            {
+                dataController.RefreshSelectionForItem(oldValue);
+            }
+
+            if (newValue is not null)
+            {
+                dataController.RefreshSelectionForItem(newValue);
+            }
         }
 
-        if (oldValue is not null)
-        {
-            dataController.RefreshSelectionForItem(oldValue);
-        }
-
-        if (newValue is not null)
-        {
-            dataController.RefreshSelectionForItem(newValue);
-        }
+        NotifySelectedItemChanged(newValue);
     }
 
     private void OnSelectedItemsChanged(IList oldValue, IList newValue)
     {
         if (oldValue is INotifyCollectionChanged observableOld)
         {
-            observableOld.CollectionChanged -= SelectedItemsChanged;
+            observableOld.CollectionChanged -= OnSelectedItemsCollectionChanged;
         }
 
         if (newValue is INotifyCollectionChanged observableNew)
         {
-            observableNew.CollectionChanged += SelectedItemsChanged;
+            observableNew.CollectionChanged += OnSelectedItemsCollectionChanged;
         }
 
         dataController.RefreshAllSelection();
+        NotifySelectedItemsChanged(newValue);
     }
 
-    private void SelectedItemsChanged(object sender, NotifyCollectionChangedEventArgs e)
+    private void OnSelectedItemsCollectionChanged(object sender, NotifyCollectionChangedEventArgs e)
     {
         if (isSelectedItemsUpdating || SelectionMode != SelectionMode.Multiple)
         {
@@ -603,6 +638,8 @@ public partial class TreeView : ContentView
         {
             isSelectedItemsUpdating = false;
         }
+
+        NotifySelectedItemsChanged(SelectedItems);
     }
 
     partial void UpdatePlatformAnimationState();

--- a/test/UraniumUI.Material.Tests/Controls/TreeView_Test.cs
+++ b/test/UraniumUI.Material.Tests/Controls/TreeView_Test.cs
@@ -62,6 +62,104 @@ public class TreeView_Test
     }
 
     [Fact]
+    public void SelectedItemChanged_Event_ShouldFire_WhenSelectedItemChanges()
+    {
+        var itemSource = new[] { "1", "2", "3", "4" };
+        var control = AnimationReadyHandler.Prepare(new TreeView
+        {
+            ItemsSource = itemSource,
+            SelectionMode = SelectionMode.Single,
+        });
+        object selectedItem = null;
+        var callCount = 0;
+
+        control.SelectedItemChanged += (_, item) =>
+        {
+            callCount++;
+            selectedItem = item;
+        };
+
+        control.SelectedItem = itemSource[1];
+
+        callCount.ShouldBe(1);
+        selectedItem.ShouldBe(itemSource[1]);
+    }
+
+    [Fact]
+    public void SelectedItemChangedCommand_ShouldExecute_WhenSelectedItemChanges()
+    {
+        var itemSource = new[] { "1", "2", "3", "4" };
+        var command = new RecordingCommand();
+        var control = AnimationReadyHandler.Prepare(new TreeView
+        {
+            ItemsSource = itemSource,
+            SelectionMode = SelectionMode.Single,
+            SelectedItemChangedCommand = command,
+        });
+
+        control.SelectedItem = itemSource[2];
+
+        command.ExecuteCount.ShouldBe(1);
+        command.LastParameter.ShouldBe(itemSource[2]);
+    }
+
+    [Fact]
+    public void SelectedItemsChanged_Event_ShouldFire_WhenCollectionChanges()
+    {
+        var control = AnimationReadyHandler.Prepare(new TreeView
+        {
+            SelectionMode = SelectionMode.Multiple,
+        });
+        IList selectedItems = null;
+        var callCount = 0;
+
+        control.SelectedItemsChanged += (_, items) =>
+        {
+            callCount++;
+            selectedItems = items;
+        };
+
+        control.SelectedItems.Add("1");
+
+        callCount.ShouldBe(1);
+        selectedItems.ShouldBeSameAs(control.SelectedItems);
+        selectedItems.Cast<object>().ShouldContain("1");
+    }
+
+    [Fact]
+    public void SelectedItemsChanged_Event_ShouldFire_WhenCollectionReferenceChanges()
+    {
+        var control = AnimationReadyHandler.Prepare(new TreeView
+        {
+            SelectionMode = SelectionMode.Multiple,
+        });
+        var replacement = new ObservableCollection<object> { "1" };
+        IList selectedItems = null;
+
+        control.SelectedItemsChanged += (_, items) => selectedItems = items;
+
+        control.SelectedItems = replacement;
+
+        selectedItems.ShouldBeSameAs(replacement);
+    }
+
+    [Fact]
+    public void SelectedItemsChangedCommand_ShouldExecute_WhenCollectionChanges()
+    {
+        var command = new RecordingCommand();
+        var control = AnimationReadyHandler.Prepare(new TreeView
+        {
+            SelectionMode = SelectionMode.Multiple,
+            SelectedItemsChangedCommand = command,
+        });
+
+        control.SelectedItems.Add("1");
+
+        command.ExecuteCount.ShouldBe(1);
+        command.LastParameter.ShouldBeSameAs(control.SelectedItems);
+    }
+
+    [Fact]
     public void DataController_ShouldShowOnlyRootNodes_Initially()
     {
         var roots = new[]
@@ -713,6 +811,23 @@ public class TreeView_Test
         public bool CanExecute(object parameter) => true;
 
         public void Execute(object parameter) => execute((T)parameter);
+    }
+
+    private sealed class RecordingCommand : ICommand
+    {
+        public int ExecuteCount { get; private set; }
+
+        public object LastParameter { get; private set; }
+
+        public event EventHandler CanExecuteChanged { add { } remove { } }
+
+        public bool CanExecute(object parameter) => true;
+
+        public void Execute(object parameter)
+        {
+            ExecuteCount++;
+            LastParameter = parameter;
+        }
     }
 
     private sealed class CountingHierarchicalSelectBehavior : TreeViewHierarchicalSelectBehavior


### PR DESCRIPTION
## Summary
- add public `TreeView` selection change events and matching command properties for both single and multiple selection
- fire `SelectedItemChanged` / `SelectedItemChangedCommand` from `SelectedItem` changes
- fire `SelectedItemsChanged` / `SelectedItemsChangedCommand` when the selected-items collection changes or is replaced
- document the new event/command-based usage alongside the existing binding examples

## Automated Testing
- `dotnet test "test/UraniumUI.Material.Tests/UraniumUI.Material.Tests.csproj" --filter "FullyQualifiedName~TreeView_Test"`
- `dotnet build "src/UraniumUI.Material/UraniumUI.Material.csproj" -f net10.0 --no-restore`

Closes #856
