### PR TITLE
fix: show TextField clear button for initialized text

### DIFF
--- a/src/UraniumUI.Material/Controls/TextField.cs
+++ b/src/UraniumUI.Material/Controls/TextField.cs
@@ -61,6 +61,12 @@ public partial class TextField : InputField
 
     partial void AfterConstructor();
 
+    protected override void OnApplyTemplate()
+    {
+        base.OnApplyTemplate();
+        UpdateClearIconState();
+    }
+
     protected override void OnHandlerChanged()
     {
         base.OnHandlerChanged();

--- a/test/UraniumUI.Material.Tests/Controls/TextField_Test.cs
+++ b/test/UraniumUI.Material.Tests/Controls/TextField_Test.cs
@@ -212,6 +212,17 @@ public class TextField_Test
     }
 
     [Fact]
+    public void OnApplyTemplate_ShouldReevaluateClearIconState_WhenAllowClearIsInitialized()
+    {
+        var control = new TemplateAwareTextField { AllowClear = true };
+        var updatesBeforeTemplate = control.UpdateClearIconStateCallCount;
+
+        control.ApplyTemplateForTest();
+
+        control.UpdateClearIconStateCallCount.ShouldBe(updatesBeforeTemplate + 1);
+    }
+
+    [Fact]
     public void SelectionLength_ShouldBeSent_ToViewModel()
     {
         var control = AnimationReadyHandler.Prepare(new TextField());
@@ -525,5 +536,18 @@ public class TextField_Test
         public ClearButtonVisibility ClearButtonVisibility { get => clearButtonVisibility; set => SetProperty(ref clearButtonVisibility, value); }
 
         public double CharacterSpacing { get => characterSpacing; set => SetProperty(ref characterSpacing, value); }
+    }
+
+    private sealed class TemplateAwareTextField : TextField
+    {
+        public int UpdateClearIconStateCallCount { get; private set; }
+
+        public void ApplyTemplateForTest() => base.OnApplyTemplate();
+
+        protected override void UpdateClearIconState()
+        {
+            UpdateClearIconStateCallCount++;
+            base.UpdateClearIconState();
+        }
     }
 }


### PR DESCRIPTION
## Summary
- re-evaluate `TextField` clear icon state when the control template is applied
- add a regression test that covers the template lifecycle hook for initialized clear-button state

## Automated Testing
- `dotnet test test/UraniumUI.Material.Tests/UraniumUI.Material.Tests.csproj --filter FullyQualifiedName~TextField_Test`

## Manual Testing
- Environment: any UraniumUI Material page on a MAUI target such as Windows or Android
- Add `<material:TextField Text="URANIUM" AllowClear="True" />` to a page
- Launch the page and observe the trailing clear button on first render
- Expected result: the clear button is visible immediately without waiting for a `TextChanged` event

Closes #237
