### PR TITLE
fix: preserve transparent ButtonView backgrounds on press

### DIFF
--- a/src/UraniumUI/Theming/DynamicTint.cs
+++ b/src/UraniumUI/Theming/DynamicTint.cs
@@ -1,6 +1,24 @@
 ﻿namespace UraniumUI.Theming;
 public static class DynamicTint
 {
+    private static readonly BindableProperty BaseBackgroundColorProperty = BindableProperty.CreateAttached(
+        "BaseBackgroundColor",
+        typeof(Color),
+        typeof(DynamicTint),
+        default(Color));
+
+    private static readonly BindableProperty IsApplyingTintProperty = BindableProperty.CreateAttached(
+        "IsApplyingTint",
+        typeof(bool),
+        typeof(DynamicTint),
+        false);
+
+    private static readonly BindableProperty IsTrackingBackgroundColorProperty = BindableProperty.CreateAttached(
+        "IsTrackingBackgroundColor",
+        typeof(bool),
+        typeof(DynamicTint),
+        false);
+
     public static readonly BindableProperty BackgroundColorOpacityProperty = BindableProperty.CreateAttached(
         "BackgroundColorOpacity",
         typeof(float),
@@ -20,14 +38,64 @@ public static class DynamicTint
     
     private static void OnBackgroundColorOpacityChanged(BindableObject bindable, object oldValue, object newValue)
     {
-        if (bindable is not View view)
+        if (bindable is not View view || newValue is not float dynamicTintOpacity)
         {
             return;
         }
 
-        if (newValue is float dynamicTintOpacity)
+        EnsureBackgroundTracking(view);
+        ApplyTint(view, dynamicTintOpacity);
+    }
+
+    private static void EnsureBackgroundTracking(View view)
+    {
+        if ((bool)view.GetValue(IsTrackingBackgroundColorProperty))
         {
-            view.BackgroundColor = view.BackgroundColor.WithAlpha(dynamicTintOpacity);
+            return;
         }
+
+        view.SetValue(IsTrackingBackgroundColorProperty, true);
+        view.SetValue(BaseBackgroundColorProperty, view.BackgroundColor);
+        view.PropertyChanged += OnViewPropertyChanged;
+    }
+
+    private static void OnViewPropertyChanged(object sender, System.ComponentModel.PropertyChangedEventArgs e)
+    {
+        if (sender is not View view || e.PropertyName != nameof(VisualElement.BackgroundColor))
+        {
+            return;
+        }
+
+        if ((bool)view.GetValue(IsApplyingTintProperty))
+        {
+            return;
+        }
+
+        view.SetValue(BaseBackgroundColorProperty, view.BackgroundColor);
+        ApplyTint(view, GetBackgroundColorOpacity(view));
+    }
+
+    private static void ApplyTint(View view, float dynamicTintOpacity)
+    {
+        var baseBackgroundColor = view.GetValue(BaseBackgroundColorProperty) as Color ?? view.BackgroundColor;
+
+        if (baseBackgroundColor is null)
+        {
+            return;
+        }
+
+        var tintedColor = IsTransparentWithoutTintSource(baseBackgroundColor)
+            ? baseBackgroundColor
+            : baseBackgroundColor.WithAlpha(dynamicTintOpacity);
+
+        view.SetValue(IsApplyingTintProperty, true);
+        view.BackgroundColor = tintedColor;
+        view.SetValue(IsApplyingTintProperty, false);
+    }
+
+    private static bool IsTransparentWithoutTintSource(Color color)
+    {
+        return color == Colors.Transparent
+            || (color.Alpha == 0 && color.Red == 0 && color.Green == 0 && color.Blue == 0);
     }
 }

--- a/test/UraniumUI.Tests/Theming/DynamicTint_Test.cs
+++ b/test/UraniumUI.Tests/Theming/DynamicTint_Test.cs
@@ -1,0 +1,42 @@
+using Shouldly;
+using UraniumUI.Tests.Core;
+using UraniumUI.Theming;
+
+namespace UraniumUI.Tests.Theming;
+
+public class DynamicTint_Test
+{
+    public DynamicTint_Test()
+    {
+        ApplicationExtensions.CreateAndSetMockApplication();
+    }
+
+    [Fact]
+    public void TransparentBackground_ShouldStayTransparent_WhenTintChanges()
+    {
+        var view = new Grid
+        {
+            BackgroundColor = Colors.Transparent
+        };
+
+        DynamicTint.SetBackgroundColorOpacity(view, 0.8f);
+
+        view.BackgroundColor.ShouldBe(Colors.Transparent);
+    }
+
+    [Fact]
+    public void BackgroundColorChange_ShouldRespectCurrentTintOpacity()
+    {
+        var view = new Grid
+        {
+            BackgroundColor = Colors.Red
+        };
+
+        DynamicTint.SetBackgroundColorOpacity(view, 0.8f);
+        view.BackgroundColor.ShouldBe(Colors.Red.WithAlpha(0.8f));
+
+        view.BackgroundColor = Colors.Blue;
+
+        view.BackgroundColor.ShouldBe(Colors.Blue.WithAlpha(0.8f));
+    }
+}


### PR DESCRIPTION
## Summary
- preserve the base background color while applying `DynamicTint` opacity changes
- keep explicitly transparent backgrounds from turning into opaque black during `ButtonView` state transitions
- add unit coverage for transparent backgrounds and runtime background color changes

## Automated Testing
- `dotnet test test/UraniumUI.Tests/UraniumUI.Tests.csproj --filter FullyQualifiedName~DynamicTint_Test`
- `dotnet build src/UraniumUI.Material/UraniumUI.Material.csproj -f net10.0`

## Manual Testing
- Platform: Windows or Android
- Create a `ButtonView` with `BackgroundColor="Transparent"`
- Press and release the control
- Expected result: the background remains transparent and does not get stuck as black

Closes #368
