### PR TITLE
feat: add DataGridIgnore for auto columns

### DIFF
--- a/docs/en/themes/material/components/DataGrid.md
+++ b/docs/en/themes/material/components/DataGrid.md
@@ -71,11 +71,14 @@ You can customize the cell item template by using `CellItemTemplate` property. I
 ### Columns
 
 #### Auto Columns
-Columns are automatically detected by **DataGrid** when `UseAutoColumns` property is set as `True`. It uses reflection to get properties of the data source. You can use DataAnnosations attributes to define Title of column in auto mode. Adding `[DisplayName]` attribute to the property will define the title of the column.
+Columns are automatically detected by **DataGrid** when `UseAutoColumns` property is set as `True`. It uses reflection to get properties of the data source. You can use DataAnnosations attributes to define Title of column in auto mode. Adding `[DisplayName]` attribute to the property will define the title of the column. Properties marked with `[DataGridIgnore]` are skipped during auto-generation.
 
 ```csharp
 [DisplayName("Identity Number")]
 public int Id { get; set; }
+
+[DataGridIgnore]
+public string InternalCode { get; set; }
 ```
 
 ![MAUI Datagrid header](../../../../images/datagrid-displayname.png)

--- a/src/UraniumUI.Material/Controls/DataGrid.cs
+++ b/src/UraniumUI.Material/Controls/DataGrid.cs
@@ -141,6 +141,7 @@ public partial class DataGrid : Border
             }
 
             Columns = CurrentType?.GetProperties(BindingFlags.Instance | BindingFlags.Public)
+                .Where(property => property.GetCustomAttribute<DataGridIgnoreAttribute>() is null)
                 .Select(s => new DataGridColumn
                 {
                     Title = s.GetCustomAttribute<DisplayNameAttribute>()?.DisplayName ?? s.GetCustomAttribute<DisplayAttribute>()?.Name ?? s.Name,

--- a/src/UraniumUI.Material/Controls/DataGridIgnoreAttribute.cs
+++ b/src/UraniumUI.Material/Controls/DataGridIgnoreAttribute.cs
@@ -1,0 +1,6 @@
+namespace UraniumUI.Material.Controls;
+
+[AttributeUsage(AttributeTargets.Property)]
+public sealed class DataGridIgnoreAttribute : Attribute
+{
+}

--- a/test/UraniumUI.Material.Tests/Controls/DataGrid_Test.cs
+++ b/test/UraniumUI.Material.Tests/Controls/DataGrid_Test.cs
@@ -1,8 +1,6 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
+using System.ComponentModel;
 using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using Microsoft.Maui.Controls.Xaml;
 using Shouldly;
 using UraniumUI.Material.Controls;
@@ -190,6 +188,22 @@ public class DataGrid_Test
         source.Name.ShouldBe("Two");
     }
 
+    [Fact]
+    public void UseAutoColumns_ShouldIgnoreProperties_WithDataGridIgnoreAttribute()
+    {
+        var control = AnimationReadyHandler.Prepare(new DataGrid
+        {
+            UseAutoColumns = true,
+            ItemsSource = new List<AutoColumnRow>
+            {
+                new() { Id = 1, Name = "One", Hidden = "secret" },
+            },
+        });
+
+        control.Columns.Select(column => column.Title).ShouldBe(["Identity", "Name"]);
+        control.Columns.Select(column => ((Binding)column.ValueBinding).Path).ShouldBe([nameof(AutoColumnRow.Id), nameof(AutoColumnRow.Name)]);
+    }
+
     private sealed class DataGridRow
     {
         public int Id { get; init; }
@@ -212,6 +226,17 @@ public class DataGrid_Test
         {
             return serviceType == typeof(IProvideValueTarget) ? this : null;
         }
+    }
+
+    private sealed class AutoColumnRow
+    {
+        [DisplayName("Identity")]
+        public int Id { get; init; }
+
+        public string Name { get; init; }
+
+        [DataGridIgnore]
+        public string Hidden { get; init; }
     }
 
     internal class DataGridTestViewModel : UraniumBindableObject


### PR DESCRIPTION
## Summary
- add a `DataGridIgnoreAttribute` public API for `DataGrid` auto columns
- skip ignored properties during `UseAutoColumns` reflection
- document the new opt-out and cover it with targeted `DataGrid` tests

## Automated Testing
- `dotnet test test/UraniumUI.Material.Tests/UraniumUI.Material.Tests.csproj --filter FullyQualifiedName~DataGrid_Test`

## Notes
- Row selection without a dedicated checkbox column remains tracked separately in #513.

Closes #427
