### PR TITLE
build: update MAUI to 10.0.71 and drop net9

### DIFF
--- a/.github/workflows/static-docs.yml
+++ b/.github/workflows/static-docs.yml
@@ -28,7 +28,7 @@ jobs:
     - name: Dotnet Setup
       uses: actions/setup-dotnet@v3
       with:
-        dotnet-version: 9.x
+        dotnet-version: 10.x
 
     - run: dotnet workload restore
     - run: dotnet tool update -g docfx

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,7 +10,7 @@
 
 ## Package Boundaries
 - `src/UraniumUI` is core. Add-on packages such as `UraniumUI.Material`, `UraniumUI.Blurs`, `UraniumUI.WebComponents`, and `UraniumUI.Dialogs.*` reference core; avoid making core depend on theme, dialog implementation, icon, blur, or web-component packages.
-- Most library packages multi-target `net9.0`/`net10.0` plus MAUI platform TFMs. `UraniumUI.Validations.DataAnnotations` targets only `net9.0;net10.0` but still has `UseMaui=true`.
+- Most library packages target `net10.0` plus MAUI platform TFMs. `UraniumUI.Validations.DataAnnotations` targets only `net10.0` but still has `UseMaui=true`.
 - Public MAUI registration entrypoints live in package-level extension files: `UseUraniumUI`, `UseUraniumUIMaterial`, `UseUraniumUIBlurs`, and `UseUraniumUIWebComponents`. The demo app in `demo/UraniumApp/MauiProgram.cs` shows the full wiring.
 
 ## XAML And API Gotchas

--- a/README.md
+++ b/README.md
@@ -192,7 +192,7 @@ Learn more: [AutoFormView](https://enisn-projects.io/docs/en/uranium/latest/infr
 
 | Target | Support |
 | --- | --- |
-| Current versions | `.NET 10` LTS and `.NET 9` |
+| Current version | `.NET 10` LTS |
 | .NET 8 | Use UraniumUI `v2.6` through `v2.12` |
 | .NET 6 and .NET 7 | Use UraniumUI `v2.5` |
 

--- a/maui.common.props
+++ b/maui.common.props
@@ -1,11 +1,5 @@
 <Project>
-    <PropertyGroup Condition="$(TargetFramework.Contains('net8'))">
-        <MauiVersion>8.0.83</MauiVersion>
-    </PropertyGroup>
-    <PropertyGroup Condition="$(TargetFramework.Contains('net9'))">
-        <MauiVersion>9.0.120</MauiVersion>
-    </PropertyGroup>
     <PropertyGroup Condition="$(TargetFramework.Contains('net10'))">
-        <MauiVersion>10.0.51</MauiVersion>
+        <MauiVersion>10.0.71</MauiVersion>
     </PropertyGroup>
 </Project>

--- a/src/UraniumUI.Blurs/UraniumUI.Blurs.csproj
+++ b/src/UraniumUI.Blurs/UraniumUI.Blurs.csproj
@@ -4,8 +4,8 @@
 	<Import Project="..\..\common.props" />
 
 	<PropertyGroup>
-		<TargetFrameworks>net9.0;net9.0-android;net9.0-ios;net9.0-maccatalyst;net10.0;net10.0-android;net10.0-ios;net10.0-maccatalyst</TargetFrameworks>
-		<TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows'))">$(TargetFrameworks);net9.0-windows10.0.19041.0;net10.0-windows10.0.19041.0</TargetFrameworks>
+		<TargetFrameworks>net10.0;net10.0-android;net10.0-ios;net10.0-maccatalyst</TargetFrameworks>
+		<TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows'))">$(TargetFrameworks);net10.0-windows10.0.19041.0</TargetFrameworks>
 		<!-- Uncomment to also build the tizen app. You will need to install tizen by following this: https://github.com/Samsung/Tizen.NET -->
 		<!-- <TargetFrameworks>$(TargetFrameworks);net7.0-tizen</TargetFrameworks> -->
 		<UseMaui>true</UseMaui>

--- a/src/UraniumUI.Dialogs.CommunityToolkit/UraniumUI.Dialogs.CommunityToolkit.csproj
+++ b/src/UraniumUI.Dialogs.CommunityToolkit/UraniumUI.Dialogs.CommunityToolkit.csproj
@@ -4,8 +4,8 @@
   <Import Project="..\..\common.props" />
 
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net9.0-android;net9.0-ios;net9.0-maccatalyst;net10.0;net10.0-android;net10.0-ios;net10.0-maccatalyst</TargetFrameworks>
-    <TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows'))">$(TargetFrameworks);net9.0-windows10.0.19041.0;net10.0-windows10.0.19041.0</TargetFrameworks>
+    <TargetFrameworks>net10.0;net10.0-android;net10.0-ios;net10.0-maccatalyst</TargetFrameworks>
+    <TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows'))">$(TargetFrameworks);net10.0-windows10.0.19041.0</TargetFrameworks>
     <!-- Uncomment to also build the tizen app. You will need to install tizen by following this: https://github.com/Samsung/Tizen.NET -->
     <!-- <TargetFrameworks>$(TargetFrameworks);net7.0-tizen</TargetFrameworks> -->
     <UseMaui>true</UseMaui>
@@ -25,10 +25,7 @@
     <SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'tizen'">6.5</SupportedOSPlatformVersion>
   </PropertyGroup>
 
-  <ItemGroup Condition="$(TargetFramework.Contains('net9'))">
-    <PackageReference Include="CommunityToolkit.Maui" Version="12.3.0" />
-  </ItemGroup>
-  <ItemGroup Condition="$(TargetFramework.Contains('net10'))">
+  <ItemGroup>
     <PackageReference Include="CommunityToolkit.Maui" Version="13.0.0" />
   </ItemGroup>
 

--- a/src/UraniumUI.Dialogs.Mopups/UraniumUI.Dialogs.Mopups.csproj
+++ b/src/UraniumUI.Dialogs.Mopups/UraniumUI.Dialogs.Mopups.csproj
@@ -4,8 +4,8 @@
   <Import Project="..\..\common.props" />
 
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net9.0-android;net9.0-ios;net9.0-maccatalyst;net10.0;net10.0-android;net10.0-ios;net10.0-maccatalyst</TargetFrameworks>
-    <TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows'))">$(TargetFrameworks);net9.0-windows10.0.19041.0;net10.0-windows10.0.19041.0</TargetFrameworks>
+    <TargetFrameworks>net10.0;net10.0-android;net10.0-ios;net10.0-maccatalyst</TargetFrameworks>
+    <TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows'))">$(TargetFrameworks);net10.0-windows10.0.19041.0</TargetFrameworks>
     <!-- Uncomment to also build the tizen app. You will need to install tizen by following this: https://github.com/Samsung/Tizen.NET -->
     <!-- <TargetFrameworks>$(TargetFrameworks);net7.0-tizen</TargetFrameworks> -->
     <UseMaui>true</UseMaui>

--- a/src/UraniumUI.Icons.FontAwesome/UraniumUI.Icons.FontAwesome.csproj
+++ b/src/UraniumUI.Icons.FontAwesome/UraniumUI.Icons.FontAwesome.csproj
@@ -4,8 +4,8 @@
   <Import Project="..\..\common.props" />
 
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net9.0-android;net9.0-ios;net9.0-maccatalyst;net10.0;net10.0-android;net10.0-ios;net10.0-maccatalyst</TargetFrameworks>
-    <TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows'))">$(TargetFrameworks);net9.0-windows10.0.19041.0;net10.0-windows10.0.19041.0</TargetFrameworks>
+    <TargetFrameworks>net10.0;net10.0-android;net10.0-ios;net10.0-maccatalyst</TargetFrameworks>
+    <TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows'))">$(TargetFrameworks);net10.0-windows10.0.19041.0</TargetFrameworks>
     <!-- Uncomment to also build the tizen app. You will need to install tizen by following this: https://github.com/Samsung/Tizen.NET -->
     <!-- <TargetFrameworks>$(TargetFrameworks);net7.0-tizen</TargetFrameworks> -->
     <UseMaui>true</UseMaui>

--- a/src/UraniumUI.Icons.MaterialIcons/UraniumUI.Icons.MaterialIcons.csproj
+++ b/src/UraniumUI.Icons.MaterialIcons/UraniumUI.Icons.MaterialIcons.csproj
@@ -4,8 +4,8 @@
   <Import Project="..\..\common.props" />
 
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net9.0-android;net9.0-ios;net9.0-maccatalyst;net10.0;net10.0-android;net10.0-ios;net10.0-maccatalyst</TargetFrameworks>
-    <TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows'))">$(TargetFrameworks);net9.0-windows10.0.19041.0;net10.0-windows10.0.19041.0</TargetFrameworks>
+    <TargetFrameworks>net10.0;net10.0-android;net10.0-ios;net10.0-maccatalyst</TargetFrameworks>
+    <TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows'))">$(TargetFrameworks);net10.0-windows10.0.19041.0</TargetFrameworks>
     <!-- Uncomment to also build the tizen app. You will need to install tizen by following this: https://github.com/Samsung/Tizen.NET -->
     <!-- <TargetFrameworks>$(TargetFrameworks);net7.0-tizen</TargetFrameworks> -->
     <UseMaui>true</UseMaui>

--- a/src/UraniumUI.Icons.MaterialSymbols/UraniumUI.Icons.MaterialSymbols.csproj
+++ b/src/UraniumUI.Icons.MaterialSymbols/UraniumUI.Icons.MaterialSymbols.csproj
@@ -4,8 +4,8 @@
   <Import Project="..\..\common.props" />
 
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net9.0-android;net9.0-ios;net9.0-maccatalyst;net10.0;net10.0-android;net10.0-ios;net10.0-maccatalyst</TargetFrameworks>
-    <TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows'))">$(TargetFrameworks);net9.0-windows10.0.19041.0;net10.0-windows10.0.19041.0</TargetFrameworks>
+    <TargetFrameworks>net10.0;net10.0-android;net10.0-ios;net10.0-maccatalyst</TargetFrameworks>
+    <TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows'))">$(TargetFrameworks);net10.0-windows10.0.19041.0</TargetFrameworks>
     <!-- Uncomment to also build the tizen app. You will need to install tizen by following this: https://github.com/Samsung/Tizen.NET -->
     <!-- <TargetFrameworks>$(TargetFrameworks);net7.0-tizen</TargetFrameworks> -->
     <UseMaui>true</UseMaui>

--- a/src/UraniumUI.Icons.SegoeFluent/UraniumUI.Icons.SegoeFluent.csproj
+++ b/src/UraniumUI.Icons.SegoeFluent/UraniumUI.Icons.SegoeFluent.csproj
@@ -5,8 +5,8 @@
 
 
   <PropertyGroup>
-      <TargetFrameworks>net9.0;net9.0-android;net9.0-ios;net9.0-maccatalyst;net10.0;net10.0-android;net10.0-ios;net10.0-maccatalyst</TargetFrameworks>
-      <TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows'))">$(TargetFrameworks);net9.0-windows10.0.19041.0;net10.0-windows10.0.19041.0</TargetFrameworks>
+      <TargetFrameworks>net10.0;net10.0-android;net10.0-ios;net10.0-maccatalyst</TargetFrameworks>
+      <TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows'))">$(TargetFrameworks);net10.0-windows10.0.19041.0</TargetFrameworks>
 		<!-- Uncomment to also build the tizen app. You will need to install tizen by following this: https://github.com/Samsung/Tizen.NET -->
 		<!-- <TargetFrameworks>$(TargetFrameworks);net7.0-tizen</TargetFrameworks> -->
 		<UseMaui>true</UseMaui>

--- a/src/UraniumUI.Material/UraniumUI.Material.csproj
+++ b/src/UraniumUI.Material/UraniumUI.Material.csproj
@@ -4,8 +4,8 @@
   <Import Project="..\..\common.props" />
 
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net9.0-android;net9.0-ios;net9.0-maccatalyst;net10.0;net10.0-android;net10.0-ios;net10.0-maccatalyst</TargetFrameworks>
-    <TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows'))">$(TargetFrameworks);net9.0-windows10.0.19041.0;net10.0-windows10.0.19041.0</TargetFrameworks>
+    <TargetFrameworks>net10.0;net10.0-android;net10.0-ios;net10.0-maccatalyst</TargetFrameworks>
+    <TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows'))">$(TargetFrameworks);net10.0-windows10.0.19041.0</TargetFrameworks>
     <!-- Uncomment to also build the tizen app. You will need to install tizen by following this: https://github.com/Samsung/Tizen.NET -->
     <!-- <TargetFrameworks>$(TargetFrameworks);net7.0-tizen</TargetFrameworks> -->
     <UseMaui>true</UseMaui>

--- a/src/UraniumUI.Validations.DataAnnotations/UraniumUI.Validations.DataAnnotations.csproj
+++ b/src/UraniumUI.Validations.DataAnnotations/UraniumUI.Validations.DataAnnotations.csproj
@@ -4,7 +4,7 @@
   <Import Project="..\..\common.props" />
 
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net10.0</TargetFrameworks>
+    <TargetFramework>net10.0</TargetFramework>
 
     <!-- Uncomment to also build the tizen app. You will need to install tizen by following this: https://github.com/Samsung/Tizen.NET -->
     <!-- <TargetFrameworks>$(TargetFrameworks);net7.0-tizen</TargetFrameworks> -->
@@ -18,10 +18,7 @@
     <IsRidAgnostic Condition="'$(OutputType)' == 'Library'">true</IsRidAgnostic>
   </PropertyGroup>
 
-  <ItemGroup Condition="$(TargetFramework.Contains('net9'))">
-    <PackageReference Include="InputKit.Maui" Version="4.5.2" />
-  </ItemGroup>
-  <ItemGroup Condition="$(TargetFramework.Contains('net10'))">
+  <ItemGroup>
     <PackageReference Include="InputKit.Maui" Version="4.6.0" />
   </ItemGroup>
 

--- a/src/UraniumUI.WebComponents/UraniumUI.WebComponents.csproj
+++ b/src/UraniumUI.WebComponents/UraniumUI.WebComponents.csproj
@@ -4,8 +4,8 @@
   <Import Project="..\..\common.props" />
   
 	<PropertyGroup>
-        <TargetFrameworks>net9.0;net9.0-android;net9.0-ios;net9.0-maccatalyst;net10.0;net10.0-android;net10.0-ios;net10.0-maccatalyst</TargetFrameworks>
-        <TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows'))">$(TargetFrameworks);net9.0-windows10.0.19041.0;net10.0-windows10.0.19041.0</TargetFrameworks>
+        <TargetFrameworks>net10.0;net10.0-android;net10.0-ios;net10.0-maccatalyst</TargetFrameworks>
+        <TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows'))">$(TargetFrameworks);net10.0-windows10.0.19041.0</TargetFrameworks>
 		<!-- Uncomment to also build the tizen app. You will need to install tizen by following this: https://github.com/Samsung/Tizen.NET -->
 		<!-- <TargetFrameworks>$(TargetFrameworks);net7.0-tizen</TargetFrameworks> -->
 		<UseMaui>true</UseMaui>

--- a/src/UraniumUI/UraniumUI.csproj
+++ b/src/UraniumUI/UraniumUI.csproj
@@ -4,8 +4,8 @@
   <Import Project="..\..\common.props" />
 
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net9.0-android;net9.0-ios;net9.0-maccatalyst;net10.0;net10.0-android;net10.0-ios;net10.0-maccatalyst</TargetFrameworks>
-    <TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows'))">$(TargetFrameworks);net9.0-windows10.0.19041.0;net10.0-windows10.0.19041.0</TargetFrameworks>
+    <TargetFrameworks>net10.0;net10.0-android;net10.0-ios;net10.0-maccatalyst</TargetFrameworks>
+    <TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows'))">$(TargetFrameworks);net10.0-windows10.0.19041.0</TargetFrameworks>
     <!-- Uncomment to also build the tizen app. You will need to install tizen by following this: https://github.com/Samsung/Tizen.NET -->
     <!-- <TargetFrameworks>$(TargetFrameworks);net7.0-tizen</TargetFrameworks> -->
     <UseMaui>true</UseMaui>
@@ -23,16 +23,9 @@
     <SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'tizen'">6.5</SupportedOSPlatformVersion>
   </PropertyGroup>
 
-  <ItemGroup Condition="$(TargetFramework.Contains('net9'))">
-    <PackageReference Include="InputKit.Maui" Version="4.5.2" />
-    <PackageReference Include="Plainer.Maui" Version="1.7.1" />
-  </ItemGroup>
-
   <ItemGroup>
     <PackageReference Include="Microsoft.Maui.Controls" Version="$(MauiVersion)" />
-  </ItemGroup>
-  <ItemGroup Condition="$(TargetFramework.Contains('net10'))">
-	  <PackageReference Include="InputKit.Maui" Version="4.6.0" />
-	  <PackageReference Include="Plainer.Maui" Version="1.8.0" />
+    <PackageReference Include="InputKit.Maui" Version="4.6.0" />
+    <PackageReference Include="Plainer.Maui" Version="1.8.0" />
   </ItemGroup>
 </Project>

--- a/templates/app-blank/MyCompany.MyProject/MyCompany.MyProject.csproj
+++ b/templates/app-blank/MyCompany.MyProject/MyCompany.MyProject.csproj
@@ -1,6 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
+		<MauiVersion>10.0.71</MauiVersion>
 		<TargetFrameworks>net10.0-android;net10.0-ios;net10.0-maccatalyst</TargetFrameworks>
 		<TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows'))">$(TargetFrameworks);net10.0-windows10.0.19041.0</TargetFrameworks>
 		<!-- Uncomment to also build the tizen app. You will need to install tizen by following this: https://github.com/Samsung/Tizen.NET -->

--- a/templates/app/MyCompany.MyProject/MyCompany.MyProject.csproj
+++ b/templates/app/MyCompany.MyProject/MyCompany.MyProject.csproj
@@ -1,6 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
+		<MauiVersion>10.0.71</MauiVersion>
 		<TargetFrameworks>net10.0-android;net10.0-ios;net10.0-maccatalyst</TargetFrameworks>
 		<TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows'))">$(TargetFrameworks);net10.0-windows10.0.19041.0</TargetFrameworks>
 		<!-- Uncomment to also build the tizen app. You will need to install tizen by following this: https://github.com/Samsung/Tizen.NET -->


### PR DESCRIPTION
## Summary

- update the shared MAUI pin to `10.0.71`
- drop `net9` targets across source packages and keep `net10` only
- simplify `net10`-only package references in core and companion packages
- fix template projects so generated apps resolve `MauiVersion`
- update docs and workflow metadata to reflect `.NET 10` support

## Validation

- `dotnet build`
- `dotnet test`
- packed and installed local templates
- generated a fresh `uraniumui-blank-app`
- built the generated template app successfully

## Notes

- `dotnet workload install maui` was attempted locally, but the workload updater aborted while switching workload sets
- existing installed MAUI workloads were still sufficient for successful build, test, and template smoke validation