### PR TITLE
Add theme creation handbook

### DIFF
--- a/docs/en/docs-nav.json
+++ b/docs/en/docs-nav.json
@@ -113,6 +113,10 @@
           "path": "theming/CreatingTheme.md"
         },
         {
+          "text": "Building Theme Controls",
+          "path": "theming/BuildingThemeControls.md"
+        },
+        {
           "text": "Icons",
           "path": "theming/Icons.md",
           "items": [

--- a/docs/en/theming/BuildingThemeControls.md
+++ b/docs/en/theming/BuildingThemeControls.md
@@ -1,8 +1,8 @@
 # Building Theme Controls
 
-This page is the advanced companion to [Creating a Theme](CreatingTheme.md). It explains how to build custom theme controls by composing UraniumUI primitives instead of starting with platform handlers.
+This page is the advanced companion to [Creating a Theme](CreatingTheme.md). It explains how to build app-specific controls by composing UraniumUI primitives instead of starting with platform handlers.
 
-Most theme controls should be MAUI controls, UraniumUI primitives, and styles. Add a platform handler only when composition cannot provide the required native behavior.
+Most app controls should be MAUI controls, UraniumUI primitives, and styles. Add a platform handler only when composition cannot provide the required native behavior.
 
 ## Primitive Selection
 
@@ -76,7 +76,7 @@ Use this wrapper approach when you do not need a reusable control class.
 
 ## Reusable Text Field Control
 
-Create a subclass when the app or theme needs a reusable control API.
+Create a subclass when your app needs a reusable control API.
 
 ```csharp
 using Microsoft.Maui;
@@ -85,9 +85,9 @@ using Microsoft.Maui.Graphics;
 using Plainer.Maui.Controls;
 using UraniumUI.Material.Controls;
 
-namespace MyCompany.UraniumUI.Brand.Controls;
+namespace MyApp.Controls;
 
-public class BrandTextField : InputField
+public class AppTextField : InputField
 {
     private readonly EntryView entryView = new()
     {
@@ -96,7 +96,7 @@ public class BrandTextField : InputField
         VerticalOptions = LayoutOptions.Center,
     };
 
-    public BrandTextField()
+    public AppTextField()
     {
         Content = entryView;
 
@@ -114,10 +114,10 @@ public class BrandTextField : InputField
     public static readonly BindableProperty TextProperty = BindableProperty.Create(
         nameof(Text),
         typeof(string),
-        typeof(BrandTextField),
+        typeof(AppTextField),
         string.Empty,
         BindingMode.TwoWay,
-        propertyChanged: (bindable, _, _) => ((BrandTextField)bindable).UpdateState());
+        propertyChanged: (bindable, _, _) => ((AppTextField)bindable).UpdateState());
 
     public Keyboard Keyboard
     {
@@ -128,7 +128,7 @@ public class BrandTextField : InputField
     public static readonly BindableProperty KeyboardProperty = BindableProperty.Create(
         nameof(Keyboard),
         typeof(Keyboard),
-        typeof(BrandTextField),
+        typeof(AppTextField),
         Keyboard.Default);
 
     public bool IsReadOnly
@@ -140,7 +140,7 @@ public class BrandTextField : InputField
     public static readonly BindableProperty IsReadOnlyProperty = BindableProperty.Create(
         nameof(IsReadOnly),
         typeof(bool),
-        typeof(BrandTextField),
+        typeof(AppTextField),
         false);
 
     public override bool HasValue
@@ -293,23 +293,23 @@ This keeps page markup simple and makes the container responsible for its own lo
 
 ## AutoFormView Integration
 
-If a theme provides its own input controls, configure `AutoFormView` mappings so generated forms use them.
+If your app provides its own input controls, configure `AutoFormView` mappings so generated forms use them.
 
-Material does this in `ConfigureAutoFormViewForMaterial()`. A custom theme can follow the same pattern:
+Material does this in `ConfigureAutoFormViewForMaterial()`. An app can follow the same pattern in its own startup extension:
 
 ```csharp
-public static MauiAppBuilder ConfigureAutoFormViewForBrand(this MauiAppBuilder builder)
+public static MauiAppBuilder ConfigureAutoFormViewForAppTheme(this MauiAppBuilder builder)
 {
     builder.Services.Configure<AutoFormViewOptions>(options =>
     {
         options.EditorMapping[typeof(string)] = (property, propertyNameFactory, source) =>
         {
-            var editor = new BrandTextField
+            var editor = new AppTextField
             {
                 Title = propertyNameFactory(property),
             };
 
-            editor.SetBinding(BrandTextField.TextProperty, new Binding(property.Name, source: source));
+            editor.SetBinding(AppTextField.TextProperty, new Binding(property.Name, source: source));
 
             return editor;
         };
@@ -319,11 +319,11 @@ public static MauiAppBuilder ConfigureAutoFormViewForBrand(this MauiAppBuilder b
 }
 ```
 
-Keep mappings in the theme registration method so app startup remains predictable.
+Keep mappings in app startup or an app-level startup extension so form generation remains predictable.
 
 ## Accessibility Checklist
 
-Custom theme controls must preserve accessibility behavior from the primitives they use.
+Custom app controls must preserve accessibility behavior from the primitives they use.
 
 1. Use `Title`, visible `Label` text, or `SemanticProperties.Description` for every input.
 2. Use `ContentAutomationId` when tests need to locate the inner input of an `InputField`.
@@ -342,4 +342,4 @@ See [Accessibility Best Practices](../best-practices/Accessibility.md) for the a
 - Put visuals in styles. Put behavior and value APIs in controls.
 - Use existing UraniumUI style class names for common concepts and app-specific names for app-only variants.
 - Keep validation text close to the field.
-- Document every public XAML namespace, style class, and control property that theme consumers must use.
+- Document shared style classes and custom control properties that the app team should use consistently.

--- a/docs/en/theming/BuildingThemeControls.md
+++ b/docs/en/theming/BuildingThemeControls.md
@@ -1,0 +1,345 @@
+# Building Theme Controls
+
+This page is the advanced companion to [Creating a Theme](CreatingTheme.md). It explains how to build custom theme controls by composing UraniumUI primitives instead of starting with platform handlers.
+
+Most theme controls should be MAUI controls, UraniumUI primitives, and styles. Add a platform handler only when composition cannot provide the required native behavior.
+
+## Primitive Selection
+
+| Requirement | Start with |
+| --- | --- |
+| Text input with a border, floating title, icon, validation, or attachments | `InputField` |
+| Plain text input with fully custom chrome | `EntryView` from `Plainer.Maui.Controls` inside a `Border` or layout |
+| Custom clickable card, list row, tile, or icon action | `StatefulContentView` |
+| Material-style clickable content | `ButtonView` |
+| Dropdown or selection overlay | `Dropdown`, `Select`, or the Material field controls built on them |
+| Container that changes child text or button styles | `CascadingStyle.Resources` and `CascadingStyle.StyleClass` |
+| Dynamic field generation | `AutoFormView` with editor mappings |
+
+`UseUraniumUI()` registers the core handlers used by these primitives. `UseUraniumUIMaterial()` registers Material-specific handlers and Material `AutoFormView` mappings.
+
+## Plain Text Input With Custom Chrome
+
+UraniumUI Material `TextField` uses `InputField` as the shell and `EntryView` as the inner text entry. `EntryView` comes from `Plainer.Maui.Controls`; UraniumUI registers Plainer in `UseUraniumUI()`.
+
+If your design does not need floating labels or `InputField` validation, a border around `EntryView` is enough:
+
+```xml
+<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             xmlns:plainer="clr-namespace:Plainer.Maui.Controls;assembly=Plainer.Maui">
+
+    <Border StyleClass="SearchBox" Padding="12,8">
+        <Grid ColumnDefinitions="Auto,*" ColumnSpacing="8">
+            <Label Text="#" VerticalOptions="Center" />
+            <plainer:EntryView
+                Grid.Column="1"
+                BackgroundColor="Transparent"
+                Placeholder="Search"
+                SemanticProperties.Description="Search" />
+        </Grid>
+    </Border>
+</ContentPage>
+```
+
+Add the style as a normal class style:
+
+```xml
+<Style TargetType="Border" Class="SearchBox" BaseResourceKey="UraniumUI.Styles.Border.Rounded">
+    <Setter Property="BackgroundColor" Value="{AppThemeBinding Light={StaticResource Surface}, Dark={StaticResource SurfaceDark}}" />
+    <Setter Property="Stroke" Value="{AppThemeBinding Light={StaticResource Outline}, Dark={StaticResource OutlineDark}}" />
+    <Setter Property="StrokeThickness" Value="1" />
+</Style>
+```
+
+This approach is useful for simple search bars, filter chips with text entry, and compact inputs where Material floating-label behavior would be too heavy.
+
+## InputField as a Wrapper
+
+Use `InputField` when the inner control should look and behave like a Material input.
+
+```xml
+<material:InputField
+    xmlns:material="http://schemas.enisn-projects.io/dotnet/maui/uraniumui/material"
+    Title="Start time"
+    HasValue="True"
+    ContentAutomationId="StartTimeInput">
+    <TimePicker
+        BackgroundColor="Transparent"
+        SemanticProperties.Description="Start time" />
+</material:InputField>
+```
+
+`InputField` owns the shell. The wrapped control owns the actual value and input behavior. Set `HasValue` correctly so the floating title stays above the content when the control has a value.
+
+Use this wrapper approach when you do not need a reusable control class.
+
+## Reusable Text Field Control
+
+Create a subclass when the app or theme needs a reusable control API.
+
+```csharp
+using Microsoft.Maui;
+using Microsoft.Maui.Controls;
+using Microsoft.Maui.Graphics;
+using Plainer.Maui.Controls;
+using UraniumUI.Material.Controls;
+
+namespace MyCompany.UraniumUI.Brand.Controls;
+
+public class BrandTextField : InputField
+{
+    private readonly EntryView entryView = new()
+    {
+        BackgroundColor = Colors.Transparent,
+        Margin = new Thickness(16, 0),
+        VerticalOptions = LayoutOptions.Center,
+    };
+
+    public BrandTextField()
+    {
+        Content = entryView;
+
+        entryView.SetBinding(Entry.TextProperty, new Binding(nameof(Text), BindingMode.TwoWay, source: this));
+        entryView.SetBinding(Entry.KeyboardProperty, new Binding(nameof(Keyboard), source: this));
+        entryView.SetBinding(Entry.IsReadOnlyProperty, new Binding(nameof(IsReadOnly), source: this));
+    }
+
+    public string Text
+    {
+        get => (string)GetValue(TextProperty);
+        set => SetValue(TextProperty, value);
+    }
+
+    public static readonly BindableProperty TextProperty = BindableProperty.Create(
+        nameof(Text),
+        typeof(string),
+        typeof(BrandTextField),
+        string.Empty,
+        BindingMode.TwoWay,
+        propertyChanged: (bindable, _, _) => ((BrandTextField)bindable).UpdateState());
+
+    public Keyboard Keyboard
+    {
+        get => (Keyboard)GetValue(KeyboardProperty);
+        set => SetValue(KeyboardProperty, value);
+    }
+
+    public static readonly BindableProperty KeyboardProperty = BindableProperty.Create(
+        nameof(Keyboard),
+        typeof(Keyboard),
+        typeof(BrandTextField),
+        Keyboard.Default);
+
+    public bool IsReadOnly
+    {
+        get => (bool)GetValue(IsReadOnlyProperty);
+        set => SetValue(IsReadOnlyProperty, value);
+    }
+
+    public static readonly BindableProperty IsReadOnlyProperty = BindableProperty.Create(
+        nameof(IsReadOnly),
+        typeof(bool),
+        typeof(BrandTextField),
+        false);
+
+    public override bool HasValue
+    {
+        get => !string.IsNullOrEmpty(Text);
+        set { }
+    }
+
+    protected override object GetValueForValidator()
+    {
+        return Text;
+    }
+}
+```
+
+This is intentionally smaller than `UraniumUI.Material.Controls.TextField`. For a production text field, inspect Material `TextField` and add only the API you need, such as `TextChanged`, `Completed`, `AllowClear`, selection properties, password behavior, and command support.
+
+## InputField Styling Surface
+
+`InputField` exposes style classes for its parts:
+
+| Style class | Target type | Purpose |
+| --- | --- | --- |
+| `InputField.Title` | `Label` | Floating title text. |
+| `InputField.Border` | `Border` | Field stroke, shape, and background container. |
+| `InputField.Icon` | `Image` | Leading icon. |
+| `InputField.Attachments` | `HorizontalStackLayout` | Trailing attachment container. |
+| `InputField.ValidationIcon` | `Path` | Validation icon. |
+| `InputField.ValidationLabel` | `Label` | Validation message text. |
+
+Example:
+
+```xml
+<Style TargetType="Label" Class="InputField.Title">
+    <Setter Property="FontAttributes" Value="Bold" />
+</Style>
+
+<Style TargetType="Border" Class="InputField.Border">
+    <Setter Property="StrokeThickness" Value="1.5" />
+</Style>
+
+<Style TargetType="Label" Class="InputField.ValidationLabel">
+    <Setter Property="FontSize" Value="12" />
+    <Setter Property="TextColor" Value="{AppThemeBinding Light={StaticResource Error}, Dark={StaticResource ErrorDark}}" />
+</Style>
+```
+
+Use these part styles when the shell should change globally. Use bindable properties such as `AccentColor`, `BorderColor`, `InputBackgroundColor`, `CornerRadius`, and `TitleFontSize` when a single control instance should differ.
+
+## Attachments and Icon Actions
+
+Attachments are views placed at the trailing side of `InputField` and `TextField`. Use them for actions such as clear, show password, scan code, or open picker.
+
+Use `StatefulContentView` for icon-only actions so the attachment can be focusable and command-driven:
+
+```xml
+<material:TextField
+    xmlns:material="http://schemas.enisn-projects.io/dotnet/maui/uraniumui/material"
+    Title="Password"
+    IsPassword="True">
+    <material:TextField.Attachments>
+        <uranium:StatefulContentView
+            xmlns:uranium="http://schemas.enisn-projects.io/dotnet/maui/uraniumui"
+            TappedCommand="{Binding TogglePasswordCommand}"
+            SemanticProperties.Description="Show or hide password">
+            <Path StyleClass="PasswordVisibilityIcon" />
+        </uranium:StatefulContentView>
+    </material:TextField.Attachments>
+</material:TextField>
+```
+
+If the attachment is decorative, make it non-focusable and do not expose it as an action. If it changes state, update the visible icon and the semantic description.
+
+## Clickable Surfaces
+
+Use `StatefulContentView` for custom cards, rows, and tiles that respond to taps or keyboard activation.
+
+```xml
+<uranium:StatefulContentView
+    xmlns:uranium="http://schemas.enisn-projects.io/dotnet/maui/uraniumui"
+    StyleClass="AccountRow"
+    TappedCommand="{Binding OpenAccountCommand}"
+    SemanticProperties.Description="Open account details">
+    <Grid Padding="16" ColumnDefinitions="*,Auto">
+        <Label Text="Checking account" />
+        <Label Grid.Column="1" Text=">" />
+    </Grid>
+</uranium:StatefulContentView>
+```
+
+Style the states through `VisualStateManager`:
+
+```xml
+<ResourceDictionary xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+                    xmlns:uranium="http://schemas.enisn-projects.io/dotnet/maui/uraniumui">
+    <Style TargetType="uranium:StatefulContentView" Class="AccountRow">
+        <Setter Property="VisualStateManager.VisualStateGroups">
+            <VisualStateGroupList>
+                <VisualStateGroup x:Name="CommonStates">
+                    <VisualState x:Name="Normal">
+                        <VisualState.Setters>
+                            <Setter Property="Opacity" Value="1" />
+                        </VisualState.Setters>
+                    </VisualState>
+                    <VisualState x:Name="PointerOver">
+                        <VisualState.Setters>
+                            <Setter Property="Opacity" Value="0.9" />
+                        </VisualState.Setters>
+                    </VisualState>
+                    <VisualState x:Name="Pressed">
+                        <VisualState.Setters>
+                            <Setter Property="Opacity" Value="0.75" />
+                        </VisualState.Setters>
+                    </VisualState>
+                </VisualStateGroup>
+            </VisualStateGroupList>
+        </Setter>
+    </Style>
+</ResourceDictionary>
+```
+
+Prefer this over a `TapGestureRecognizer` on a `Grid` when the area is important to the workflow.
+
+## Container-Level Styling
+
+Use `CascadingStyle` when the parent style should control child labels, buttons, paths, or nested controls.
+
+```xml
+<ResourceDictionary xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+                    xmlns:uranium="http://schemas.enisn-projects.io/dotnet/maui/uraniumui">
+    <Style TargetType="Border" Class="WarningPanel" CanCascade="True">
+        <Setter Property="BackgroundColor" Value="{AppThemeBinding Light={StaticResource ErrorContainer}, Dark={StaticResource ErrorContainerDark}}" />
+        <Setter Property="uranium:CascadingStyle.Resources">
+            <ResourceDictionary>
+                <Style TargetType="Label">
+                    <Setter Property="TextColor" Value="{AppThemeBinding Light={StaticResource OnErrorContainer}, Dark={StaticResource OnErrorContainerDark}}" />
+                </Style>
+                <Style TargetType="Button">
+                    <Setter Property="uranium:CascadingStyle.StyleClass" Value="TextButton" />
+                </Style>
+            </ResourceDictionary>
+        </Setter>
+    </Style>
+</ResourceDictionary>
+```
+
+This keeps page markup simple and makes the container responsible for its own local design rules.
+
+## AutoFormView Integration
+
+If a theme provides its own input controls, configure `AutoFormView` mappings so generated forms use them.
+
+Material does this in `ConfigureAutoFormViewForMaterial()`. A custom theme can follow the same pattern:
+
+```csharp
+public static MauiAppBuilder ConfigureAutoFormViewForBrand(this MauiAppBuilder builder)
+{
+    builder.Services.Configure<AutoFormViewOptions>(options =>
+    {
+        options.EditorMapping[typeof(string)] = (property, propertyNameFactory, source) =>
+        {
+            var editor = new BrandTextField
+            {
+                Title = propertyNameFactory(property),
+            };
+
+            editor.SetBinding(BrandTextField.TextProperty, new Binding(property.Name, source: source));
+
+            return editor;
+        };
+    });
+
+    return builder;
+}
+```
+
+Keep mappings in the theme registration method so app startup remains predictable.
+
+## Accessibility Checklist
+
+Custom theme controls must preserve accessibility behavior from the primitives they use.
+
+1. Use `Title`, visible `Label` text, or `SemanticProperties.Description` for every input.
+2. Use `ContentAutomationId` when tests need to locate the inner input of an `InputField`.
+3. Keep icon-only actions focusable when they perform work.
+4. Provide `SemanticProperties.Description` and `SemanticProperties.Hint` for icon-only actions.
+5. Keep focus, pressed, hover, disabled, selected, and error states visually distinct.
+6. Do not rely only on color to communicate validation or selection.
+7. Test hardware keyboard navigation for text inputs, attachments, clickable rows, dropdowns, and dialogs.
+
+See [Accessibility Best Practices](../best-practices/Accessibility.md) for the app-level checklist.
+
+## Design Guidelines
+
+- Use composition first. Add a handler only for native behavior that cannot be composed.
+- Keep reusable controls small. Expose bindable properties only for behavior the app needs.
+- Put visuals in styles. Put behavior and value APIs in controls.
+- Use existing UraniumUI style class names for common concepts and app-specific names for app-only variants.
+- Keep validation text close to the field.
+- Document every public XAML namespace, style class, and control property that theme consumers must use.

--- a/docs/en/theming/CreatingTheme.md
+++ b/docs/en/theming/CreatingTheme.md
@@ -1,8 +1,8 @@
 # Creating a Theme
 
-UraniumUI themes are ordinary .NET MAUI resource dictionaries plus a small set of conventions for color tokens, keyed styles, `StyleClass` styles, and reusable control primitives. A theme can be as small as an app-specific palette over the Material theme, or as large as a separate package with its own controls, resource dictionaries, XAML namespace, and `Use...` registration method.
+In a UraniumUI app, a theme is a set of .NET MAUI resource dictionaries that define your app's colors, base styles, style classes, and reusable visual patterns. You do not need to create another library to theme an app. Most apps can keep the Material controls and replace the parts that make the UI feel like your product.
 
-This page is the handbook for building and maintaining those themes.
+This page is a handbook for app developers who want to create their own visual system on top of UraniumUI.
 
 ## Theme Scope
 
@@ -15,9 +15,8 @@ Choose the smallest scope that solves the problem.
 | Add app-specific visual variants | Add your own `StyleClass` styles after the theme resources are merged. |
 | Style a group of child controls together | Use `CascadingStyle.Resources` and `CascadingStyle.StyleClass`. |
 | Build reusable field or button controls | Compose UraniumUI primitives such as `InputField`, `StatefulContentView`, `ButtonView`, `Select`, and `EntryView`. |
-| Ship a reusable theme package | Create a package that references `UraniumUI`, exposes XAML resources, registers handlers/options, and maps XAML namespaces. |
 
-Most applications should customize the Material theme instead of creating a new package. Create a new theme package when the visual system, control set, or public API will be reused across multiple applications.
+Start with colors and styles in your app. Create custom controls only when a repeated pattern needs behavior, bindable properties, validation integration, or a cleaner API for page authors.
 
 ## Runtime Setup
 
@@ -58,18 +57,18 @@ The common app setup is:
     <Application.Resources>
         <ResourceDictionary>
             <ResourceDictionary.MergedDictionaries>
-                <ResourceDictionary x:Name="brandColors" Source="Resources/Themes/BrandColors.xaml" />
-                <ResourceDictionary x:Name="brandBaseStyles" Source="Resources/Themes/BrandBaseStyles.xaml" />
+                <ResourceDictionary x:Name="appColors" Source="Resources/Themes/AppColors.xaml" />
+                <ResourceDictionary x:Name="appBaseStyles" Source="Resources/Themes/AppBaseStyles.xaml" />
 
                 <material:StyleResource
-                    ColorsOverride="{x:Reference brandColors}"
-                    BasedOn="{x:Reference brandBaseStyles}">
+                    ColorsOverride="{x:Reference appColors}"
+                    BasedOn="{x:Reference appBaseStyles}">
                     <material:StyleResource.Overrides>
-                        <ResourceDictionary Source="Resources/Themes/BrandMaterialOverrides.xaml" />
+                        <ResourceDictionary Source="Resources/Themes/AppMaterialOverrides.xaml" />
                     </material:StyleResource.Overrides>
                 </material:StyleResource>
 
-                <ResourceDictionary Source="Resources/Themes/BrandStyleClasses.xaml" />
+                <ResourceDictionary Source="Resources/Themes/AppStyleClasses.xaml" />
             </ResourceDictionary.MergedDictionaries>
         </ResourceDictionary>
     </Application.Resources>
@@ -78,10 +77,10 @@ The common app setup is:
 
 Use this order deliberately:
 
-1. `BrandColors.xaml` provides color keys that `ColorsOverride` can copy into Material's color dictionary.
-2. `BrandBaseStyles.xaml` can provide keyed base styles that match Material style keys; Material styles inherit missing setters from those styles.
-3. `BrandMaterialOverrides.xaml` can override setters on existing Material keyed styles with matching keys.
-4. `BrandStyleClasses.xaml` can add new app-specific styles after Material resources exist.
+1. `AppColors.xaml` provides color keys that `ColorsOverride` can copy into Material's color dictionary.
+2. `AppBaseStyles.xaml` can provide keyed base styles that match Material style keys; Material styles inherit missing setters from those styles.
+3. `AppMaterialOverrides.xaml` can override setters on existing Material keyed styles with matching keys.
+4. `AppStyleClasses.xaml` can add new app-specific styles after Material resources exist.
 
 `StyleResource.Overrides` changes existing theme styles. It is not a general merge point for new styles. Put new styles in a normal merged dictionary after `material:StyleResource`.
 
@@ -139,15 +138,15 @@ Keep contrast in mind when choosing every `On...` token. `OnPrimary` must be rea
 
 ## Style Layers
 
-Theme styles normally use three layers.
+App theme styles normally use three layers.
 
 | Layer | Example | Usage |
 | --- | --- | --- |
-| Keyed base style | `x:Key="UraniumUI.Styles.Button.Filled"` | Stable extension point for theme authors. |
+| Keyed base style | `x:Key="UraniumUI.Styles.Button.Filled"` | Stable extension point for app-level overrides. |
 | Implicit style | `<Style TargetType="Label" />` | Default appearance for a type. |
 | Class style | `Class="FilledButton"` | Variant selected by `StyleClass`. |
 
-The Material theme defines keyed styles first, then maps public classes to those keyed styles:
+The Material theme defines keyed styles first, then maps built-in `StyleClass` names to those keyed styles:
 
 ```xml
 <Style x:Key="UraniumUI.Styles.Button.Filled"
@@ -170,7 +169,7 @@ That lets app code stay simple:
 <Button Text="Save" StyleClass="FilledButton" />
 ```
 
-It also gives theme authors a stable style key to override:
+It also gives your app a stable style key to override:
 
 ```xml
 <Style x:Key="UraniumUI.Styles.Button.Filled" TargetType="Button">
@@ -257,7 +256,7 @@ Use `BaseResourceKey` to create variants from existing styles:
 Use `ApplyToDerivedTypes="True"` when a base control style should also apply to subclasses:
 
 ```xml
-<Style x:Key="Brand.Styles.InputField"
+<Style x:Key="App.Styles.InputField"
        TargetType="material:InputField"
        ApplyToDerivedTypes="True">
     <Setter Property="CornerRadius" Value="10" />
@@ -306,9 +305,9 @@ Usage:
 
 See [Cascading Styling](CascadingStyling.md) for the full cascading style API.
 
-## Theme Control Primitives
+## App Control Primitives
 
-Themes should prefer composition over platform-specific handlers. UraniumUI already provides primitives that solve common interaction and accessibility problems.
+App themes should prefer composition over platform-specific handlers. UraniumUI already provides primitives that solve common interaction and accessibility problems.
 
 | Primitive | Use it for |
 | --- | --- |
@@ -321,105 +320,29 @@ Themes should prefer composition over platform-specific handlers. UraniumUI alre
 
 For example, a fully custom text input does not need a new handler just to draw a border. Wrap a chrome-free entry in a `Border`, or use `InputField` when you need the Material floating label and validation behavior. See [Building Theme Controls](BuildingThemeControls.md) for advanced examples.
 
-## Theme Package Structure
+## App Theme Folder Structure
 
-A reusable theme package should keep the same dependency direction as UraniumUI itself: the theme references core UraniumUI, and applications reference the theme. Core UraniumUI should not reference the theme.
-
-Recommended package shape:
+Keep app theme files close to the MAUI resource files that developers already know. A practical structure is:
 
 ```text
-src/MyCompany.UraniumUI.Brand/
-  AssemblyInfo.cs
-  MauiProgramExtensions.cs
-  Resources/
-    ColorResource.xaml
-    ColorResource.xaml.cs
-    StyleResource.xaml
-    StyleResource.xaml.cs
-  Controls/
-    BrandTextField.cs
-    BrandButtonView.cs
+Resources/
+  Themes/
+    AppColors.xaml
+    AppBaseStyles.xaml
+    AppMaterialOverrides.xaml
+    AppStyleClasses.xaml
+  Styles/
+    Colors.xaml
+    Styles.xaml
 ```
 
-Expose a XAML namespace for public controls and resources:
+Use `Resources/Styles/Colors.xaml` and `Resources/Styles/Styles.xaml` for ordinary MAUI starter-template resources. Use `Resources/Themes` for UraniumUI-specific tokens, Material overrides, and style classes. This separation makes it easier to see which files are part of your UraniumUI visual system.
 
-```csharp
-[assembly: XmlnsDefinition(Constants.XamlNamespace, "MyCompany.UraniumUI.Brand.Controls")]
-[assembly: XmlnsDefinition(Constants.XamlNamespace, "MyCompany.UraniumUI.Brand.Resources")]
-[assembly: Microsoft.Maui.Controls.XmlnsPrefix(Constants.XamlNamespace, "brand")]
-
-internal static class Constants
-{
-    public const string XamlNamespace = "http://schemas.mycompany.com/dotnet/maui/uraniumui/brand";
-}
-```
-
-Expose one registration method:
-
-```csharp
-public static class BrandThemeMauiProgramExtensions
-{
-    public static MauiAppBuilder UseUraniumUIBrand(this MauiAppBuilder builder)
-    {
-        builder.UseUraniumUI();
-
-        builder.ConfigureMauiHandlers(handlers =>
-        {
-            // Register only handlers that belong to this theme package.
-        });
-
-        return builder;
-    }
-}
-```
-
-If your theme depends on Material controls, reference `UraniumUI.Material` and call `UseUraniumUIMaterial()` from your app or from your theme registration method. If your theme is independent, reference only `UraniumUI`.
-
-## StyleResource for a Custom Theme
-
-A custom theme can start with a normal `ResourceDictionary`:
-
-```xml
-<?xml version="1.0" encoding="UTF-8" ?>
-<ResourceDictionary x:Class="MyCompany.UraniumUI.Brand.Resources.StyleResource"
-                    xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
-                    xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
-                    xmlns:local="clr-namespace:MyCompany.UraniumUI.Brand.Resources">
-
-    <ResourceDictionary.MergedDictionaries>
-        <local:ColorResource />
-
-        <ResourceDictionary>
-            <Style x:Key="Brand.Styles.Page" TargetType="Page" ApplyToDerivedTypes="True" CanCascade="True">
-                <Setter Property="BackgroundColor" Value="{AppThemeBinding Light={StaticResource Background}, Dark={StaticResource BackgroundDark}}" />
-            </Style>
-
-            <Style x:Key="Brand.Styles.Button.Filled" TargetType="Button" CanCascade="True">
-                <Setter Property="BackgroundColor" Value="{AppThemeBinding Light={StaticResource Primary}, Dark={StaticResource PrimaryDark}}" />
-                <Setter Property="TextColor" Value="{AppThemeBinding Light={StaticResource OnPrimary}, Dark={StaticResource OnPrimaryDark}}" />
-                <Setter Property="CornerRadius" Value="18" />
-            </Style>
-
-            <Style BaseResourceKey="Brand.Styles.Page" TargetType="Page" ApplyToDerivedTypes="True" CanCascade="True" />
-            <Style BaseResourceKey="Brand.Styles.Button.Filled" TargetType="Button" Class="FilledButton" CanCascade="True" />
-        </ResourceDictionary>
-    </ResourceDictionary.MergedDictionaries>
-</ResourceDictionary>
-```
-
-Then app projects can merge it:
-
-```xml
-<ResourceDictionary.MergedDictionaries>
-    <brand:StyleResource />
-</ResourceDictionary.MergedDictionaries>
-```
-
-If you want app-level `ColorsOverride`, `BasedOn`, or `Overrides` behavior like Material has, implement those properties in your theme's `StyleResource.xaml.cs`. Material's `StyleResource` is a good reference implementation.
+If your app only needs a small color change, you may only need `AppColors.xaml`. Add the other files when the app starts to need shared button variants, card styles, input-field changes, or custom control styles.
 
 ## Accessibility Contract
 
-Accessibility is part of the theme contract. Every interactive style and custom control should preserve these behaviors:
+Accessibility is part of the app theme contract. Every interactive style and custom control should preserve these behaviors:
 
 | Area | Requirement |
 | --- | --- |
@@ -431,21 +354,6 @@ Accessibility is part of the theme contract. Every interactive style and custom 
 | Contrast | Text and icons have sufficient contrast against their container tokens. |
 
 Use `StatefulContentView` or `ButtonView` for custom clickable surfaces instead of a passive layout with only `TapGestureRecognizer`. See [Accessibility Best Practices](../best-practices/Accessibility.md) and [Clickable Areas](../best-practices/ClickableAreas.md).
-
-## Theme Review Checklist
-
-Before publishing a theme or opening a theme PR, check:
-
-1. App startup calls the required `UseUraniumUI...` methods.
-2. Resource dictionaries are merged in the correct order.
-3. Light and dark color tokens exist for every style that uses `AppThemeBinding`.
-4. New public controls and resources have `XmlnsDefinition` entries.
-5. Keyed styles are stable and class styles are easy to use from app XAML.
-6. New style variants use `BaseResourceKey` instead of copying large styles.
-7. Interactive controls are keyboard reachable and have visible focus.
-8. Validation messages are readable and mapped to the correct field.
-9. `AutoFormView` mappings are configured if the theme provides replacement editors.
-10. Documentation shows the required XML namespace, resource setup, and control examples.
 
 ## Related Pages
 

--- a/docs/en/theming/CreatingTheme.md
+++ b/docs/en/theming/CreatingTheme.md
@@ -1,3 +1,457 @@
 # Creating a Theme
 
-TODO
+UraniumUI themes are ordinary .NET MAUI resource dictionaries plus a small set of conventions for color tokens, keyed styles, `StyleClass` styles, and reusable control primitives. A theme can be as small as an app-specific palette over the Material theme, or as large as a separate package with its own controls, resource dictionaries, XAML namespace, and `Use...` registration method.
+
+This page is the handbook for building and maintaining those themes.
+
+## Theme Scope
+
+Choose the smallest scope that solves the problem.
+
+| Goal | Recommended approach |
+| --- | --- |
+| Change app colors | Provide a colors dictionary through `material:StyleResource ColorsOverride`. |
+| Change existing Material styles | Use `material:StyleResource.Overrides` for existing keyed styles. |
+| Add app-specific visual variants | Add your own `StyleClass` styles after the theme resources are merged. |
+| Style a group of child controls together | Use `CascadingStyle.Resources` and `CascadingStyle.StyleClass`. |
+| Build reusable field or button controls | Compose UraniumUI primitives such as `InputField`, `StatefulContentView`, `ButtonView`, `Select`, and `EntryView`. |
+| Ship a reusable theme package | Create a package that references `UraniumUI`, exposes XAML resources, registers handlers/options, and maps XAML namespaces. |
+
+Most applications should customize the Material theme instead of creating a new package. Create a new theme package when the visual system, control set, or public API will be reused across multiple applications.
+
+## Runtime Setup
+
+Every app that uses UraniumUI controls should register the core handlers:
+
+```csharp
+builder
+    .UseMauiApp<App>()
+    .UseUraniumUI();
+```
+
+Apps that use the Material theme or Material controls should also register Material:
+
+```csharp
+builder
+    .UseMauiApp<App>()
+    .UseUraniumUI()
+    .UseUraniumUIMaterial();
+```
+
+`UseUraniumUI()` registers core handlers and dependencies, including `StatefulContentView`, `Select`, `Dropdown`, InputKit handlers, and Plainer controls. `UseUraniumUIMaterial()` registers Material-specific handlers and configures `AutoFormView` to use Material editors.
+
+## Resource Setup
+
+Material resources are exposed through the Material XAML namespace:
+
+```xml
+xmlns:material="http://schemas.enisn-projects.io/dotnet/maui/uraniumui/material"
+```
+
+The common app setup is:
+
+```xml
+<Application xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             xmlns:material="http://schemas.enisn-projects.io/dotnet/maui/uraniumui/material"
+             x:Class="MyApp.App">
+    <Application.Resources>
+        <ResourceDictionary>
+            <ResourceDictionary.MergedDictionaries>
+                <ResourceDictionary x:Name="brandColors" Source="Resources/Themes/BrandColors.xaml" />
+                <ResourceDictionary x:Name="brandBaseStyles" Source="Resources/Themes/BrandBaseStyles.xaml" />
+
+                <material:StyleResource
+                    ColorsOverride="{x:Reference brandColors}"
+                    BasedOn="{x:Reference brandBaseStyles}">
+                    <material:StyleResource.Overrides>
+                        <ResourceDictionary Source="Resources/Themes/BrandMaterialOverrides.xaml" />
+                    </material:StyleResource.Overrides>
+                </material:StyleResource>
+
+                <ResourceDictionary Source="Resources/Themes/BrandStyleClasses.xaml" />
+            </ResourceDictionary.MergedDictionaries>
+        </ResourceDictionary>
+    </Application.Resources>
+</Application>
+```
+
+Use this order deliberately:
+
+1. `BrandColors.xaml` provides color keys that `ColorsOverride` can copy into Material's color dictionary.
+2. `BrandBaseStyles.xaml` can provide keyed base styles that match Material style keys; Material styles inherit missing setters from those styles.
+3. `BrandMaterialOverrides.xaml` can override setters on existing Material keyed styles with matching keys.
+4. `BrandStyleClasses.xaml` can add new app-specific styles after Material resources exist.
+
+`StyleResource.Overrides` changes existing theme styles. It is not a general merge point for new styles. Put new styles in a normal merged dictionary after `material:StyleResource`.
+
+## Color Tokens
+
+UraniumUI Material uses named color tokens and the dark-token suffix convention. The light token is named `Primary`; the dark token is named `PrimaryDark`. Styles bind both with `AppThemeBinding`:
+
+```xml
+<Setter Property="TextColor"
+        Value="{AppThemeBinding Light={StaticResource OnSurface}, Dark={StaticResource OnSurfaceDark}}" />
+```
+
+Use these token groups when designing a palette:
+
+| Tokens | Purpose |
+| --- | --- |
+| `Primary`, `OnPrimary`, `PrimaryContainer`, `OnPrimaryContainer` | Main brand actions and high-emphasis surfaces. |
+| `Secondary`, `OnSecondary`, `SecondaryContainer`, `OnSecondaryContainer` | Supporting actions and lower-emphasis brand surfaces. |
+| `Tertiary`, `OnTertiary`, `TertiaryContainer`, `OnTertiaryContainer` | Accent areas and alternate selection states. |
+| `Surface`, `OnSurface`, `SurfaceVariant`, `OnSurfaceVariant` | Cards, sheets, dialogs, inputs, dividers, and text on surfaces. |
+| `Background`, `OnBackground` | Page-level backgrounds and default text. |
+| `Error`, `ErrorContainer`, `OnError`, `OnErrorContainer` | Validation and destructive/error states. |
+| `Outline`, `OutlineVariant` | Borders, separators, and low-emphasis strokes. |
+| `Shadow`, `Scrim`, `InverseSurface`, `InverseOnSurface`, `InversePrimary` | Elevation, overlays, and inverse surfaces. |
+
+A minimal color override file should keep the same keys that Material expects:
+
+```xml
+<?xml version="1.0" encoding="utf-8" ?>
+<ResourceDictionary xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml">
+    <Color x:Key="Primary">#2458D3</Color>
+    <Color x:Key="PrimaryDark">#ADC6FF</Color>
+    <Color x:Key="OnPrimary">#FFFFFF</Color>
+    <Color x:Key="OnPrimaryDark">#082B73</Color>
+
+    <Color x:Key="Surface">#FCFBFF</Color>
+    <Color x:Key="SurfaceDark">#111318</Color>
+    <Color x:Key="OnSurface">#1B1B21</Color>
+    <Color x:Key="OnSurfaceDark">#E4E2EA</Color>
+
+    <Color x:Key="Background">#F7F8FF</Color>
+    <Color x:Key="BackgroundDark">#0C0E13</Color>
+    <Color x:Key="OnBackground">#1B1B21</Color>
+    <Color x:Key="OnBackgroundDark">#E4E2EA</Color>
+
+    <Color x:Key="Error">#BA1A1A</Color>
+    <Color x:Key="ErrorDark">#FFB4AB</Color>
+    <Color x:Key="Outline">#74777F</Color>
+    <Color x:Key="OutlineDark">#8E9099</Color>
+</ResourceDictionary>
+```
+
+Keep contrast in mind when choosing every `On...` token. `OnPrimary` must be readable on `Primary`, `OnSurface` must be readable on `Surface`, and validation text must remain readable in both light and dark themes.
+
+## Style Layers
+
+Theme styles normally use three layers.
+
+| Layer | Example | Usage |
+| --- | --- | --- |
+| Keyed base style | `x:Key="UraniumUI.Styles.Button.Filled"` | Stable extension point for theme authors. |
+| Implicit style | `<Style TargetType="Label" />` | Default appearance for a type. |
+| Class style | `Class="FilledButton"` | Variant selected by `StyleClass`. |
+
+The Material theme defines keyed styles first, then maps public classes to those keyed styles:
+
+```xml
+<Style x:Key="UraniumUI.Styles.Button.Filled"
+       TargetType="Button"
+       BaseResourceKey="BaseButtonStyle"
+       CanCascade="True">
+    <Setter Property="BackgroundColor" Value="{AppThemeBinding Light={StaticResource Primary}, Dark={StaticResource PrimaryDark}}" />
+    <Setter Property="TextColor" Value="{AppThemeBinding Light={StaticResource OnPrimary}, Dark={StaticResource OnPrimaryDark}}" />
+</Style>
+
+<Style BaseResourceKey="UraniumUI.Styles.Button.Filled"
+       TargetType="Button"
+       Class="FilledButton"
+       CanCascade="True" />
+```
+
+That lets app code stay simple:
+
+```xml
+<Button Text="Save" StyleClass="FilledButton" />
+```
+
+It also gives theme authors a stable style key to override:
+
+```xml
+<Style x:Key="UraniumUI.Styles.Button.Filled" TargetType="Button">
+    <Setter Property="CornerRadius" Value="14" />
+    <Setter Property="HeightRequest" Value="44" />
+</Style>
+```
+
+Use `BaseResourceKey` instead of copying large styles. This keeps future theme fixes and state definitions intact unless you intentionally replace them.
+
+## Material Style Overrides
+
+Use `material:StyleResource.Overrides` when you want to change existing Material keyed styles.
+
+```xml
+<ResourceDictionary xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+                    xmlns:material="http://schemas.enisn-projects.io/dotnet/maui/uraniumui/material">
+
+    <Style x:Key="UraniumUI.Styles.InputField"
+           TargetType="material:InputField"
+           ApplyToDerivedTypes="True">
+        <Setter Property="CornerRadius" Value="12" />
+        <Setter Property="BorderThickness" Value="1.5" />
+        <Setter Property="InputBackgroundColor" Value="{AppThemeBinding Light={StaticResource Surface}, Dark={StaticResource SurfaceDark}}" />
+    </Style>
+
+    <Style x:Key="UraniumUI.Styles.TextField" TargetType="material:TextField">
+        <Setter Property="SelectionHighlightColor" Value="{StaticResource Primary}" />
+    </Style>
+</ResourceDictionary>
+```
+
+Only setters are merged into the existing Material style. If the override contains a setter for a property that already exists, the value is replaced. If it contains a new setter, the setter is added.
+
+## New Style Classes
+
+Add new class styles in a normal dictionary after the theme is merged:
+
+```xml
+<ResourceDictionary xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml">
+
+    <Style TargetType="Button"
+           Class="DangerButton"
+           BaseResourceKey="UraniumUI.Styles.Button.Filled">
+        <Setter Property="BackgroundColor" Value="{AppThemeBinding Light={StaticResource Error}, Dark={StaticResource ErrorDark}}" />
+        <Setter Property="TextColor" Value="{AppThemeBinding Light={StaticResource OnError}, Dark={StaticResource OnErrorDark}}" />
+    </Style>
+
+    <Style TargetType="Border" Class="Card" BaseResourceKey="UraniumUI.Styles.Border.Rounded">
+        <Setter Property="Padding" Value="16" />
+        <Setter Property="BackgroundColor" Value="{AppThemeBinding Light={StaticResource Surface}, Dark={StaticResource SurfaceDark}}" />
+        <Setter Property="Stroke" Value="{AppThemeBinding Light={StaticResource OutlineVariant}, Dark={StaticResource OutlineVariantDark}}" />
+    </Style>
+</ResourceDictionary>
+```
+
+Usage:
+
+```xml
+<Button Text="Delete" StyleClass="DangerButton" />
+
+<Border StyleClass="Card">
+    <Label Text="Account details" />
+</Border>
+```
+
+Use class styles for variants that developers select explicitly. Use implicit styles only when every control of that type should change.
+
+## Inherited Styles
+
+Use `BaseResourceKey` to create variants from existing styles:
+
+```xml
+<Style TargetType="Button"
+       Class="CompactFilledButton"
+       BaseResourceKey="UraniumUI.Styles.Button.Filled">
+    <Setter Property="HeightRequest" Value="34" />
+    <Setter Property="Padding" Value="14,0" />
+</Style>
+```
+
+Use `ApplyToDerivedTypes="True"` when a base control style should also apply to subclasses:
+
+```xml
+<Style x:Key="Brand.Styles.InputField"
+       TargetType="material:InputField"
+       ApplyToDerivedTypes="True">
+    <Setter Property="CornerRadius" Value="10" />
+</Style>
+```
+
+Use `CanCascade="True"` on styles that should participate in UraniumUI cascading style behavior.
+
+## Cascading Styles
+
+Cascading styles are useful when a container should set the appearance of its children without requiring every child to specify a `StyleClass`.
+
+```xml
+<ResourceDictionary xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+                    xmlns:uranium="http://schemas.enisn-projects.io/dotnet/maui/uraniumui">
+
+    <Style TargetType="Border" Class="PrimaryCard" BaseResourceKey="UraniumUI.Styles.Border.Rounded" CanCascade="True">
+        <Setter Property="Padding" Value="20" />
+        <Setter Property="BackgroundColor" Value="{AppThemeBinding Light={StaticResource PrimaryContainer}, Dark={StaticResource PrimaryContainerDark}}" />
+        <Setter Property="uranium:CascadingStyle.Resources">
+            <ResourceDictionary>
+                <Style TargetType="Label">
+                    <Setter Property="TextColor" Value="{AppThemeBinding Light={StaticResource OnPrimaryContainer}, Dark={StaticResource OnPrimaryContainerDark}}" />
+                </Style>
+
+                <Style TargetType="Button">
+                    <Setter Property="uranium:CascadingStyle.StyleClass" Value="TextButton" />
+                </Style>
+            </ResourceDictionary>
+        </Setter>
+    </Style>
+</ResourceDictionary>
+```
+
+Usage:
+
+```xml
+<Border StyleClass="PrimaryCard">
+    <VerticalStackLayout Spacing="12">
+        <Label Text="Subscription" />
+        <Button Text="Manage" />
+    </VerticalStackLayout>
+</Border>
+```
+
+See [Cascading Styling](CascadingStyling.md) for the full cascading style API.
+
+## Theme Control Primitives
+
+Themes should prefer composition over platform-specific handlers. UraniumUI already provides primitives that solve common interaction and accessibility problems.
+
+| Primitive | Use it for |
+| --- | --- |
+| `InputField` | A Material field shell with floating label, border, icon, attachments, focus state, and validation area. |
+| `TextField` | Text input built from `InputField` plus a chrome-free `EntryView`. Use it directly or copy its pattern for custom text fields. |
+| `StatefulContentView` | Clickable custom surfaces with pressed, pointer-over, focus, and command support. |
+| `ButtonView` | Material clickable content when a normal MAUI `Button` is not flexible enough. |
+| `Select` and `Dropdown` | Selection and overlay patterns that need keyboard-aware behavior. |
+| `CascadingStyle` | Container-level child styling and style-class assignment. |
+
+For example, a fully custom text input does not need a new handler just to draw a border. Wrap a chrome-free entry in a `Border`, or use `InputField` when you need the Material floating label and validation behavior. See [Building Theme Controls](BuildingThemeControls.md) for advanced examples.
+
+## Theme Package Structure
+
+A reusable theme package should keep the same dependency direction as UraniumUI itself: the theme references core UraniumUI, and applications reference the theme. Core UraniumUI should not reference the theme.
+
+Recommended package shape:
+
+```text
+src/MyCompany.UraniumUI.Brand/
+  AssemblyInfo.cs
+  MauiProgramExtensions.cs
+  Resources/
+    ColorResource.xaml
+    ColorResource.xaml.cs
+    StyleResource.xaml
+    StyleResource.xaml.cs
+  Controls/
+    BrandTextField.cs
+    BrandButtonView.cs
+```
+
+Expose a XAML namespace for public controls and resources:
+
+```csharp
+[assembly: XmlnsDefinition(Constants.XamlNamespace, "MyCompany.UraniumUI.Brand.Controls")]
+[assembly: XmlnsDefinition(Constants.XamlNamespace, "MyCompany.UraniumUI.Brand.Resources")]
+[assembly: Microsoft.Maui.Controls.XmlnsPrefix(Constants.XamlNamespace, "brand")]
+
+internal static class Constants
+{
+    public const string XamlNamespace = "http://schemas.mycompany.com/dotnet/maui/uraniumui/brand";
+}
+```
+
+Expose one registration method:
+
+```csharp
+public static class BrandThemeMauiProgramExtensions
+{
+    public static MauiAppBuilder UseUraniumUIBrand(this MauiAppBuilder builder)
+    {
+        builder.UseUraniumUI();
+
+        builder.ConfigureMauiHandlers(handlers =>
+        {
+            // Register only handlers that belong to this theme package.
+        });
+
+        return builder;
+    }
+}
+```
+
+If your theme depends on Material controls, reference `UraniumUI.Material` and call `UseUraniumUIMaterial()` from your app or from your theme registration method. If your theme is independent, reference only `UraniumUI`.
+
+## StyleResource for a Custom Theme
+
+A custom theme can start with a normal `ResourceDictionary`:
+
+```xml
+<?xml version="1.0" encoding="UTF-8" ?>
+<ResourceDictionary x:Class="MyCompany.UraniumUI.Brand.Resources.StyleResource"
+                    xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+                    xmlns:local="clr-namespace:MyCompany.UraniumUI.Brand.Resources">
+
+    <ResourceDictionary.MergedDictionaries>
+        <local:ColorResource />
+
+        <ResourceDictionary>
+            <Style x:Key="Brand.Styles.Page" TargetType="Page" ApplyToDerivedTypes="True" CanCascade="True">
+                <Setter Property="BackgroundColor" Value="{AppThemeBinding Light={StaticResource Background}, Dark={StaticResource BackgroundDark}}" />
+            </Style>
+
+            <Style x:Key="Brand.Styles.Button.Filled" TargetType="Button" CanCascade="True">
+                <Setter Property="BackgroundColor" Value="{AppThemeBinding Light={StaticResource Primary}, Dark={StaticResource PrimaryDark}}" />
+                <Setter Property="TextColor" Value="{AppThemeBinding Light={StaticResource OnPrimary}, Dark={StaticResource OnPrimaryDark}}" />
+                <Setter Property="CornerRadius" Value="18" />
+            </Style>
+
+            <Style BaseResourceKey="Brand.Styles.Page" TargetType="Page" ApplyToDerivedTypes="True" CanCascade="True" />
+            <Style BaseResourceKey="Brand.Styles.Button.Filled" TargetType="Button" Class="FilledButton" CanCascade="True" />
+        </ResourceDictionary>
+    </ResourceDictionary.MergedDictionaries>
+</ResourceDictionary>
+```
+
+Then app projects can merge it:
+
+```xml
+<ResourceDictionary.MergedDictionaries>
+    <brand:StyleResource />
+</ResourceDictionary.MergedDictionaries>
+```
+
+If you want app-level `ColorsOverride`, `BasedOn`, or `Overrides` behavior like Material has, implement those properties in your theme's `StyleResource.xaml.cs`. Material's `StyleResource` is a good reference implementation.
+
+## Accessibility Contract
+
+Accessibility is part of the theme contract. Every interactive style and custom control should preserve these behaviors:
+
+| Area | Requirement |
+| --- | --- |
+| Keyboard | Interactive controls are reachable by `Tab` and activate with the expected keys. |
+| Focus | Focus state is visible in light and dark themes. |
+| Pointer states | Hover, pressed, disabled, selected, and error states remain visually distinct. |
+| Screen readers | Icon-only actions have `SemanticProperties.Description` and useful hints. |
+| Validation | Error messages are visible as text and not communicated only by color or an icon. |
+| Contrast | Text and icons have sufficient contrast against their container tokens. |
+
+Use `StatefulContentView` or `ButtonView` for custom clickable surfaces instead of a passive layout with only `TapGestureRecognizer`. See [Accessibility Best Practices](../best-practices/Accessibility.md) and [Clickable Areas](../best-practices/ClickableAreas.md).
+
+## Theme Review Checklist
+
+Before publishing a theme or opening a theme PR, check:
+
+1. App startup calls the required `UseUraniumUI...` methods.
+2. Resource dictionaries are merged in the correct order.
+3. Light and dark color tokens exist for every style that uses `AppThemeBinding`.
+4. New public controls and resources have `XmlnsDefinition` entries.
+5. Keyed styles are stable and class styles are easy to use from app XAML.
+6. New style variants use `BaseResourceKey` instead of copying large styles.
+7. Interactive controls are keyboard reachable and have visible focus.
+8. Validation messages are readable and mapped to the correct field.
+9. `AutoFormView` mappings are configured if the theme provides replacement editors.
+10. Documentation shows the required XML namespace, resource setup, and control examples.
+
+## Related Pages
+
+- [Color System](ColorSystem.md)
+- [Cascading Styling](CascadingStyling.md)
+- [Building Theme Controls](BuildingThemeControls.md)
+- [Material Colors & Styles](../themes/material/ColorsAndStyles.md)
+- [InputField](../themes/material/components/InputField.md)
+- [StatefulContentView](../infrastructure/StatefulContentView.md)

--- a/docs/en/toc.yml
+++ b/docs/en/toc.yml
@@ -52,6 +52,8 @@
       href: theming/CascadingStyling.md
     - name: Creating a Theme
       href: theming/CreatingTheme.md
+    - name: Building Theme Controls
+      href: theming/BuildingThemeControls.md
     - name: Icons
       href: theming/Icons.md
       items:


### PR DESCRIPTION
## Summary

- Replace the stale `CreatingTheme.md` TODO with an app-focused theming handbook covering Material customization, color tokens, keyed styles, style classes, inherited styles, cascading styles, app theme file organization, and accessibility expectations.
- Add an advanced `BuildingThemeControls.md` page for composing app-specific controls with `InputField`, `EntryView`, `StatefulContentView`, attachments, and `AutoFormView` mappings.
- Add the new advanced page to both docs navigation files.

## Verification

- `git diff --check` passes, with only Windows CRLF conversion warnings.
- `docs/en/docs-nav.json` parses with `ConvertFrom-Json`.
- Linked local docs paths referenced from the new handbook pages exist.
