### PR TITLE
Make input field attachments settable

### DIFF
--- a/src/UraniumUI.Material/Controls/InputField.cs
+++ b/src/UraniumUI.Material/Controls/InputField.cs
@@ -1,4 +1,6 @@
 using Microsoft.Maui.Controls.Shapes;
+using System.Collections.ObjectModel;
+using System.Collections.Specialized;
 using System.ComponentModel;
 using UraniumUI.Extensions;
 using UraniumUI.Pages;
@@ -21,6 +23,8 @@ public partial class InputField : ContentView
     private Grid rootGridPart;
     private Grid innerGridPart;
     private HorizontalStackLayout endIconsContainerPart;
+    private readonly List<IView> appliedAttachments = new();
+    private INotifyCollectionChanged subscribedAttachments;
     private bool isTemplateApplied;
 
     public virtual new View Content { get => (View)GetValue(ContentProperty); set => SetValue(ContentProperty, value); }
@@ -75,7 +79,36 @@ public partial class InputField : ContentView
 
     protected HorizontalStackLayout endIconsContainer => endIconsContainerPart ??= FindTemplatePart<HorizontalStackLayout>("EndIconsContainer");
 
-    public IList<IView> Attachments => endIconsContainer?.Children;
+    public static readonly BindableProperty AttachmentsProperty = BindableProperty.Create(
+        nameof(Attachments),
+        typeof(object),
+        typeof(InputField),
+        defaultValueCreator: _ => new ObservableCollection<IView>(),
+        validateValue: (_, value) => value is null || value is IList<IView> || value is IView || value is IEnumerable<IView>,
+        propertyChanged: (bindable, oldValue, newValue) =>
+        {
+            if (bindable is not InputField inputField)
+            {
+                return;
+            }
+
+            inputField.UnsubscribeFromAttachments(oldValue);
+            inputField.SubscribeToAttachments(newValue);
+            inputField.ApplyAttachments();
+            inputField.OnPropertyChanged(nameof(Attachments));
+        },
+        coerceValue: (_, value) => value switch
+        {
+            null => null,
+            IList<IView> => value,
+            IView attachment => new ObservableCollection<IView> { attachment },
+            IEnumerable<IView> attachments => new ObservableCollection<IView>(attachments.Where(attachment => attachment is not null)),
+            _ => value,
+        });
+
+    private IList<IView> BindableAttachments => GetValue(AttachmentsProperty) as IList<IView>;
+
+    public IList<IView> Attachments { get => endIconsContainer?.Children ?? BindableAttachments; set => SetValue(AttachmentsProperty, value); }
 
     private Color LastFontimageColor;
 
@@ -167,8 +200,71 @@ public partial class InputField : ContentView
     public InputField()
     {
         this.ControlTemplate = inputFieldControlTemplate;
+        SubscribeToAttachments(BindableAttachments);
 
         InitializeValidation();
+    }
+
+    private void SubscribeToAttachments(object attachments)
+    {
+        if (attachments is not INotifyCollectionChanged collectionChanged || ReferenceEquals(collectionChanged, subscribedAttachments))
+        {
+            return;
+        }
+
+        collectionChanged.CollectionChanged += Attachments_CollectionChanged;
+        subscribedAttachments = collectionChanged;
+    }
+
+    private void UnsubscribeFromAttachments(object attachments)
+    {
+        if (attachments is not INotifyCollectionChanged collectionChanged)
+        {
+            return;
+        }
+
+        collectionChanged.CollectionChanged -= Attachments_CollectionChanged;
+
+        if (ReferenceEquals(collectionChanged, subscribedAttachments))
+        {
+            subscribedAttachments = null;
+        }
+    }
+
+    private void Attachments_CollectionChanged(object sender, NotifyCollectionChangedEventArgs e)
+    {
+        ApplyAttachments();
+    }
+
+    private void ApplyAttachments()
+    {
+        var currentEndIconsContainer = endIconsContainer;
+        if (currentEndIconsContainer is null)
+        {
+            return;
+        }
+
+        foreach (var attachment in appliedAttachments.ToArray())
+        {
+            currentEndIconsContainer.Remove(attachment);
+        }
+
+        appliedAttachments.Clear();
+
+        if (BindableAttachments is null)
+        {
+            return;
+        }
+
+        foreach (var attachment in BindableAttachments.Where(attachment => attachment is not null))
+        {
+            if (!currentEndIconsContainer.Contains(attachment))
+            {
+                currentEndIconsContainer.Add(attachment);
+            }
+
+            appliedAttachments.Add(attachment);
+        }
     }
 
     public virtual bool HasValue
@@ -494,6 +590,7 @@ public partial class InputField : ContentView
         ResetTemplateParts();
 
         ApplyTitleFormattedText();
+        ApplyAttachments();
 
         if (Icon != null)
         {

--- a/test/UraniumUI.Material.Tests/Controls/TextField_Test.cs
+++ b/test/UraniumUI.Material.Tests/Controls/TextField_Test.cs
@@ -1,6 +1,7 @@
 ﻿using FluentAssertions;
 using NSubstitute;
 using Shouldly;
+using System.Collections.ObjectModel;
 using System.Windows.Input;
 using UraniumUI.Material.Controls;
 using UraniumUI.Tests.Core;
@@ -145,6 +146,89 @@ public class TextField_Test
         endIconsContainer.Spacing.ShouldBe(InputField.AttachmentsSpacing);
         control.Attachments.ShouldContain(first);
         control.Attachments.ShouldContain(second);
+        endIconsContainer.Children.ShouldContain(first);
+        endIconsContainer.Children.ShouldContain(second);
+    }
+
+    [Fact]
+    public void Attachments_AddedBeforeTemplateApplied_ShouldBeRenderedAfterTemplateApplied()
+    {
+        var attachment = new ActivityIndicator { IsRunning = true };
+        var control = new TextField();
+
+        control.Attachments.Add(attachment);
+
+        AnimationReadyHandler.Prepare(control);
+
+        var endIconsContainer = control.FindByViewQueryIdInVisualTreeDescendants<HorizontalStackLayout>("EndIconsContainer");
+
+        endIconsContainer.ShouldNotBeNull();
+        endIconsContainer.Children.ShouldContain(attachment);
+    }
+
+    [Fact]
+    public void Attachments_CanBeSetViaImplicitStyle()
+    {
+        var attachment = new ActivityIndicator { IsRunning = true };
+        var style = new Style(typeof(TextField));
+        style.Setters.Add(new Setter
+        {
+            Property = InputField.AttachmentsProperty,
+            Value = attachment,
+        });
+
+        var resources = new ResourceDictionary();
+        resources.Add(style);
+
+        var control = AnimationReadyHandler.Prepare(new TextField());
+
+        control.Resources = resources;
+
+        var endIconsContainer = control.FindByViewQueryIdInVisualTreeDescendants<HorizontalStackLayout>("EndIconsContainer");
+
+        endIconsContainer.ShouldNotBeNull();
+        control.Attachments.ShouldContain(attachment);
+        endIconsContainer.Children.ShouldContain(attachment);
+    }
+
+    [Fact]
+    public void Attachments_CanBeBoundToCollection()
+    {
+        var attachment = new ActivityIndicator { IsRunning = true };
+        var viewModel = new TestViewModel
+        {
+            Attachments = new ObservableCollection<IView> { attachment },
+        };
+        var control = new TextField
+        {
+            BindingContext = viewModel,
+        };
+
+        control.SetBinding(InputField.AttachmentsProperty, new Binding(nameof(TestViewModel.Attachments)));
+
+        AnimationReadyHandler.Prepare(control);
+
+        var endIconsContainer = control.FindByViewQueryIdInVisualTreeDescendants<HorizontalStackLayout>("EndIconsContainer");
+
+        endIconsContainer.ShouldNotBeNull();
+        endIconsContainer.Children.ShouldContain(attachment);
+    }
+
+    [Fact]
+    public void Attachments_ReplacedAfterTemplateApplied_ShouldPreserveBuiltInClearIcon()
+    {
+        var control = AnimationReadyHandler.Prepare(new TextField { AllowClear = true });
+        var clearIcon = control.FindByViewQueryIdInVisualTreeDescendants<StatefulContentView>("ClearIcon");
+        var attachment = new ActivityIndicator { IsRunning = true };
+
+        control.Attachments = new ObservableCollection<IView> { attachment };
+
+        var endIconsContainer = control.FindByViewQueryIdInVisualTreeDescendants<HorizontalStackLayout>("EndIconsContainer");
+
+        clearIcon.ShouldNotBeNull();
+        endIconsContainer.ShouldNotBeNull();
+        endIconsContainer.Children.ShouldContain(clearIcon);
+        endIconsContainer.Children.ShouldContain(attachment);
     }
 
     [Fact]
@@ -516,6 +600,7 @@ public class TextField_Test
         private Keyboard keyboard;
         private ClearButtonVisibility clearButtonVisibility;
         private double characterSpacing;
+        private IList<IView> attachments;
         private object commandParameter = "My Command Parameter 1";
 
         public bool IsChecked { get => isChecked; set => SetProperty(ref isChecked, value); }
@@ -536,6 +621,8 @@ public class TextField_Test
         public ClearButtonVisibility ClearButtonVisibility { get => clearButtonVisibility; set => SetProperty(ref clearButtonVisibility, value); }
 
         public double CharacterSpacing { get => characterSpacing; set => SetProperty(ref characterSpacing, value); }
+
+        public IList<IView> Attachments { get => attachments; set => SetProperty(ref attachments, value); }
     }
 
     private sealed class TemplateAwareTextField : TextField


### PR DESCRIPTION
## Summary
- make Material `InputField` attachments settable and bindable while preserving existing collection-style access to rendered attachments
- sync pre-template, bound, styled, and replaced attachments into the input field end-icons container
- add Material tests for collection syntax, implicit style setters, bindings, and preserving built-in clear icons

## Automated Testing
- `dotnet test "test/UraniumUI.Material.Tests/UraniumUI.Material.Tests.csproj"`

Closes #619
