### PR TITLE
Add Keyboard support to AutoCompleteTextField

### DIFF
--- a/docs/en/themes/material/components/AutoCompleteTextField.md
+++ b/docs/en/themes/material/components/AutoCompleteTextField.md
@@ -55,6 +55,7 @@ Then you can use it in a page like this:
 - `SelectedText` (string): The text value when an item is selected from suggestions
 - `ItemsSource` (IList<string>): The collection of items to show as suggestions
 - `Threshold` (int): Minimum number of characters to type before showing suggestions (default: 2)
+- `Keyboard` (Keyboard): The soft keyboard type to use for text input (for example, `Numeric`)
 - `TextColor` (Color): The color of the input text
 - `AllowClear` (bool): Whether to show a clear button when text is entered (default: false)
 

--- a/src/UraniumUI.Material/Controls/AutoCompleteTextField.cs
+++ b/src/UraniumUI.Material/Controls/AutoCompleteTextField.cs
@@ -1,4 +1,6 @@
 ﻿using Plainer.Maui.Controls;
+using Microsoft.Maui.Converters;
+using System.ComponentModel;
 using UraniumUI.Controls;
 using UraniumUI.Pages;
 using UraniumUI.Resources;
@@ -50,6 +52,7 @@ public class AutoCompleteTextField : InputField
         autoCompleteView.SetBinding(AutoCompleteView.ItemsSourceProperty, new Binding(nameof(ItemsSource), source: this));
         autoCompleteView.SetBinding(AutoCompleteView.TextColorProperty, new Binding(nameof(TextColor), source: this));
         autoCompleteView.SetBinding(AutoCompleteView.ThresholdProperty, new Binding(nameof(Threshold), source: this));
+        autoCompleteView.SetBinding(AutoCompleteView.KeyboardProperty, new Binding(nameof(Keyboard), source: this));
     }
 
     public override bool HasValue => !string.IsNullOrEmpty(Text);
@@ -179,4 +182,14 @@ public class AutoCompleteTextField : InputField
         typeof(AutoCompleteTextField),
         AutoCompleteView.ThresholdProperty.DefaultValue,
         propertyChanged: (bindable, oldValue, newValue) => (bindable as AutoCompleteTextField).AutoCompleteView.Threshold = (int)newValue);
+
+    [TypeConverter(typeof(KeyboardTypeConverter))]
+    public Keyboard Keyboard { get => (Keyboard)GetValue(KeyboardProperty); set => SetValue(KeyboardProperty, value); }
+
+    public static BindableProperty KeyboardProperty = BindableProperty.Create(
+        nameof(Keyboard),
+        typeof(Keyboard),
+        typeof(AutoCompleteTextField),
+        AutoCompleteView.KeyboardProperty.DefaultValue,
+        propertyChanged: (bindable, oldValue, newValue) => (bindable as AutoCompleteTextField).AutoCompleteView.Keyboard = (Keyboard)newValue);
 }

--- a/src/UraniumUI/Controls/AutoCompleteView.cs
+++ b/src/UraniumUI/Controls/AutoCompleteView.cs
@@ -1,6 +1,8 @@
 ﻿using System;
 using System.Collections;
+using System.ComponentModel;
 using System.Windows.Input;
+using Microsoft.Maui.Converters;
 
 namespace UraniumUI.Controls;
 public class AutoCompleteView : View, IAutoCompleteView
@@ -70,6 +72,15 @@ public class AutoCompleteView : View, IAutoCompleteView
         typeof(int),
         typeof(AutoCompleteView),
         2);
+
+    [TypeConverter(typeof(KeyboardTypeConverter))]
+    public Keyboard Keyboard { get => (Keyboard)GetValue(KeyboardProperty); set => SetValue(KeyboardProperty, value); }
+
+    public static readonly BindableProperty KeyboardProperty = BindableProperty.Create(
+        nameof(Keyboard),
+        typeof(Keyboard),
+        typeof(AutoCompleteView),
+        Keyboard.Default);
 
     public ICommand ReturnCommand { get => (ICommand)GetValue(ReturnCommandProperty); set => SetValue(ReturnCommandProperty, value); }
 

--- a/src/UraniumUI/Controls/IAutoCompleteView.cs
+++ b/src/UraniumUI/Controls/IAutoCompleteView.cs
@@ -9,6 +9,7 @@ public interface IAutoCompleteView : IView
     Color TextColor { get; set; }
     IList ItemsSource { get; set; }
     int Threshold { get; set; }
+    Keyboard Keyboard { get; set; }
 
     void Completed();
 }

--- a/src/UraniumUI/Handlers/AutoCompleteViewHandler.Android.cs
+++ b/src/UraniumUI/Handlers/AutoCompleteViewHandler.Android.cs
@@ -140,6 +140,12 @@ public partial class AutoCompleteViewHandler : ViewHandler<IAutoCompleteView, Ap
             handler.PlatformView.Threshold = view.Threshold;
         }
     }
+
+    public static void MapKeyboard(AutoCompleteViewHandler handler, AutoCompleteView view)
+    {
+        handler.PlatformView.InputType = view.Keyboard.ToInputType();
+        handler.PlatformView.SetSingleLine(true);
+    }
 }
 
 internal class BoxArrayAdapter : ArrayAdapter

--- a/src/UraniumUI/Handlers/AutoCompleteViewHandler.Apple.cs
+++ b/src/UraniumUI/Handlers/AutoCompleteViewHandler.Apple.cs
@@ -108,6 +108,11 @@ public partial class AutoCompleteViewHandler : ViewHandler<IAutoCompleteView, UI
         handler.PlatformView.Threshold = view.Threshold;
     }
 
+    public static void MapKeyboard(AutoCompleteViewHandler handler, AutoCompleteView view)
+    {
+        handler.PlatformView.ApplyKeyboard(view.Keyboard);
+    }
+
     private void SetItemsSource()
     {
         if (VirtualView.ItemsSource != null)

--- a/src/UraniumUI/Handlers/AutoCompleteViewHandler.Windows.cs
+++ b/src/UraniumUI/Handlers/AutoCompleteViewHandler.Windows.cs
@@ -1,6 +1,9 @@
 ﻿#if WINDOWS
 using Microsoft.Maui.Handlers;
+using Microsoft.Maui.Platform;
+using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Media;
 using UraniumUI.Controls;
 
 namespace UraniumUI.Handlers;
@@ -27,6 +30,9 @@ public partial class AutoCompleteViewHandler : ViewHandler<IAutoCompleteView, Au
         platformView.GotFocus += PlatformView_GotFocus;
         platformView.KeyDown += TextBox_KeyDown;
         platformView.SuggestionChosen += PlatformView_SuggestionChosen;
+        platformView.Loaded += PlatformView_Loaded;
+
+        UpdateInputScope();
     }
 
     protected override void DisconnectHandler(AutoSuggestBox platformView)
@@ -35,6 +41,12 @@ public partial class AutoCompleteViewHandler : ViewHandler<IAutoCompleteView, Au
         platformView.GotFocus -= PlatformView_GotFocus;
         platformView.KeyDown -= TextBox_KeyDown;
         platformView.SuggestionChosen -= PlatformView_SuggestionChosen;
+        platformView.Loaded -= PlatformView_Loaded;
+    }
+
+    private void PlatformView_Loaded(object sender, Microsoft.UI.Xaml.RoutedEventArgs e)
+    {
+        UpdateInputScope();
     }
 
     private void PlatformView_TextChanged(AutoSuggestBox sender, AutoSuggestBoxTextChangedEventArgs args)
@@ -87,6 +99,42 @@ public partial class AutoCompleteViewHandler : ViewHandler<IAutoCompleteView, Au
     public static void MapThreshold(AutoCompleteViewHandler handler, AutoCompleteView view)
     {
         // Not supported, handled manually
+    }
+
+    public static void MapKeyboard(AutoCompleteViewHandler handler, AutoCompleteView view)
+    {
+        handler.UpdateInputScope();
+    }
+
+    private void UpdateInputScope()
+    {
+        // AutoSuggestBox exposes the editable TextBox only through its template.
+        if (PlatformView is null || VirtualView is null || FindTextBox(PlatformView) is not TextBox textBox)
+        {
+            return;
+        }
+
+        textBox.InputScope = VirtualView.Keyboard.ToInputScope();
+    }
+
+    private static TextBox FindTextBox(DependencyObject parent)
+    {
+        for (var i = 0; i < VisualTreeHelper.GetChildrenCount(parent); i++)
+        {
+            var child = VisualTreeHelper.GetChild(parent, i);
+
+            if (child is TextBox textBox)
+            {
+                return textBox;
+            }
+
+            if (FindTextBox(child) is TextBox descendantTextBox)
+            {
+                return descendantTextBox;
+            }
+        }
+
+        return null;
     }
 }
 #endif

--- a/src/UraniumUI/Handlers/AutoCompleteViewHandler.cs
+++ b/src/UraniumUI/Handlers/AutoCompleteViewHandler.cs
@@ -18,6 +18,7 @@ public partial class AutoCompleteViewHandler
             [nameof(AutoCompleteView.Text)] = MapText,
             [nameof(AutoCompleteView.ItemsSource)] = MapItemsSource,
             [nameof(AutoCompleteView.Threshold)] = MapThreshold,
+            [nameof(AutoCompleteView.Keyboard)] = MapKeyboard,
         };
     public AutoCompleteViewHandler() : base(AutoCompleteViewMapper)
     {
@@ -45,6 +46,10 @@ public partial class AutoCompleteViewHandler : ViewHandler<AutoCompleteView, obj
     }
 
     public static void MapThreshold(AutoCompleteViewHandler handler, AutoCompleteView view)
+    {
+    }
+
+    public static void MapKeyboard(AutoCompleteViewHandler handler, AutoCompleteView view)
     {
     }
 }

--- a/test/UraniumUI.Material.Tests/Controls/AutoCompleteTextField_Test.cs
+++ b/test/UraniumUI.Material.Tests/Controls/AutoCompleteTextField_Test.cs
@@ -65,10 +65,44 @@ public class AutoCompleteTextField_Test
         clearIcon.Padding.ShouldBe(new Thickness(InputField.BuiltInAttachmentLeftPadding, 0, 0, 0));
     }
 
+    [Fact]
+    public void Keyboard_ShouldBeSet_FromViewModel()
+    {
+        var control = AnimationReadyHandler.Prepare(new AutoCompleteTextField());
+        var viewModel = new AutoCompleteTextFieldTestViewModel { Keyboard = Keyboard.Numeric };
+        control.BindingContext = viewModel;
+
+        // Act
+        control.SetBinding(AutoCompleteTextField.KeyboardProperty, new Binding(nameof(viewModel.Keyboard)));
+
+        // Assert
+        control.Keyboard.ShouldBe(viewModel.Keyboard);
+        control.AutoCompleteView.Keyboard.ShouldBe(viewModel.Keyboard);
+    }
+
+    [Fact]
+    public void Keyboard_ShouldBeUpdated_FromViewModel()
+    {
+        var control = AnimationReadyHandler.Prepare(new AutoCompleteTextField());
+        var viewModel = new AutoCompleteTextFieldTestViewModel { Keyboard = Keyboard.Numeric };
+        control.BindingContext = viewModel;
+        control.SetBinding(AutoCompleteTextField.KeyboardProperty, new Binding(nameof(viewModel.Keyboard)));
+
+        // Act
+        viewModel.Keyboard = Keyboard.Telephone;
+
+        // Assert
+        control.Keyboard.ShouldBe(viewModel.Keyboard);
+        control.AutoCompleteView.Keyboard.ShouldBe(viewModel.Keyboard);
+    }
+
     internal class AutoCompleteTextFieldTestViewModel : UraniumBindableObject
     {
         private string text;
+        private Keyboard keyboard;
 
         public string Text { get => text; set => SetProperty(ref text, value); }
+
+        public Keyboard Keyboard { get => keyboard; set => SetProperty(ref keyboard, value); }
     }
 }


### PR DESCRIPTION
## Summary
- add a `Keyboard` bindable property to `AutoCompleteView` and `AutoCompleteTextField`
- map the keyboard setting to Android, iOS/Mac Catalyst, and Windows native autocomplete inputs
- add focused tests for `AutoCompleteTextField` keyboard binding/forwarding and document the property

## Automated Testing
- `dotnet test test/UraniumUI.Material.Tests/UraniumUI.Material.Tests.csproj --filter FullyQualifiedName~AutoCompleteTextField_Test`
- `dotnet build src/UraniumUI/UraniumUI.csproj -f net10.0-android`
- `dotnet build src/UraniumUI/UraniumUI.csproj -f net10.0-windows10.0.19041.0`
- `dotnet build src/UraniumUI/UraniumUI.csproj -f net10.0-ios`
- `dotnet build src/UraniumUI.Material/UraniumUI.Material.csproj -f net10.0-android`
- `dotnet build src/UraniumUI.Material/UraniumUI.Material.csproj -f net10.0-windows10.0.19041.0`
- `dotnet build src/UraniumUI.Material/UraniumUI.Material.csproj -f net10.0-ios`

## Manual Testing
- Not run in an interactive device/emulator session from this environment.
- Recommended check: run a page with `<material:AutoCompleteTextField Keyboard="Numeric" ItemsSource="..." />` on Android or iOS, focus the field, and verify the numeric soft keyboard is shown while autocomplete suggestions still appear.
- Recommended Windows check: run the same field on a touch-enabled Windows device, focus the field, and verify the touch keyboard uses the numeric input scope.

Closes #829
