### PR TITLE
Fix BottomSheet collapsed alignment after header resize

### DIFF
--- a/src/UraniumUI.Material/Attachments/BottomSheetView.cs
+++ b/src/UraniumUI.Material/Attachments/BottomSheetView.cs
@@ -21,10 +21,16 @@ public partial class BottomSheetView : Border, IPageAttachment
         Init();
 
         AttachedPage = page;
+        Header.SizeChanged += BottomSheetContent_SizeChanged;
         if (Body != null)
         {
-            Body.SizeChanged += (s, e) => AlignBottomSheet(false);
+            Body.SizeChanged += BottomSheetContent_SizeChanged;
         }
+    }
+
+    private void BottomSheetContent_SizeChanged(object sender, EventArgs e)
+    {
+        AlignBottomSheet(false);
     }
 
     protected virtual void Init()

--- a/test/UraniumUI.Material.Tests/Attachments/BottomSheetView_Test.cs
+++ b/test/UraniumUI.Material.Tests/Attachments/BottomSheetView_Test.cs
@@ -1,5 +1,7 @@
-﻿using Shouldly;
+﻿using System.Reflection;
+using Shouldly;
 using UraniumUI.Material.Attachments;
+using UraniumUI.Pages;
 using UraniumUI.Tests.Core;
 
 namespace UraniumUI.Material.Tests.Attachments;
@@ -35,6 +37,45 @@ public class BottomSheetView_Test
 
         // Assert
         control.DisablePageWhenOpened.ShouldBe(viewModel.DisablePageWhenOpened);
+    }
+
+    [Fact]
+    public void HeaderSizeChanged_ShouldRealignCollapsedSheet()
+    {
+        var header = AnimationReadyHandler.Prepare(new Border());
+        var body = AnimationReadyHandler.Prepare(new BoxView());
+        var control = AnimationReadyHandler.Prepare(new BottomSheetView
+        {
+            Header = header,
+            Body = body,
+            CloseOnTapOutside = false,
+            DisablePageWhenOpened = false,
+        });
+
+        control.OnAttached(new UraniumContentPage());
+        SetFrame(control, 100, 300);
+#pragma warning disable CS0618 // Layout is the simplest way to trigger SizeChanged in the headless MAUI test host.
+        header.Layout(new Rect(0, 0, 100, 200));
+#pragma warning restore CS0618
+
+        control.IsPresented = true;
+        control.TranslationY.ShouldBe(0);
+
+        control.IsPresented = false;
+        control.TranslationY.ShouldBe(100);
+
+#pragma warning disable CS0618 // Layout is the simplest way to trigger SizeChanged in the headless MAUI test host.
+        header.Layout(new Rect(0, 0, 100, 60));
+#pragma warning restore CS0618
+
+        control.TranslationY.ShouldBe(240);
+    }
+
+    private static void SetFrame(VisualElement element, double width, double height)
+    {
+        var frameProperty = typeof(VisualElement).GetProperty("Frame", BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic);
+        frameProperty.ShouldNotBeNull();
+        frameProperty.SetValue(element, new Rect(0, 0, width, height));
     }
 
     internal class BottomSheetTestViewModel : UraniumBindableObject


### PR DESCRIPTION
## Summary
- realign BottomSheetView when its header size changes, not only when the body size changes
- add regression coverage for a collapsed sheet whose header shrinks after `IsPresented` changes

## Automated Testing
- `dotnet test test/UraniumUI.Material.Tests/UraniumUI.Material.Tests.csproj --filter FullyQualifiedName~BottomSheetView_Test`
- `dotnet test test/UraniumUI.Material.Tests/UraniumUI.Material.Tests.csproj`

## Manual Testing
- Not run. This change is covered by headless layout regression tests, but the issue video describes visible MAUI UI behavior and should still be smoke-tested in the demo app on a target device/emulator before release.

Closes #795
