### PR TITLE
Fix password show/hide icon theme updates

### DIFF
--- a/src/UraniumUI.Material/Controls/TextFieldPasswordShowHideAttachment.cs
+++ b/src/UraniumUI.Material/Controls/TextFieldPasswordShowHideAttachment.cs
@@ -55,11 +55,17 @@ public class TextFieldPasswordShowHideAttachment : StatefulContentView
 
     private Path GetPathFromData(Geometry data)
     {
-        return new Path
+        var path = new Path
         {
-            Fill = ColorResource.GetColor("OnBackground", "OnBackgroundDark", Colors.DarkGray).WithAlpha(.5f),
             VerticalOptions = LayoutOptions.Center,
             Data = data,
         };
+
+        path.SetAppTheme(
+            Path.FillProperty,
+            new SolidColorBrush(ColorResource.GetColor("OnBackground", Colors.DarkGray).WithAlpha(.5f)),
+            new SolidColorBrush(ColorResource.GetColor("OnBackgroundDark", Colors.DarkGray).WithAlpha(.5f)));
+
+        return path;
     }
 }

--- a/test/UraniumUI.Material.Tests/Controls/TextField_Test.cs
+++ b/test/UraniumUI.Material.Tests/Controls/TextField_Test.cs
@@ -1,11 +1,13 @@
 ﻿using FluentAssertions;
 using NSubstitute;
 using Shouldly;
+using System.Reflection;
 using System.Windows.Input;
 using UraniumUI.Material.Controls;
 using UraniumUI.Tests.Core;
 using UraniumUI.ViewExtensions;
 using UraniumUI.Views;
+using Path = Microsoft.Maui.Controls.Shapes.Path;
 
 namespace UraniumUI.Material.Tests.Controls;
 public class TextField_Test
@@ -309,6 +311,35 @@ public class TextField_Test
     }
 
     [Fact]
+    public void PasswordShowHideAttachment_IconFill_ShouldUseAppThemeBinding()
+    {
+        var originalTheme = Application.Current.UserAppTheme;
+
+        try
+        {
+            Application.Current.UserAppTheme = AppTheme.Light;
+            Application.Current.Resources["OnBackground"] = Colors.Purple;
+            Application.Current.Resources["OnBackgroundDark"] = Colors.White;
+            var attachment = new TextFieldPasswordShowHideAttachment();
+            var control = AnimationReadyHandler.Prepare(new TextField { IsPassword = true });
+
+            control.Attachments.Add(attachment);
+
+            var iconPath = attachment.Content.ShouldBeOfType<Path>();
+            iconPath.Fill.ShouldBeOfType<SolidColorBrush>().Color.ShouldBe(Colors.Purple.WithAlpha(.5f));
+            var fillBinding = GetBinding(iconPath, Path.FillProperty);
+
+            fillBinding.GetType().Name.ShouldBe("AppThemeBinding");
+            GetAppThemeBrush(fillBinding, "Light").Color.ShouldBe(Colors.Purple.WithAlpha(.5f));
+            GetAppThemeBrush(fillBinding, "Dark").Color.ShouldBe(Colors.White.WithAlpha(.5f));
+        }
+        finally
+        {
+            Application.Current.UserAppTheme = originalTheme;
+        }
+    }
+
+    [Fact]
     public void IsSpellCheckEnabled_ShouldBeSet_FromViewModel()
     {
         var control = AnimationReadyHandler.Prepare(new TextField());
@@ -549,5 +580,30 @@ public class TextField_Test
             UpdateClearIconStateCallCount++;
             base.UpdateClearIconState();
         }
+    }
+
+    private static object GetBinding(BindableObject bindableObject, BindableProperty bindableProperty)
+    {
+        var properties = (System.Collections.IDictionary)typeof(BindableObject)
+            .GetField("_properties", BindingFlags.Instance | BindingFlags.NonPublic)
+            .GetValue(bindableObject);
+        var context = properties[bindableProperty];
+
+        context.ShouldNotBeNull();
+        var bindings = context.GetType()
+            .GetField("Bindings", BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic)
+            .GetValue(context);
+
+        return bindings.GetType()
+            .GetMethod("GetValue", BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic, Type.EmptyTypes)
+            .Invoke(bindings, null);
+    }
+
+    private static SolidColorBrush GetAppThemeBrush(object appThemeBinding, string propertyName)
+    {
+        return appThemeBinding.GetType()
+            .GetProperty(propertyName, BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic)
+            .GetValue(appThemeBinding)
+            .ShouldBeOfType<SolidColorBrush>();
     }
 }


### PR DESCRIPTION
## Summary
- update the password show/hide icon to bind its fill through the current app theme
- add focused coverage that the generated password icon uses light and dark theme brushes

## Automated Testing
- `dotnet test test/UraniumUI.Material.Tests/UraniumUI.Material.Tests.csproj --filter FullyQualifiedName~TextField_Test`
- `dotnet test test/UraniumUI.Material.Tests/UraniumUI.Material.Tests.csproj`

## Manual Testing
- Not run locally.
- Environment: any MAUI target that supports runtime app theme changes, such as Windows or Android.
- Steps: open a `TextField` with `TextFieldPasswordShowHideAttachment`, switch the app from light to dark theme, then switch back.
- Expected result: the password show/hide icon tint follows the active theme without recreating the field.

Closes #811
