### PR TITLE
Fix DataGrid selection checkbox sync

### DIFF
--- a/src/UraniumUI.Material/Controls/DataGrid.BindableProperties.cs
+++ b/src/UraniumUI.Material/Controls/DataGrid.BindableProperties.cs
@@ -43,7 +43,7 @@ public partial class DataGrid
 
     public static readonly BindableProperty SelectedItemsProperty =
         BindableProperty.Create(nameof(SelectedItems), typeof(IList), typeof(DataGrid), defaultValue: new ObservableCollection<object>(),
-            defaultBindingMode: BindingMode.TwoWay, propertyChanged: (bo, ov, nv) => (bo as DataGrid).OnSelectedItemsSet());
+            defaultBindingMode: BindingMode.TwoWay, propertyChanged: (bo, ov, nv) => (bo as DataGrid).OnSelectedItemsChanged(ov as IList, nv as IList));
 
     public Color SelectionColor { get => (Color)GetValue(SelectionColorProperty); set => SetValue(SelectionColorProperty, value); }
 

--- a/src/UraniumUI.Material/Controls/DataGrid.cs
+++ b/src/UraniumUI.Material/Controls/DataGrid.cs
@@ -12,6 +12,8 @@ namespace UraniumUI.Material.Controls;
 public partial class DataGrid : Border
 {
     private Grid _rootGrid;
+    private readonly HashSet<View> _selectionCells = [];
+    private bool _syncingSelectionCells;
 
     public Type CurrentType { get; protected set; }
 
@@ -179,10 +181,12 @@ public partial class DataGrid : Border
         }
 
         RegisterSelectionChanges();
+        UpdateSelections();
     }
 
     private void ResetGrid()
     {
+        _selectionCells.Clear();
         _rootGrid.Clear();
         _rootGrid.Children.Clear();
 
@@ -276,6 +280,10 @@ public partial class DataGrid : Border
             cell.SetBinding(ContentView.IsVisibleProperty, new Binding(nameof(DataGridColumn.IsVisible), source: column));
 
             SetSelectionVisualStates(cell);
+            if (column is IDataGridSelectionColumn)
+            {
+                _selectionCells.Add(cell);
+            }
 
             _rootGrid.RowDefinitions.Add(new RowDefinition(GridLength.Auto));
             _rootGrid.Add(cell, columnNumber, row: actualRow);
@@ -366,29 +374,94 @@ public partial class DataGrid : Border
         }
     }
 
+    private void OnSelectedItemsChanged(IList oldValue, IList newValue)
+    {
+        if (oldValue is INotifyCollectionChanged oldObservable)
+        {
+            oldObservable.CollectionChanged -= SelectedItems_CollectionChanged;
+        }
+
+        if (newValue is INotifyCollectionChanged observable)
+        {
+            observable.CollectionChanged -= SelectedItems_CollectionChanged;
+            observable.CollectionChanged += SelectedItems_CollectionChanged;
+        }
+
+        OnSelectedItemsSet();
+    }
+
     protected virtual void OnSelectedItemsSet()
     {
         UpdateSelections();
+    }
 
-        if (SelectedItems is INotifyCollectionChanged observable)
-        {
-            observable.CollectionChanged += (s, e) => UpdateSelections();
-        }
+    private void SelectedItems_CollectionChanged(object sender, NotifyCollectionChangedEventArgs e)
+    {
+        UpdateSelections();
     }
 
     protected void UpdateSelections()
     {
-        foreach (View child in _rootGrid.Children)
+        if (_rootGrid is null)
         {
-            if (SelectedItems.Contains(child.BindingContext))
+            return;
+        }
+
+        _syncingSelectionCells = true;
+
+        try
+        {
+            foreach (View child in _rootGrid.Children)
             {
-                VisualStateManager.GoToState(child, DataGridCellVisualStates.Selected);
-            }
-            else
-            {
-                VisualStateManager.GoToState(child, DataGridCellVisualStates.Unselected);
+                var isSelected = SelectedItems?.Contains(child.BindingContext) == true;
+                VisualStateManager.GoToState(child, isSelected ? DataGridCellVisualStates.Selected : DataGridCellVisualStates.Unselected);
+
+                if (_selectionCells.Contains(child))
+                {
+                    UpdateSelectionCellCheckBox(child, isSelected);
+                }
             }
         }
+        finally
+        {
+            _syncingSelectionCells = false;
+        }
+    }
+
+    private static void UpdateSelectionCellCheckBox(Element element, bool isSelected)
+    {
+        var checkBox = FindSelectionCheckBox(element);
+        if (checkBox is not null && checkBox.IsChecked != isSelected)
+        {
+            checkBox.IsChecked = isSelected;
+        }
+    }
+
+    private static CheckBox FindSelectionCheckBox(Element element)
+    {
+        if (element is CheckBox checkBox)
+        {
+            return checkBox;
+        }
+
+        if (element is ContentView { Content: Element content })
+        {
+            return FindSelectionCheckBox(content);
+        }
+
+        if (element is Layout layout)
+        {
+            foreach (var child in layout.Children.OfType<Element>())
+            {
+                var checkBoxChild = FindSelectionCheckBox(child);
+                if (checkBoxChild is not null)
+                {
+                    return checkBoxChild;
+                }
+            }
+        }
+
+        return null;
     }
 
     protected virtual void RenderEmptyView()
@@ -435,12 +508,18 @@ public partial class DataGrid : Border
     {
         foreach (IDataGridSelectionColumn selection in Columns.Where(x => x is IDataGridSelectionColumn))
         {
+            selection.SelectionChanged -= SelectionChanged;
             selection.SelectionChanged += SelectionChanged;
         }
     }
 
     private void SelectionChanged(object sender, bool isSelected)
     {
+        if (_syncingSelectionCells)
+        {
+            return;
+        }
+
         if (SelectedItems is null)
         {
             SelectedItems = new ObservableCollection<object>();
@@ -461,6 +540,7 @@ public partial class DataGrid : Border
             }
 
             OnPropertyChanged(nameof(SelectedItems));
+            UpdateSelections();
         }
     }
 

--- a/test/UraniumUI.Material.Tests/Controls/DataGrid_Test.cs
+++ b/test/UraniumUI.Material.Tests/Controls/DataGrid_Test.cs
@@ -1,10 +1,12 @@
 ﻿using System.Collections.Generic;
+using System.Collections.ObjectModel;
 using System.ComponentModel;
 using System.Linq;
 using Microsoft.Maui.Controls.Xaml;
 using Shouldly;
 using UraniumUI.Material.Controls;
 using UraniumUI.Tests.Core;
+using MaterialCheckBox = UraniumUI.Material.Controls.CheckBox;
 
 namespace UraniumUI.Material.Tests.Controls;
 public class DataGrid_Test
@@ -202,6 +204,72 @@ public class DataGrid_Test
 
         control.Columns.Select(column => column.Title).ShouldBe(["Identity", "Name"]);
         control.Columns.Select(column => ((Binding)column.ValueBinding).Path).ShouldBe([nameof(AutoColumnRow.Id), nameof(AutoColumnRow.Name)]);
+    }
+
+    [Fact]
+    public void SelectionColumn_CheckBox_ShouldBeChecked_WhenSelectedItemsInitializedBeforeItemsSource()
+    {
+        var rows = new List<DataGridRow>
+        {
+            new() { Id = 1, Name = "One" },
+            new() { Id = 2, Name = "Two" },
+        };
+
+        var control = AnimationReadyHandler.Prepare(new DataGrid
+        {
+            Columns =
+            [
+                new DataGridSelectionColumn(),
+                new DataGridColumn { Title = "Id", ValueBinding = new Binding(nameof(DataGridRow.Id)) },
+            ],
+            SelectedItems = new ObservableCollection<object> { rows[1] },
+            ItemsSource = rows,
+        });
+
+        var checkBox = GetSelectionCheckBox(control, rows[1]);
+
+        checkBox.IsChecked.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void SelectionColumn_CheckBox_ShouldUpdate_WhenSelectedItemsCollectionChanges()
+    {
+        var rows = new List<DataGridRow>
+        {
+            new() { Id = 1, Name = "One" },
+            new() { Id = 2, Name = "Two" },
+        };
+        var selectedItems = new ObservableCollection<object>();
+
+        var control = AnimationReadyHandler.Prepare(new DataGrid
+        {
+            Columns =
+            [
+                new DataGridSelectionColumn(),
+                new DataGridColumn { Title = "Id", ValueBinding = new Binding(nameof(DataGridRow.Id)) },
+            ],
+            ItemsSource = rows,
+            SelectedItems = selectedItems,
+        });
+
+        var checkBox = GetSelectionCheckBox(control, rows[0]);
+        checkBox.IsChecked.ShouldBeFalse();
+
+        selectedItems.Add(rows[0]);
+        checkBox.IsChecked.ShouldBeTrue();
+
+        selectedItems.Remove(rows[0]);
+        checkBox.IsChecked.ShouldBeFalse();
+    }
+
+    private static MaterialCheckBox GetSelectionCheckBox(DataGrid control, DataGridRow row)
+    {
+        var rootGrid = control.Content.ShouldBeOfType<Grid>();
+        var selectionCell = rootGrid.Children.OfType<ContentView>()
+            .Single(child => Grid.GetColumn(child) == 0 && child.BindingContext == row);
+
+        return selectionCell.Content.ShouldBeOfType<ContentView>()
+            .Content.ShouldBeOfType<MaterialCheckBox>();
     }
 
     private sealed class DataGridRow


### PR DESCRIPTION
## Summary
- sync DataGrid selection-column checkboxes from `SelectedItems` during initial render
- update selection-column checkboxes when the bound `SelectedItems` collection changes
- keep row visual states and checkbox state aligned without recursively mutating `SelectedItems`
- add regression coverage for initialization and collection-change scenarios

## Automated Testing
- `dotnet test test/UraniumUI.Material.Tests/UraniumUI.Material.Tests.csproj --filter FullyQualifiedName~SelectionColumn_CheckBox`
- `dotnet test test/UraniumUI.Material.Tests/UraniumUI.Material.Tests.csproj --filter FullyQualifiedName~DataGrid_Test`
- `dotnet test test/UraniumUI.Material.Tests/UraniumUI.Material.Tests.csproj`

Closes #191
