### PR TITLE
Improve Android blur performance strategy

### DIFF
--- a/demo/UraniumApp/Pages/BlurIndexPage.xaml
+++ b/demo/UraniumApp/Pages/BlurIndexPage.xaml
@@ -15,10 +15,10 @@
             <Button Text="BlurView Properties" Clicked="GoToPreviewPage" />
 
             <Grid>
-                <Image HeightRequest="300" Source="https://images.unsplash.com/photo-1464820453369-31d2c0b651af?q=80&amp;w=2080&amp;auto=format&amp;fit=crop&amp;ixlib=rb-4.0.3&amp;ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D" Aspect="AspectFill" />
-                <StackLayout HorizontalOptions="Center" VerticalOptions="Center" WidthRequest="200">
+                <Image x:Name="BackgroundImage" HeightRequest="300" Source="https://images.unsplash.com/photo-1464820453369-31d2c0b651af?q=80&amp;w=2080&amp;auto=format&amp;fit=crop&amp;ixlib=rb-4.0.3&amp;ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D" Aspect="AspectFill" />
+                <StackLayout x:Name="BlurHost" HorizontalOptions="Center" VerticalOptions="Center" WidthRequest="200">
                     <StackLayout.Effects>
-                        <uranium:BlurEffect />
+                        <uranium:BlurEffect AndroidStrategy="StaticCapture" />
                     </StackLayout.Effects>
                     <Label Text="Hello, World!" Margin="32" HorizontalOptions="Center" VerticalOptions="Center" />
                 </StackLayout>

--- a/demo/UraniumApp/Pages/BlurIndexPage.xaml.cs
+++ b/demo/UraniumApp/Pages/BlurIndexPage.xaml.cs
@@ -1,4 +1,6 @@
+using System.ComponentModel;
 using UraniumApp.Pages.Blurs;
+using UraniumUI.Blurs;
 
 namespace UraniumApp.Pages;
 
@@ -7,7 +9,40 @@ public partial class BlurIndexPage : ContentPage
 	public BlurIndexPage()
 	{
 		InitializeComponent();
+
+        BackgroundImage.Loaded += BackgroundImage_Loaded;
+        BackgroundImage.PropertyChanged += BackgroundImage_PropertyChanged;
 	}
+
+    private void BackgroundImage_Loaded(object sender, EventArgs e)
+    {
+        if (!BackgroundImage.IsLoading)
+        {
+            InvalidateBlurAfterImageLoadingFinished();
+        }
+    }
+
+    private void BackgroundImage_PropertyChanged(object sender, PropertyChangedEventArgs e)
+    {
+        if (e.PropertyName == nameof(Image.IsLoading) && !BackgroundImage.IsLoading)
+        {
+            InvalidateBlurAfterImageLoadingFinished();
+        }
+    }
+
+    private void InvalidateBlurAfterImageLoadingFinished()
+    {
+        Dispatcher.Dispatch(InvalidateBlur);
+        Dispatcher.DispatchDelayed(TimeSpan.FromMilliseconds(100), InvalidateBlur);
+    }
+
+    private void InvalidateBlur()
+    {
+        foreach (var blurEffect in BlurHost.Effects.OfType<BlurEffect>())
+        {
+            blurEffect.InvalidateAndroidBlur();
+        }
+    }
 
     private void GoToPreviewPage(object sender, EventArgs e)
     {

--- a/demo/UraniumApp/Pages/Blurs/BlursPreviewPage.xaml
+++ b/demo/UraniumApp/Pages/Blurs/BlursPreviewPage.xaml
@@ -32,7 +32,11 @@
 
         <StackLayout HorizontalOptions="Center" VerticalOptions="Center">
             <StackLayout.Effects>
-                <uranium:BlurEffect Mode="{root:XBind BlurMode}" AccentColor="{root:XBind AccentColor}" AccentOpacity="{root:XBind AccentOpacity}" />
+                <uranium:BlurEffect
+                    Mode="{root:XBind BlurMode}"
+                    AccentColor="{root:XBind AccentColor}"
+                    AccentOpacity="{root:XBind AccentOpacity}"
+                    AndroidStrategy="RealtimeCapture" />
             </StackLayout.Effects>
 
             <!-- TODO: Use Property Editor-->

--- a/docs/en/Blurs.md
+++ b/docs/en/Blurs.md
@@ -2,7 +2,7 @@
 UraniumUI supports blur effects on MAUI. You can use it on any control by using `BlurEffect`.
 
 Apple has its own blur effect and Windows has a Brush for it. So it's implemented natively for those platforms.
-Android blur is best-effort because Android doesn't provide the same arbitrary backdrop blur primitive as iOS `UIVisualEffectView` or WinUI `AcrylicBrush`. By default, Android uses a lightweight native/material strategy and keeps the capture-based [Dimezis/BlurView](https://github.com/Dimezis/BlurView) pipeline as an explicit opt-in for realtime backdrop blur.
+Android blur is best-effort because Android doesn't provide the same arbitrary backdrop blur primitive as iOS `UIVisualEffectView` or WinUI `AcrylicBrush`. By default, Android uses a lightweight material-style tinted strategy and keeps the capture-based [Dimezis/BlurView](https://github.com/Dimezis/BlurView) pipeline as an explicit opt-in for backdrop blur.
 
 
 
@@ -112,7 +112,8 @@ BlurEffect is a `Effect` which means you can use it on any control.
     | `Default` | Uses the material-style tinted surface. This avoids blurring the effect host content and avoids backdrop capture. |
     | `RenderEffect` | Uses Android's native `RenderEffect` for the effect host layer on Android 12/API 31+. This blurs the host view's own rendered layer, including its content and children, not the backdrop behind it. Falls back to `Material` below API 31. |
     | `Material` | Uses only the configured tint color and opacity. This is the cheapest option and does not capture the backdrop. |
-    | `RealtimeCapture` | Uses the previous capture-based backdrop blur pipeline. This can be expensive because it redraws the backdrop into a bitmap and blurs it repeatedly. |
+    | `RealtimeCapture` | Uses capture-based backdrop blur. It is throttled by `AndroidRealtimeCaptureFps`, but it still redraws the backdrop into a bitmap repeatedly. |
+    | `StaticCapture` | Captures and blurs once, then refreshes only after size/root changes or `InvalidateAndroidBlur()`. This is useful for static backdrops. |
 
     ```xml
     <StackLayout>
@@ -123,6 +124,10 @@ BlurEffect is a `Effect` which means you can use it on any control.
     </StackLayout>
     ```
 
+- AndroidRealtimeCaptureFps: `int` (Default: `15`) - Defines the maximum capture update rate for `RealtimeCapture`. Values are clamped between `1` and `60`.
+
+- AndroidCaptureDownsampleFactor: `float` (Default: `8`) - Defines how much the Android capture bitmap is downsampled before blur. Larger values improve performance but reduce blur quality. Values are clamped between `1` and `32`.
+
 ## Android limitations
 
 Android `RenderEffect` blurs the layer owned by the effect host. It is lightweight, but it is not equivalent to arbitrary backdrop blur behind the control. If it is applied to a container, the container content is blurred too.
@@ -130,3 +135,9 @@ Android `RenderEffect` blurs the layer owned by the effect host. It is lightweig
 Do not use `RenderEffect` as a dialog, `ContentPage`, or `TabbedPage` backdrop blur replacement. It targets the native Android view generated for the MAUI element, so it cannot blur the page behind that view the same way iOS `UIVisualEffectView` does.
 
 Use `AndroidStrategy="RealtimeCapture"` only when you explicitly need backdrop blur behind an in-page surface. Prefer small, mostly static surfaces for this strategy because scrolling, repeated dialog open/close, and navigation loops can allocate and redraw bitmaps frequently.
+
+Use `AndroidStrategy="StaticCapture"` when the backdrop behind the blur surface does not move. You can request a refresh from code when the backdrop changes:
+
+```csharp
+blurEffect.InvalidateAndroidBlur();
+```

--- a/docs/en/Blurs.md
+++ b/docs/en/Blurs.md
@@ -109,8 +109,8 @@ BlurEffect is a `Effect` which means you can use it on any control.
 
     | Value | Behavior |
     | --- | --- |
-    | `Default` | Uses `RenderEffect` on Android 12/API 31+ and a material-style tinted surface on older Android versions. |
-    | `RenderEffect` | Uses Android's native `RenderEffect` for the effect host layer on Android 12/API 31+. Falls back to `Material` below API 31. |
+    | `Default` | Uses the material-style tinted surface. This avoids blurring the effect host content and avoids backdrop capture. |
+    | `RenderEffect` | Uses Android's native `RenderEffect` for the effect host layer on Android 12/API 31+. This blurs the host view's own rendered layer, including its content and children, not the backdrop behind it. Falls back to `Material` below API 31. |
     | `Material` | Uses only the configured tint color and opacity. This is the cheapest option and does not capture the backdrop. |
     | `RealtimeCapture` | Uses the previous capture-based backdrop blur pipeline. This can be expensive because it redraws the backdrop into a bitmap and blurs it repeatedly. |
 
@@ -125,6 +125,8 @@ BlurEffect is a `Effect` which means you can use it on any control.
 
 ## Android limitations
 
-Android `RenderEffect` blurs the layer owned by the effect host. It is lightweight, but it is not equivalent to arbitrary backdrop blur behind the control.
+Android `RenderEffect` blurs the layer owned by the effect host. It is lightweight, but it is not equivalent to arbitrary backdrop blur behind the control. If it is applied to a container, the container content is blurred too.
+
+Do not use `RenderEffect` as a dialog, `ContentPage`, or `TabbedPage` backdrop blur replacement. It targets the native Android view generated for the MAUI element, so it cannot blur the page behind that view the same way iOS `UIVisualEffectView` does.
 
 Use `AndroidStrategy="RealtimeCapture"` only when you explicitly need backdrop blur behind an in-page surface. Prefer small, mostly static surfaces for this strategy because scrolling, repeated dialog open/close, and navigation loops can allocate and redraw bitmaps frequently.

--- a/docs/en/Blurs.md
+++ b/docs/en/Blurs.md
@@ -2,7 +2,7 @@
 UraniumUI supports blur effects on MAUI. You can use it on any control by using `BlurEffect`.
 
 Apple has its own blur effect and Windows has a Brush for it. So it's implemented natively for those platforms.
-Android platform doesn't support blur effects by default. So it's implemented in [Dimezis/BlurView](https://github.com/Dimezis/BlurView) and ported to C#.
+Android blur is best-effort because Android doesn't provide the same arbitrary backdrop blur primitive as iOS `UIVisualEffectView` or WinUI `AcrylicBrush`. By default, Android uses a lightweight native/material strategy and keeps the capture-based [Dimezis/BlurView](https://github.com/Dimezis/BlurView) pipeline as an explicit opt-in for realtime backdrop blur.
 
 
 
@@ -104,3 +104,27 @@ BlurEffect is a `Effect` which means you can use it on any control.
     ```
     
     ![MAUI Blur Effect Accent Opacity](images/blurs-example-accent-dark-opacity.png)
+
+- AndroidStrategy: `AndroidBlurStrategy` (Default: `Default`) - Defines which Android blur strategy is used.
+
+    | Value | Behavior |
+    | --- | --- |
+    | `Default` | Uses `RenderEffect` on Android 12/API 31+ and a material-style tinted surface on older Android versions. |
+    | `RenderEffect` | Uses Android's native `RenderEffect` for the effect host layer on Android 12/API 31+. Falls back to `Material` below API 31. |
+    | `Material` | Uses only the configured tint color and opacity. This is the cheapest option and does not capture the backdrop. |
+    | `RealtimeCapture` | Uses the previous capture-based backdrop blur pipeline. This can be expensive because it redraws the backdrop into a bitmap and blurs it repeatedly. |
+
+    ```xml
+    <StackLayout>
+        <StackLayout.Effects>
+            <uranium:BlurEffect AndroidStrategy="RealtimeCapture" />
+        </StackLayout.Effects>
+        <!-- Your content goes here -->
+    </StackLayout>
+    ```
+
+## Android limitations
+
+Android `RenderEffect` blurs the layer owned by the effect host. It is lightweight, but it is not equivalent to arbitrary backdrop blur behind the control.
+
+Use `AndroidStrategy="RealtimeCapture"` only when you explicitly need backdrop blur behind an in-page surface. Prefer small, mostly static surfaces for this strategy because scrolling, repeated dialog open/close, and navigation loops can allocate and redraw bitmaps frequently.

--- a/src/UraniumUI.Blurs/BlurEffect.cs
+++ b/src/UraniumUI.Blurs/BlurEffect.cs
@@ -7,6 +7,8 @@ public class BlurEffect : RoutingEffect
     private Color accentColor;
     private float accentOpacity = .2f;
     private AndroidBlurStrategy androidStrategy;
+    private int androidRealtimeCaptureFps = 15;
+    private float androidCaptureDownsampleFactor = 8f;
 
     public BlurMode Mode { get => mode; set { mode = value; UpdateEffectCommand?.Execute(this); } }
 
@@ -16,9 +18,24 @@ public class BlurEffect : RoutingEffect
 
     public AndroidBlurStrategy AndroidStrategy { get => androidStrategy; set { androidStrategy = value; UpdateEffectCommand?.Execute(this); } }
 
+    public int AndroidRealtimeCaptureFps { get => androidRealtimeCaptureFps; set { androidRealtimeCaptureFps = value; UpdateEffectCommand?.Execute(this); } }
+
+    public float AndroidCaptureDownsampleFactor { get => androidCaptureDownsampleFactor; set { androidCaptureDownsampleFactor = value; UpdateEffectCommand?.Execute(this); } }
+
     internal float EffectiveAccentOpacity => Math.Clamp(AccentOpacity, 0f, 1f);
 
+    internal int EffectiveAndroidRealtimeCaptureFps => Math.Clamp(AndroidRealtimeCaptureFps, 1, 60);
+
+    internal float EffectiveAndroidCaptureDownsampleFactor => Math.Clamp(AndroidCaptureDownsampleFactor, 1f, 32f);
+
     internal ICommand UpdateEffectCommand { get; set; }
+
+    internal ICommand InvalidateEffectCommand { get; set; }
+
+    public void InvalidateAndroidBlur()
+    {
+        InvalidateEffectCommand?.Execute(this);
+    }
 
     public BlurEffect()
     {
@@ -38,4 +55,5 @@ public enum AndroidBlurStrategy
     Material,
     RenderEffect,
     RealtimeCapture,
+    StaticCapture,
 }

--- a/src/UraniumUI.Blurs/BlurEffect.cs
+++ b/src/UraniumUI.Blurs/BlurEffect.cs
@@ -6,12 +6,15 @@ public class BlurEffect : RoutingEffect
     private BlurMode mode;
     private Color accentColor;
     private float accentOpacity = .2f;
+    private AndroidBlurStrategy androidStrategy;
 
     public BlurMode Mode { get => mode; set { mode = value; UpdateEffectCommand?.Execute(this); } }
 
     public Color AccentColor { get => accentColor; set { accentColor = value; UpdateEffectCommand?.Execute(this); } }
 
     public float AccentOpacity { get => accentOpacity; set { accentOpacity = value; UpdateEffectCommand?.Execute(this); } }
+
+    public AndroidBlurStrategy AndroidStrategy { get => androidStrategy; set { androidStrategy = value; UpdateEffectCommand?.Execute(this); } }
 
     internal float EffectiveAccentOpacity => Math.Clamp(AccentOpacity, 0f, 1f);
 
@@ -27,4 +30,12 @@ public enum BlurMode
 {
     Light,
     Dark,
+}
+
+public enum AndroidBlurStrategy
+{
+    Default,
+    Material,
+    RenderEffect,
+    RealtimeCapture,
 }

--- a/src/UraniumUI.Blurs/BlurPlatformEffect.Android.cs
+++ b/src/UraniumUI.Blurs/BlurPlatformEffect.Android.cs
@@ -19,7 +19,11 @@ public class BlurPlatformEffect : PlatformEffect
     private Drawable _originalBackground;
     private ViewGroup _blurRoot;
     private Command _updateEffectCommand;
+    private Command _invalidateEffectCommand;
     private bool _nativeRenderEffectApplied;
+    private AndroidBlurCaptureMode _blurCaptureMode;
+    private int _blurCaptureFps;
+    private float _blurCaptureDownsampleFactor;
 
     public BlurEffect VirtualEffect { get; private set; }
 
@@ -29,7 +33,9 @@ public class BlurPlatformEffect : PlatformEffect
         {
             VirtualEffect = blurEffect;
             _updateEffectCommand = new Command(UpdateEffect);
+            _invalidateEffectCommand = new Command(InvalidateBlur);
             blurEffect.UpdateEffectCommand = _updateEffectCommand;
+            blurEffect.InvalidateEffectCommand = _invalidateEffectCommand;
         }
 
         if (Element is Microsoft.Maui.Controls.View view)
@@ -56,6 +62,11 @@ public class BlurPlatformEffect : PlatformEffect
             VirtualEffect.UpdateEffectCommand = null;
         }
 
+        if (VirtualEffect?.InvalidateEffectCommand == _invalidateEffectCommand)
+        {
+            VirtualEffect.InvalidateEffectCommand = null;
+        }
+
         ReleaseBlurView();
 
         if (_mainDrawable != null)
@@ -67,12 +78,18 @@ public class BlurPlatformEffect : PlatformEffect
         }
 
         _updateEffectCommand = null;
+        _invalidateEffectCommand = null;
         VirtualEffect = null;
     }
 
     private void BlurPlatformEffect_SizeChanged(object sender, EventArgs e)
     {
         AlignBlurView();
+
+        if (_blurView != null)
+        {
+            UpdateEffect();
+        }
     }
 
     private void View_ParentChanged(object sender, EventArgs e)
@@ -94,7 +111,10 @@ public class BlurPlatformEffect : PlatformEffect
         switch (ResolveAndroidStrategy())
         {
             case AndroidBlurStrategy.RealtimeCapture:
-                ApplyRealtimeCaptureStrategy();
+                ApplyCaptureStrategy(AndroidBlurCaptureMode.Realtime);
+                break;
+            case AndroidBlurStrategy.StaticCapture:
+                ApplyCaptureStrategy(AndroidBlurCaptureMode.Static);
                 break;
             case AndroidBlurStrategy.RenderEffect:
                 ApplyRenderEffectStrategy();
@@ -130,7 +150,7 @@ public class BlurPlatformEffect : PlatformEffect
         _nativeRenderEffectApplied = true;
     }
 
-    private void ApplyRealtimeCaptureStrategy()
+    private void ApplyCaptureStrategy(AndroidBlurCaptureMode captureMode)
     {
         ClearNativeRenderEffect();
 
@@ -147,6 +167,13 @@ public class BlurPlatformEffect : PlatformEffect
             _blurView = new BlurView(Context);
             _blurView.SetOverlayColor(Color.Transparent);
         }
+
+        var captureFps = VirtualEffect?.EffectiveAndroidRealtimeCaptureFps ?? BlurViewDefaults.REALTIME_CAPTURE_FPS;
+        var downsampleFactor = VirtualEffect?.EffectiveAndroidCaptureDownsampleFactor ?? BlurViewDefaults.CAPTURE_SCALE_FACTOR;
+
+        _blurView.CaptureMode = captureMode;
+        _blurView.RealtimeCaptureFps = captureFps;
+        _blurView.CaptureDownsampleFactor = downsampleFactor;
 
         if (_blurView.Parent != viewGroup)
         {
@@ -166,7 +193,7 @@ public class BlurPlatformEffect : PlatformEffect
         _blurView.SetBackgroundColor(GetColor());
 
         var decorView = Microsoft.Maui.ApplicationModel.Platform.CurrentActivity?.Window?.DecorView;
-        var root = decorView?.FindViewById(global::Android.Resource.Id.Content) as ViewGroup;
+        var root = GetCaptureRoot(viewGroup, decorView);
         if (root == null)
         {
             _blurView.Release();
@@ -174,14 +201,47 @@ public class BlurPlatformEffect : PlatformEffect
             return;
         }
 
-        if (_blurRoot != root)
+        if (_blurRoot != root || CaptureOptionsChanged(captureMode, captureFps, downsampleFactor))
         {
             _blurRoot = root;
+            _blurCaptureMode = captureMode;
+            _blurCaptureFps = captureFps;
+            _blurCaptureDownsampleFactor = downsampleFactor;
             _blurView
                .SetupWith(root)
-               .SetFrameClearDrawable(decorView.Background)
+               .SetFrameClearDrawable(root.Background ?? decorView?.Background)
                .SetBlurRadius(DefaultBlurRadius);
         }
+    }
+
+    private bool CaptureOptionsChanged(AndroidBlurCaptureMode captureMode, int captureFps, float downsampleFactor)
+    {
+        return _blurCaptureMode != captureMode
+            || _blurCaptureFps != captureFps
+            || Math.Abs(_blurCaptureDownsampleFactor - downsampleFactor) > 0.001f;
+    }
+
+    private ViewGroup GetCaptureRoot(ViewGroup viewGroup, Android.Views.View decorView)
+    {
+        return GetClosestCaptureRoot(viewGroup)
+            ?? decorView?.FindViewById(global::Android.Resource.Id.Content) as ViewGroup;
+    }
+
+    private ViewGroup GetClosestCaptureRoot(ViewGroup viewGroup)
+    {
+        var parent = viewGroup.Parent as ViewGroup;
+
+        while (parent != null)
+        {
+            if (parent.Width > 0 && parent.Height > 0)
+            {
+                return parent;
+            }
+
+            parent = parent.Parent as ViewGroup;
+        }
+
+        return null;
     }
 
     private AndroidBlurStrategy ResolveAndroidStrategy()
@@ -218,6 +278,11 @@ public class BlurPlatformEffect : PlatformEffect
 
         Control.SetRenderEffect(null);
         _nativeRenderEffectApplied = false;
+    }
+
+    private void InvalidateBlur()
+    {
+        _blurView?.InvalidateBlur();
     }
 
     protected Android.Graphics.Color GetColor()

--- a/src/UraniumUI.Blurs/BlurPlatformEffect.Android.cs
+++ b/src/UraniumUI.Blurs/BlurPlatformEffect.Android.cs
@@ -192,9 +192,7 @@ public class BlurPlatformEffect : PlatformEffect
             return strategy;
         }
 
-        return OperatingSystem.IsAndroidVersionAtLeast(31)
-            ? AndroidBlurStrategy.RenderEffect
-            : AndroidBlurStrategy.Material;
+        return AndroidBlurStrategy.Material;
     }
 
     private void EnsureBackgroundDrawable()

--- a/src/UraniumUI.Blurs/BlurPlatformEffect.Android.cs
+++ b/src/UraniumUI.Blurs/BlurPlatformEffect.Android.cs
@@ -10,6 +10,8 @@ using Color = Android.Graphics.Color;
 namespace UraniumUI.Blurs;
 public class BlurPlatformEffect : PlatformEffect
 {
+    private const float DefaultBlurRadius = 24f;
+
     public Context Context => Control?.Context;
 
     private BlurView _blurView;
@@ -17,6 +19,7 @@ public class BlurPlatformEffect : PlatformEffect
     private Drawable _originalBackground;
     private ViewGroup _blurRoot;
     private Command _updateEffectCommand;
+    private bool _nativeRenderEffectApplied;
 
     public BlurEffect VirtualEffect { get; private set; }
 
@@ -40,6 +43,8 @@ public class BlurPlatformEffect : PlatformEffect
 
     protected override void OnDetached()
     {
+        ClearNativeRenderEffect();
+
         if (Element is Microsoft.Maui.Controls.View view)
         {
             view.SizeChanged -= BlurPlatformEffect_SizeChanged;
@@ -77,61 +82,144 @@ public class BlurPlatformEffect : PlatformEffect
 
     protected void UpdateEffect()
     {
-        if (Control is ViewGroup viewGroup && Context != null)
+        if (Control == null || Context == null)
         {
-            if (_mainDrawable == null)
-            {
-                _originalBackground = Control.Background;
-                _mainDrawable = new GradientDrawable();
-                _mainDrawable.SetColor(Colors.Transparent.ToPlatform());
-                Control.Background = _mainDrawable;
-            }
-
-            if (_blurView == null)
-            {
-                _blurView = new BlurView(Context);
-                _blurView.SetOverlayColor(Color.Transparent);
-            }
-
-            if (_blurView.Parent != viewGroup)
-            {
-                if (_blurView.Parent is ViewGroup previousParent)
-                {
-                    previousParent.RemoveView(_blurView);
-                }
-
-                viewGroup.AddView(_blurView, 0, new FrameLayout.LayoutParams(
-                    ViewGroup.LayoutParams.MatchParent,
-                    ViewGroup.LayoutParams.MatchParent,
-                    GravityFlags.NoGravity));
-            }
-
-            AlignBlurView();
-
-            _blurView.SetBackgroundColor(GetColor());
-
-            var decorView = Microsoft.Maui.ApplicationModel.Platform.CurrentActivity?.Window?.DecorView;
-            var root = decorView?.FindViewById(global::Android.Resource.Id.Content) as ViewGroup;
-            if (root == null)
-            {
-                _blurView.Release();
-                _blurRoot = null;
-                return;
-            }
-
-            if (_blurRoot != root)
-            {
-                _blurRoot = root;
-                _blurView
-                   .SetupWith(root)
-                   .SetFrameClearDrawable(decorView.Background)
-                   .SetBlurRadius(24f);
-            }
-        }
-        else
-        {
+            ClearNativeRenderEffect();
             ReleaseBlurView();
+            return;
         }
+
+        EnsureBackgroundDrawable();
+
+        switch (ResolveAndroidStrategy())
+        {
+            case AndroidBlurStrategy.RealtimeCapture:
+                ApplyRealtimeCaptureStrategy();
+                break;
+            case AndroidBlurStrategy.RenderEffect:
+                ApplyRenderEffectStrategy();
+                break;
+            default:
+                ApplyMaterialStrategy();
+                break;
+        }
+    }
+
+    private void ApplyMaterialStrategy()
+    {
+        ClearNativeRenderEffect();
+        ReleaseBlurView();
+        _mainDrawable.SetColor(GetColor());
+    }
+
+    private void ApplyRenderEffectStrategy()
+    {
+        if (!OperatingSystem.IsAndroidVersionAtLeast(31))
+        {
+            ApplyMaterialStrategy();
+            return;
+        }
+
+        ReleaseBlurView();
+        _mainDrawable.SetColor(GetColor());
+
+        Control.SetRenderEffect(Android.Graphics.RenderEffect.CreateBlurEffect(
+            DefaultBlurRadius,
+            DefaultBlurRadius,
+            Android.Graphics.Shader.TileMode.Clamp));
+        _nativeRenderEffectApplied = true;
+    }
+
+    private void ApplyRealtimeCaptureStrategy()
+    {
+        ClearNativeRenderEffect();
+
+        if (Control is not ViewGroup viewGroup)
+        {
+            ApplyMaterialStrategy();
+            return;
+        }
+
+        _mainDrawable.SetColor(Colors.Transparent.ToPlatform());
+
+        if (_blurView == null)
+        {
+            _blurView = new BlurView(Context);
+            _blurView.SetOverlayColor(Color.Transparent);
+        }
+
+        if (_blurView.Parent != viewGroup)
+        {
+            if (_blurView.Parent is ViewGroup previousParent)
+            {
+                previousParent.RemoveView(_blurView);
+            }
+
+            viewGroup.AddView(_blurView, 0, new FrameLayout.LayoutParams(
+                ViewGroup.LayoutParams.MatchParent,
+                ViewGroup.LayoutParams.MatchParent,
+                GravityFlags.NoGravity));
+        }
+
+        AlignBlurView();
+
+        _blurView.SetBackgroundColor(GetColor());
+
+        var decorView = Microsoft.Maui.ApplicationModel.Platform.CurrentActivity?.Window?.DecorView;
+        var root = decorView?.FindViewById(global::Android.Resource.Id.Content) as ViewGroup;
+        if (root == null)
+        {
+            _blurView.Release();
+            _blurRoot = null;
+            return;
+        }
+
+        if (_blurRoot != root)
+        {
+            _blurRoot = root;
+            _blurView
+               .SetupWith(root)
+               .SetFrameClearDrawable(decorView.Background)
+               .SetBlurRadius(DefaultBlurRadius);
+        }
+    }
+
+    private AndroidBlurStrategy ResolveAndroidStrategy()
+    {
+        var strategy = VirtualEffect?.AndroidStrategy ?? AndroidBlurStrategy.Default;
+        if (strategy != AndroidBlurStrategy.Default)
+        {
+            return strategy;
+        }
+
+        return OperatingSystem.IsAndroidVersionAtLeast(31)
+            ? AndroidBlurStrategy.RenderEffect
+            : AndroidBlurStrategy.Material;
+    }
+
+    private void EnsureBackgroundDrawable()
+    {
+        if (_mainDrawable != null)
+        {
+            return;
+        }
+
+        _originalBackground = Control.Background;
+        _mainDrawable = new GradientDrawable();
+        _mainDrawable.SetColor(Colors.Transparent.ToPlatform());
+        Control.Background = _mainDrawable;
+    }
+
+    private void ClearNativeRenderEffect()
+    {
+        if (!_nativeRenderEffectApplied || Control == null || !OperatingSystem.IsAndroidVersionAtLeast(31))
+        {
+            _nativeRenderEffectApplied = false;
+            return;
+        }
+
+        Control.SetRenderEffect(null);
+        _nativeRenderEffectApplied = false;
     }
 
     protected Android.Graphics.Color GetColor()

--- a/src/UraniumUI.Blurs/Platforms/Android/BlurView.cs
+++ b/src/UraniumUI.Blurs/Platforms/Android/BlurView.cs
@@ -16,6 +16,12 @@ public class BlurView : FrameLayout
 
     private Color overlayColor;
 
+    internal AndroidBlurCaptureMode CaptureMode { get; set; } = AndroidBlurCaptureMode.Realtime;
+
+    internal int RealtimeCaptureFps { get; set; } = BlurViewDefaults.REALTIME_CAPTURE_FPS;
+
+    internal float CaptureDownsampleFactor { get; set; } = BlurViewDefaults.CAPTURE_SCALE_FACTOR;
+
     public BlurView(Context context) : base(context)
     {
     }
@@ -46,6 +52,20 @@ public class BlurView : FrameLayout
     public void UpdateBlurViewSize()
     {
         blurController.UpdateBlurViewSize();
+    }
+
+    internal void InvalidateBlur()
+    {
+        if (blurController is PreDrawBlurController preDrawBlurController)
+        {
+            preDrawBlurController.RefreshBlur();
+        }
+        else
+        {
+            blurController.UpdateBlurViewSize();
+        }
+
+        Invalidate();
     }
 
     protected override void OnAttachedToWindow()
@@ -89,7 +109,14 @@ public class BlurView : FrameLayout
         }
 
         this.blurController.Destroy();
-        var controller = new PreDrawBlurController(this, rootView, overlayColor, algorithm);
+        var controller = new PreDrawBlurController(
+            this,
+            rootView,
+            overlayColor,
+            algorithm,
+            CaptureMode,
+            RealtimeCaptureFps,
+            CaptureDownsampleFactor);
         this.blurController = controller;
 
         return controller;

--- a/src/UraniumUI.Blurs/Platforms/Android/IBlurController.cs
+++ b/src/UraniumUI.Blurs/Platforms/Android/IBlurController.cs
@@ -30,5 +30,13 @@ public interface IBlurController : IBlurViewFacade
 public static class BlurViewDefaults
 {
     public const float SCALE_FACTOR = 6f;
+    public const float CAPTURE_SCALE_FACTOR = 8f;
     public const float BLUR_RADIUS = 16f;
+    public const int REALTIME_CAPTURE_FPS = 15;
+}
+
+internal enum AndroidBlurCaptureMode
+{
+    Realtime,
+    Static,
 }

--- a/src/UraniumUI.Blurs/Platforms/Android/PreDrawBlurController.cs
+++ b/src/UraniumUI.Blurs/Platforms/Android/PreDrawBlurController.cs
@@ -1,5 +1,6 @@
 ﻿using Android.Graphics;
 using Android.Graphics.Drawables;
+using Android.OS;
 using Android.Views;
 using View = Android.Views.View;
 using Color = Android.Graphics.Color;
@@ -13,6 +14,9 @@ public class PreDrawBlurController : IBlurController
     private float blurRadius = BlurViewDefaults.BLUR_RADIUS;
 
     private readonly IBlurAlgorithm blurAlgorithm;
+    private readonly AndroidBlurCaptureMode captureMode;
+    private readonly long minRealtimeUpdateIntervalMillis;
+    private readonly float scaleFactor;
     private BlurViewCanvas internalCanvas;
     private Bitmap internalBitmap;
 
@@ -25,21 +29,45 @@ public class PreDrawBlurController : IBlurController
     private bool blurEnabled = true;
     private bool initialized;
     private bool destroyed;
+    private bool autoUpdateEnabled;
+    private bool pendingBlurUpdate = true;
+    private long lastBlurUpdateUptimeMillis;
 
     private Drawable frameClearDrawable;
 
     private readonly OnPreDrawListener drawListener;
     public PreDrawBlurController(View blurView, ViewGroup rootView, Color overlayColor, IBlurAlgorithm algorithm)
+        : this(
+            blurView,
+            rootView,
+            overlayColor,
+            algorithm,
+            AndroidBlurCaptureMode.Realtime,
+            BlurViewDefaults.REALTIME_CAPTURE_FPS,
+            BlurViewDefaults.CAPTURE_SCALE_FACTOR)
     {
-        drawListener = new OnPreDrawListener(() =>
-        {
-            UpdateBlur();
-        });
+    }
+
+    internal PreDrawBlurController(
+        View blurView,
+        ViewGroup rootView,
+        Color overlayColor,
+        IBlurAlgorithm algorithm,
+        AndroidBlurCaptureMode captureMode,
+        int maxRealtimeUpdatesPerSecond,
+        float scaleFactor)
+    {
+        drawListener = new OnPreDrawListener(HandlePreDraw);
 
         this.rootView = rootView;
         this.blurView = blurView;
         this.overlayColor = overlayColor;
         this.blurAlgorithm = algorithm;
+        this.captureMode = captureMode;
+        this.scaleFactor = Math.Clamp(scaleFactor, 1f, 32f);
+
+        var updatesPerSecond = Math.Clamp(maxRealtimeUpdatesPerSecond, 1, 60);
+        minRealtimeUpdateIntervalMillis = 1000L / updatesPerSecond;
 
         if (algorithm is RenderEffectBlur renderEffectBlur) {
             renderEffectBlur.SetContext(blurView.Context);
@@ -59,13 +87,14 @@ public class PreDrawBlurController : IBlurController
         }
 
         SetBlurAutoUpdate(true);
-        SizeScaler sizeScaler = new SizeScaler(blurAlgorithm.ScaleFactor);
+        SizeScaler sizeScaler = new SizeScaler(scaleFactor);
         if (sizeScaler.IsZeroSized(measuredWidth, measuredHeight))
         {
             // Will be initialized later when the View reports a size change
             initialized = false;
             blurView.SetWillNotDraw(true);
             ReleaseBitmap();
+            RequestBlurUpdate();
             return;
         }
 
@@ -75,7 +104,7 @@ public class PreDrawBlurController : IBlurController
         if (initialized && internalBitmap != null && !internalBitmap.IsRecycled &&
             internalBitmap.Width == bitmapSize.width && internalBitmap.Height == bitmapSize.height)
         {
-            UpdateBlur();
+            RefreshBlur();
             return;
         }
 
@@ -87,14 +116,53 @@ public class PreDrawBlurController : IBlurController
         // But it handles cases when the PreDraw listener is attached to a different Window, for example
         // when the BlurView is in a Dialog window, but the root is in the Activity.
         // Previously it was done in `draw`, but it was causing potential side effects and Jetpack Compose crashes
-        UpdateBlur();
+        RefreshBlur();
     }
 
-    void UpdateBlur()
+    private void HandlePreDraw()
     {
-        if (destroyed || !blurEnabled || !initialized || internalBitmap == null || internalCanvas == null || rootView == null)
+        if (destroyed || !blurEnabled)
         {
             return;
+        }
+
+        if (captureMode == AndroidBlurCaptureMode.Static)
+        {
+            if (pendingBlurUpdate)
+            {
+                UpdateBlur(force: true);
+            }
+
+            return;
+        }
+
+        if (pendingBlurUpdate || CanUpdateRealtimeBlur())
+        {
+            UpdateBlur(force: pendingBlurUpdate);
+        }
+    }
+
+    private bool CanUpdateRealtimeBlur()
+    {
+        if (lastBlurUpdateUptimeMillis == 0)
+        {
+            return true;
+        }
+
+        return SystemClock.UptimeMillis() - lastBlurUpdateUptimeMillis >= minRealtimeUpdateIntervalMillis;
+    }
+
+    bool UpdateBlur(bool force = false)
+    {
+        if (!force && captureMode == AndroidBlurCaptureMode.Realtime && !CanUpdateRealtimeBlur())
+        {
+            return false;
+        }
+
+        if (!CanDrawRootIntoBlurBitmap())
+        {
+            RequestBlurUpdate();
+            return false;
         }
 
         if (frameClearDrawable == null)
@@ -112,6 +180,37 @@ public class PreDrawBlurController : IBlurController
         internalCanvas.Restore();
 
         BlurAndSave();
+        pendingBlurUpdate = false;
+        lastBlurUpdateUptimeMillis = SystemClock.UptimeMillis();
+        blurView.Invalidate();
+        UpdateAutoUpdateSubscription();
+        return true;
+    }
+
+    private bool CanDrawRootIntoBlurBitmap()
+    {
+        if (destroyed || !blurEnabled || !initialized || internalBitmap == null || internalCanvas == null || rootView == null)
+        {
+            return false;
+        }
+
+        if (blurView.Width <= 0 || blurView.Height <= 0 || rootView.Width <= 0 || rootView.Height <= 0)
+        {
+            return false;
+        }
+
+        if (!blurView.IsShown || !rootView.IsShown || blurView.WindowToken == null || blurView.Alpha <= 0f)
+        {
+            return false;
+        }
+
+        return !IsNativeAnimationRunning(blurView) && !IsNativeAnimationRunning(rootView);
+    }
+
+    private static bool IsNativeAnimationRunning(View view)
+    {
+        var animation = view.Animation;
+        return animation != null && animation.HasStarted && !animation.HasEnded;
     }
     /**
     * Set up matrix to draw starting from blurView's position
@@ -212,37 +311,58 @@ public class PreDrawBlurController : IBlurController
     public IBlurViewFacade SetBlurRadius(float radius)
     {
         this.blurRadius = radius;
+        RequestBlurUpdate();
         return this;
     }
 
     public IBlurViewFacade SetFrameClearDrawable(Drawable frameClearDrawable)
     {
         this.frameClearDrawable = frameClearDrawable;
+        RequestBlurUpdate();
         return this;
     }
 
     public IBlurViewFacade SetBlurEnabled(bool enabled)
     {
         this.blurEnabled = enabled;
-        SetBlurAutoUpdate(enabled);
+        if (enabled)
+        {
+            RequestBlurUpdate();
+        }
+        else
+        {
+            UpdateAutoUpdateSubscription();
+        }
+
         blurView.Invalidate();
         return this;
     }
 
     public IBlurViewFacade SetBlurAutoUpdate(bool enabled)
     {
+        autoUpdateEnabled = enabled;
+        UpdateAutoUpdateSubscription();
+        return this;
+    }
+
+    private void UpdateAutoUpdateSubscription()
+    {
         var viewTreeObserver = rootView?.ViewTreeObserver;
         if (viewTreeObserver == null || !viewTreeObserver.IsAlive)
         {
-            return this;
+            return;
         }
 
         viewTreeObserver.RemoveOnPreDrawListener(drawListener);
-        if (enabled)
+        if (autoUpdateEnabled && blurEnabled && !destroyed && ShouldListenForPreDraw())
         {
             viewTreeObserver.AddOnPreDrawListener(drawListener);
         }
-        return this;
+    }
+
+    private bool ShouldListenForPreDraw()
+    {
+        return captureMode == AndroidBlurCaptureMode.Realtime || pendingBlurUpdate;
     }
 
     public IBlurViewFacade SetOverlayColor(Color overlayColor)
@@ -253,6 +373,18 @@ public class PreDrawBlurController : IBlurController
             blurView.Invalidate();
         }
         return this;
+    }
+
+    public void RefreshBlur()
+    {
+        RequestBlurUpdate();
+        UpdateBlur(force: true);
+    }
+
+    private void RequestBlurUpdate()
+    {
+        pendingBlurUpdate = true;
+        UpdateAutoUpdateSubscription();
     }
 
     private void ReleaseBitmap()


### PR DESCRIPTION
## Summary
- add `BlurEffect.AndroidStrategy` so Android blur can choose `Default`, `Material`, `RenderEffect`, `RealtimeCapture`, or `StaticCapture`
- keep Android `Default` on a material-style tinted surface instead of the capture pipeline or `RenderEffect`
- keep `RenderEffect` available only as an explicit owned-layer blur strategy and document that it blurs host view content, not the backdrop behind it
- optimize capture blur by throttling realtime capture to 15 FPS by default, increasing default downsample to 8x, skipping hidden/zero-size/native-animating captures, and preferring a closer capture root when available
- add `BlurEffect.InvalidateAndroidBlur()` plus `AndroidRealtimeCaptureFps` and `AndroidCaptureDownsampleFactor` tuning properties

## Automated Testing
- `dotnet build "src/UraniumUI.Blurs/UraniumUI.Blurs.csproj" -f net10.0`
- `dotnet build "src/UraniumUI.Blurs/UraniumUI.Blurs.csproj" -f net10.0-android`

## Manual Testing
- Android device or emulator: open a dialog configured by `UseUraniumUIBlurs()` and confirm the default surface uses the material-style tint instead of blurring dialog content.
- Android 12/API 31+ device or emulator: set `<uranium:BlurEffect AndroidStrategy="RenderEffect" />` on a layout and confirm the host view content is blurred, not the page behind it.
- Android device or emulator: set `<uranium:BlurEffect AndroidStrategy="RealtimeCapture" />` on a layout and confirm backdrop blur still renders while updating at the configured FPS.
- Android device or emulator: set `<uranium:BlurEffect AndroidStrategy="StaticCapture" />` and call `InvalidateAndroidBlur()` after changing the backdrop to confirm manual refresh works.

Closes #1023
