### PR TITLE
Add CalendarView multiple and range selection

### DIFF
--- a/demo/UraniumApp/Pages/CalendarViewPage.xaml
+++ b/demo/UraniumApp/Pages/CalendarViewPage.xaml
@@ -10,13 +10,19 @@
             <Label Text="CalendarView" FontSize="Title" />
             <Label Text="UraniumUI.Controls" FontSize="Micro" Opacity=".6" />
 
-            <Label Text="A custom MAUI calendar layout that supports nullable single-date selection without relying on native date picker behavior." />
+            <Label Text="A custom MAUI calendar layout that supports nullable single-date, multiple-date, and range selection without relying on native date picker behavior." />
+
+            <HorizontalStackLayout Spacing="8">
+                <Button Text="Single" Clicked="SingleModeClicked" StyleClass="OutlinedButton" />
+                <Button Text="Multiple" Clicked="MultipleModeClicked" StyleClass="OutlinedButton" />
+                <Button Text="Range" Clicked="RangeModeClicked" StyleClass="OutlinedButton" />
+            </HorizontalStackLayout>
 
             <Border StyleClass="SurfaceContainer, Rounded" StrokeThickness="0" Padding="16" MaximumWidthRequest="480">
                 <uranium:CalendarView x:Name="calendarView" MinimumDate="1970-01-01" />
             </Border>
 
-            <Label Text="{Binding Source={x:Reference calendarView}, Path=SelectedDate, StringFormat='Selected date: {0:yyyy-MM-dd}'}" />
+            <Label x:Name="selectionSummaryLabel" />
 
             <HorizontalStackLayout Spacing="8">
                 <Button Text="Today" Clicked="TodayClicked" StyleClass="OutlinedButton" />

--- a/demo/UraniumApp/Pages/CalendarViewPage.xaml.cs
+++ b/demo/UraniumApp/Pages/CalendarViewPage.xaml.cs
@@ -1,3 +1,5 @@
+using UraniumUI.Controls;
+
 namespace UraniumApp.Pages;
 
 public partial class CalendarViewPage : ContentPage
@@ -8,15 +10,60 @@ public partial class CalendarViewPage : ContentPage
 
         calendarView.MinimumDate = DateTime.Today.AddMonths(-2);
         calendarView.MaximumDate = DateTime.Today.AddMonths(2);
+        calendarView.DateSelected += (sender, args) => UpdateSelectionSummary();
+
+        UpdateSelectionSummary();
     }
 
     private void TodayClicked(object sender, EventArgs e)
     {
         calendarView.TrySelectDate(DateTime.Today);
+        UpdateSelectionSummary();
     }
 
     private void ClearClicked(object sender, EventArgs e)
     {
         calendarView.ClearSelection();
+        UpdateSelectionSummary();
+    }
+
+    private void SingleModeClicked(object sender, EventArgs e)
+    {
+        calendarView.SelectionMode = CalendarSelectionMode.Single;
+        UpdateSelectionSummary();
+    }
+
+    private void MultipleModeClicked(object sender, EventArgs e)
+    {
+        calendarView.SelectionMode = CalendarSelectionMode.Multiple;
+        UpdateSelectionSummary();
+    }
+
+    private void RangeModeClicked(object sender, EventArgs e)
+    {
+        calendarView.SelectionMode = CalendarSelectionMode.Range;
+        UpdateSelectionSummary();
+    }
+
+    private void UpdateSelectionSummary()
+    {
+        selectionSummaryLabel.Text = calendarView.SelectionMode switch
+        {
+            CalendarSelectionMode.Multiple => $"Selected dates: {FormatDates(calendarView.SelectedDates)}",
+            CalendarSelectionMode.Range => $"Selected range: {FormatDate(calendarView.RangeStartDate)} - {FormatDate(calendarView.RangeEndDate)}",
+            _ => $"Selected date: {FormatDate(calendarView.SelectedDate)}"
+        };
+    }
+
+    private static string FormatDates(IEnumerable<DateTime> dates)
+    {
+        var formattedDates = dates.Select(date => date.ToString("yyyy-MM-dd")).ToArray();
+
+        return formattedDates.Length == 0 ? "none" : string.Join(", ", formattedDates);
+    }
+
+    private static string FormatDate(DateTime? date)
+    {
+        return date?.ToString("yyyy-MM-dd") ?? "none";
     }
 }

--- a/docs/en/infrastructure/CalendarView.md
+++ b/docs/en/infrastructure/CalendarView.md
@@ -1,6 +1,6 @@
 # CalendarView
 
-`CalendarView` is a cross-platform calendar layout for single-date selection. It is rendered with MAUI controls instead of native calendar views, so nullable selection, min/max behavior, and same-date selection are consistent across platforms.
+`CalendarView` is a cross-platform calendar layout for single-date, multiple-date, and date-range selection. It is rendered with MAUI controls instead of native calendar views, so nullable selection, min/max behavior, and same-date selection are consistent across platforms.
 
 ## Usage
 
@@ -23,7 +23,11 @@ Then you can use it with the `uranium:CalendarView` tag.
 
 ## Properties
 
-- **SelectedDate**: The selected date. Supports `DateTime?` and can be `null`.
+- **SelectionMode**: The active selection behavior. Supports `Single`, `Multiple`, and `Range`. The default is `Single`.
+- **SelectedDate**: The selected date for `Single` mode. Supports `DateTime?` and can be `null`.
+- **SelectedDates**: The selected dates for `Multiple` mode. Supports `IList<DateTime>`.
+- **RangeStartDate**: The selected range start for `Range` mode. Supports `DateTime?` and can be `null`.
+- **RangeEndDate**: The selected range end for `Range` mode. Supports `DateTime?` and can be `null`.
 - **DisplayDate**: The month currently displayed by the calendar.
 - **MinimumDate**: The earliest selectable date. Dates before this value are disabled.
 - **MaximumDate**: The latest selectable date. Dates after this value are disabled.
@@ -47,6 +51,35 @@ You can also select or clear dates from code:
 calendarView.TrySelectDate(DateTime.Today);
 calendarView.ClearSelection();
 ```
+
+`ClearSelection()` clears `SelectedDate`, `SelectedDates`, `RangeStartDate`, and `RangeEndDate` regardless of the active selection mode.
+
+## Multiple Selection
+
+Use `SelectionMode="Multiple"` and bind `SelectedDates` when users can select more than one day.
+
+```xml
+<uranium:CalendarView
+    SelectionMode="Multiple"
+    SelectedDates="{Binding SelectedDates}" />
+```
+
+Tapping a selectable day toggles that date in `SelectedDates`. Tapping a disabled day does nothing.
+
+## Range Selection
+
+Use `SelectionMode="Range"` and bind `RangeStartDate` and `RangeEndDate` when users can select a continuous range.
+
+```xml
+<uranium:CalendarView
+    SelectionMode="Range"
+    RangeStartDate="{Binding StartDate}"
+    RangeEndDate="{Binding EndDate}" />
+```
+
+The first selectable tap sets `RangeStartDate` and clears `RangeEndDate`. The second selectable tap completes the range. If the second tap is before the first tap, the start and end are normalized into date order. Tapping the same date twice creates a one-day range. After a complete range is selected, the next selectable tap starts a new range.
+
+`MinimumDate` and `MaximumDate` disable out-of-range days for all selection modes, so disabled dates cannot be selected as multiple dates or range endpoints.
 
 ## Year Selection
 
@@ -77,6 +110,10 @@ The view exposes style classes for common parts:
 - `CalendarView.DayButton.OutsideMonth`
 - `CalendarView.DayButton.Disabled`
 - `CalendarView.DayButton.Selected`
+- `CalendarView.DayButton.MultipleSelected`
+- `CalendarView.DayButton.RangeStart`
+- `CalendarView.DayButton.RangeMiddle`
+- `CalendarView.DayButton.RangeEnd`
 - `CalendarView.YearGrid`
 - `CalendarView.YearButton`
 - `CalendarView.YearButton.Disabled`

--- a/src/UraniumUI/Controls/CalendarView.cs
+++ b/src/UraniumUI/Controls/CalendarView.cs
@@ -23,7 +23,10 @@ public class CalendarView : ContentView
     private const double MaxDayButtonSize = 40;
     private const uint TransitionOutLength = 80;
     private const uint TransitionInLength = 120;
+    private const uint SelectionAnimationLength = 140;
     private const double TransitionOffset = 18;
+    private const double SelectionStartScale = .92;
+    private const string DayButtonSelectionColorAnimationName = "CalendarView.DayButton.SelectionColor";
 
     private readonly Label monthLabel = new()
     {
@@ -465,14 +468,32 @@ public class CalendarView : ContentView
 
     private void UpdateDayButton(Button button, CalendarDay day)
     {
+        var previousDay = button.CommandParameter as CalendarDay;
+        var shouldAnimateSelection = previousDay?.Date == day.Date
+            && previousDay.IsSelected != day.IsSelected
+            && button.IsLoaded;
+        var selectedBackgroundColor = ColorResource.GetColor("Primary", "PrimaryDark", Colors.DodgerBlue);
+        var selectedTextColor = ColorResource.GetColor("OnPrimary", "OnPrimaryDark", Colors.White);
+        var defaultTextColor = ColorResource.GetColor("OnBackground", "OnBackgroundDark", Colors.Black);
+        var targetBackgroundColor = day.IsSelected ? selectedBackgroundColor : Colors.Transparent;
+        var targetTextColor = day.IsSelected ? selectedTextColor : defaultTextColor;
+
         button.Text = day.Date.Day.ToString(CultureInfo.CurrentCulture);
         button.CommandParameter = day;
         button.IsEnabled = day.IsEnabled;
         button.Opacity = day.IsEnabled ? day.IsCurrentMonth ? 1 : .45 : .25;
-        button.BackgroundColor = day.IsSelected ? ColorResource.GetColor("Primary", "PrimaryDark", Colors.DodgerBlue) : Colors.Transparent;
-        button.TextColor = day.IsSelected
-            ? ColorResource.GetColor("OnPrimary", "OnPrimaryDark", Colors.White)
-            : ColorResource.GetColor("OnBackground", "OnBackgroundDark", Colors.Black);
+
+        if (shouldAnimateSelection)
+        {
+            AnimateDayButtonSelection(button, targetBackgroundColor, targetTextColor, day.IsSelected);
+        }
+        else
+        {
+            button.AbortAnimation(DayButtonSelectionColorAnimationName);
+            button.BackgroundColor = targetBackgroundColor;
+            button.TextColor = targetTextColor;
+            button.Scale = 1;
+        }
 
         var styleClasses = new List<string> { "CalendarView.DayButton" };
 
@@ -512,6 +533,50 @@ public class CalendarView : ContentView
         }
 
         button.StyleClass = styleClasses.ToArray();
+    }
+
+    private void AnimateDayButtonSelection(Button button, Color targetBackgroundColor, Color targetTextColor, bool isSelected)
+    {
+        var startBackgroundColor = button.BackgroundColor ?? Colors.Transparent;
+        var startTextColor = button.TextColor;
+        var startScale = isSelected ? SelectionStartScale : button.Scale;
+
+        button.AbortAnimation(DayButtonSelectionColorAnimationName);
+
+        if (isSelected)
+        {
+            button.Scale = SelectionStartScale;
+        }
+
+        var animation = new Animation(progress =>
+        {
+            button.BackgroundColor = InterpolateColor(startBackgroundColor, targetBackgroundColor, progress);
+            button.TextColor = InterpolateColor(startTextColor, targetTextColor, progress);
+            button.Scale = startScale + ((1 - startScale) * progress);
+        });
+
+        animation.Commit(
+            button,
+            DayButtonSelectionColorAnimationName,
+            length: SelectionAnimationLength,
+            easing: Easing.CubicOut,
+            finished: (_, _) =>
+            {
+                button.BackgroundColor = targetBackgroundColor;
+                button.TextColor = targetTextColor;
+                button.Scale = 1;
+            });
+    }
+
+    private static Color InterpolateColor(Color start, Color end, double progress)
+    {
+        var amount = (float)progress;
+
+        return new Color(
+            start.Red + ((end.Red - start.Red) * amount),
+            start.Green + ((end.Green - start.Green) * amount),
+            start.Blue + ((end.Blue - start.Blue) * amount),
+            start.Alpha + ((end.Alpha - start.Alpha) * amount));
     }
 
     private void OnSelectedDatesCollectionChanged(object sender, NotifyCollectionChangedEventArgs e)

--- a/src/UraniumUI/Controls/CalendarView.cs
+++ b/src/UraniumUI/Controls/CalendarView.cs
@@ -1,3 +1,5 @@
+using System.Collections.ObjectModel;
+using System.Collections.Specialized;
 using System.Globalization;
 using System.Windows.Input;
 using Microsoft.Maui.Controls.Shapes;
@@ -64,6 +66,7 @@ public class CalendarView : ContentView
     private bool isYearSelectionVisible;
     private bool isTransitioning;
     private int yearPageStart;
+    private INotifyCollectionChanged selectedDatesNotifier;
 
     public event EventHandler<CalendarDateSelectedEventArgs> DateSelected;
 
@@ -80,6 +83,7 @@ public class CalendarView : ContentView
         SemanticProperties.SetDescription(monthLabel, "Change year");
 
         BuildLayout();
+        OnSelectedDatesChanged(null, SelectedDates);
         UpdateCalendar();
     }
 
@@ -106,6 +110,47 @@ public class CalendarView : ContentView
     public static readonly BindableProperty SelectedDateProperty = BindableProperty.Create(
         nameof(SelectedDate), typeof(DateTime?), typeof(CalendarView), default(DateTime?), BindingMode.TwoWay,
         propertyChanged: (bindable, oldValue, newValue) => ((CalendarView)bindable).OnSelectedDateChanged((DateTime?)newValue));
+
+    public CalendarSelectionMode SelectionMode
+    {
+        get => (CalendarSelectionMode)GetValue(SelectionModeProperty);
+        set => SetValue(SelectionModeProperty, value);
+    }
+
+    public static readonly BindableProperty SelectionModeProperty = BindableProperty.Create(
+        nameof(SelectionMode), typeof(CalendarSelectionMode), typeof(CalendarView), CalendarSelectionMode.Single,
+        propertyChanged: (bindable, oldValue, newValue) => ((CalendarView)bindable).UpdateCalendar());
+
+    public IList<DateTime> SelectedDates
+    {
+        get => (IList<DateTime>)GetValue(SelectedDatesProperty);
+        set => SetValue(SelectedDatesProperty, value);
+    }
+
+    public static readonly BindableProperty SelectedDatesProperty = BindableProperty.Create(
+        nameof(SelectedDates), typeof(IList<DateTime>), typeof(CalendarView), defaultBindingMode: BindingMode.TwoWay,
+        defaultValueCreator: _ => new ObservableCollection<DateTime>(),
+        propertyChanged: (bindable, oldValue, newValue) => ((CalendarView)bindable).OnSelectedDatesChanged((IList<DateTime>)oldValue, (IList<DateTime>)newValue));
+
+    public DateTime? RangeStartDate
+    {
+        get => (DateTime?)GetValue(RangeStartDateProperty);
+        set => SetValue(RangeStartDateProperty, value?.Date);
+    }
+
+    public static readonly BindableProperty RangeStartDateProperty = BindableProperty.Create(
+        nameof(RangeStartDate), typeof(DateTime?), typeof(CalendarView), default(DateTime?), BindingMode.TwoWay,
+        propertyChanged: (bindable, oldValue, newValue) => ((CalendarView)bindable).UpdateCalendar());
+
+    public DateTime? RangeEndDate
+    {
+        get => (DateTime?)GetValue(RangeEndDateProperty);
+        set => SetValue(RangeEndDateProperty, value?.Date);
+    }
+
+    public static readonly BindableProperty RangeEndDateProperty = BindableProperty.Create(
+        nameof(RangeEndDate), typeof(DateTime?), typeof(CalendarView), default(DateTime?), BindingMode.TwoWay,
+        propertyChanged: (bindable, oldValue, newValue) => ((CalendarView)bindable).UpdateCalendar());
 
     public DateTime DisplayDate
     {
@@ -157,7 +202,7 @@ public class CalendarView : ContentView
         }
 
         var oldDate = SelectedDate;
-        SelectedDate = date;
+        ApplySelection(date);
 
         if (!IsSameMonth(DisplayDate, date))
         {
@@ -172,6 +217,9 @@ public class CalendarView : ContentView
     public void ClearSelection()
     {
         SelectedDate = null;
+        SetSelectedDates(Array.Empty<DateTime>());
+        RangeStartDate = null;
+        RangeEndDate = null;
     }
 
     protected virtual void OnSelectedDateChanged(DateTime? selectedDate)
@@ -180,6 +228,24 @@ public class CalendarView : ContentView
         {
             DisplayDate = selectedDate.Value;
             return;
+        }
+
+        UpdateCalendar();
+    }
+
+    protected virtual void OnSelectedDatesChanged(IList<DateTime> oldValue, IList<DateTime> newValue)
+    {
+        if (selectedDatesNotifier is not null)
+        {
+            selectedDatesNotifier.CollectionChanged -= OnSelectedDatesCollectionChanged;
+            selectedDatesNotifier = null;
+        }
+
+        selectedDatesNotifier = newValue as INotifyCollectionChanged;
+
+        if (selectedDatesNotifier is not null)
+        {
+            selectedDatesNotifier.CollectionChanged += OnSelectedDatesCollectionChanged;
         }
 
         UpdateCalendar();
@@ -345,15 +411,27 @@ public class CalendarView : ContentView
         var offset = ((int)firstOfMonth.DayOfWeek - (int)FirstDayOfWeek + DaysInWeek) % DaysInWeek;
         var firstVisibleDate = firstOfMonth.AddDays(-offset);
         var days = new List<CalendarDay>(VisibleDayCount);
+        var selectedDates = GetSelectedDates();
+        var (rangeStart, rangeEnd) = GetSelectedRange();
 
         for (var i = 0; i < VisibleDayCount; i++)
         {
             var date = firstVisibleDate.AddDays(i);
+            var isSingleSelected = SelectionMode == CalendarSelectionMode.Single && SelectedDate?.Date == date;
+            var isMultipleSelected = SelectionMode == CalendarSelectionMode.Multiple && selectedDates.Contains(date);
+            var isRangeStart = SelectionMode == CalendarSelectionMode.Range && rangeStart == date;
+            var isRangeMiddle = SelectionMode == CalendarSelectionMode.Range && rangeStart.HasValue && rangeEnd.HasValue && date > rangeStart.Value && date < rangeEnd.Value;
+            var isRangeEnd = SelectionMode == CalendarSelectionMode.Range && rangeEnd == date;
+
             days.Add(new CalendarDay(
                 date,
                 IsSameMonth(DisplayDate, date),
                 IsDateEnabled(date),
-                SelectedDate?.Date == date));
+                isSingleSelected || isMultipleSelected || isRangeStart || isRangeMiddle || isRangeEnd,
+                isMultipleSelected,
+                isRangeStart,
+                isRangeMiddle,
+                isRangeEnd));
         }
 
         return days;
@@ -413,7 +491,119 @@ public class CalendarView : ContentView
             styleClasses.Add("CalendarView.DayButton.Selected");
         }
 
+        if (day.IsMultipleSelected)
+        {
+            styleClasses.Add("CalendarView.DayButton.MultipleSelected");
+        }
+
+        if (day.IsRangeStart)
+        {
+            styleClasses.Add("CalendarView.DayButton.RangeStart");
+        }
+
+        if (day.IsRangeMiddle)
+        {
+            styleClasses.Add("CalendarView.DayButton.RangeMiddle");
+        }
+
+        if (day.IsRangeEnd)
+        {
+            styleClasses.Add("CalendarView.DayButton.RangeEnd");
+        }
+
         button.StyleClass = styleClasses.ToArray();
+    }
+
+    private void OnSelectedDatesCollectionChanged(object sender, NotifyCollectionChangedEventArgs e)
+    {
+        OnPropertyChanged(nameof(SelectedDates));
+        UpdateCalendar();
+    }
+
+    private void ApplySelection(DateTime date)
+    {
+        switch (SelectionMode)
+        {
+            case CalendarSelectionMode.Multiple:
+                ToggleSelectedDate(date);
+                break;
+            case CalendarSelectionMode.Range:
+                SelectRangeDate(date);
+                break;
+            default:
+                SelectedDate = date;
+                break;
+        }
+    }
+
+    private void ToggleSelectedDate(DateTime date)
+    {
+        var selectedDates = GetSelectedDates().ToList();
+
+        if (!selectedDates.Remove(date))
+        {
+            selectedDates.Add(date);
+        }
+
+        SetSelectedDates(selectedDates);
+    }
+
+    private void SetSelectedDates(IEnumerable<DateTime> dates)
+    {
+        var normalizedDates = dates.Select(date => date.Date).Distinct().OrderBy(date => date).ToList();
+
+        if (SelectedDates is null || SelectedDates.IsReadOnly)
+        {
+            SelectedDates = new ObservableCollection<DateTime>(normalizedDates);
+            return;
+        }
+
+        SelectedDates.Clear();
+
+        foreach (var date in normalizedDates)
+        {
+            SelectedDates.Add(date);
+        }
+
+        OnPropertyChanged(nameof(SelectedDates));
+        UpdateCalendar();
+    }
+
+    private void SelectRangeDate(DateTime date)
+    {
+        if (!RangeStartDate.HasValue || RangeEndDate.HasValue)
+        {
+            RangeStartDate = date;
+            RangeEndDate = null;
+            return;
+        }
+
+        if (date < RangeStartDate.Value.Date)
+        {
+            RangeEndDate = RangeStartDate.Value.Date;
+            RangeStartDate = date;
+            return;
+        }
+
+        RangeEndDate = date;
+    }
+
+    private HashSet<DateTime> GetSelectedDates()
+    {
+        return SelectedDates?.Select(date => date.Date).ToHashSet() ?? new HashSet<DateTime>();
+    }
+
+    private (DateTime? Start, DateTime? End) GetSelectedRange()
+    {
+        var start = RangeStartDate?.Date;
+        var end = RangeEndDate?.Date;
+
+        if (start.HasValue && end.HasValue && end.Value < start.Value)
+        {
+            return (end.Value, start.Value);
+        }
+
+        return (start, end);
     }
 
     private void UpdateDayButtonSize(double width)
@@ -706,12 +896,24 @@ public class CalendarView : ContentView
 
 public class CalendarDay
 {
-    public CalendarDay(DateTime date, bool isCurrentMonth, bool isEnabled, bool isSelected)
+    public CalendarDay(
+        DateTime date,
+        bool isCurrentMonth,
+        bool isEnabled,
+        bool isSelected,
+        bool isMultipleSelected = false,
+        bool isRangeStart = false,
+        bool isRangeMiddle = false,
+        bool isRangeEnd = false)
     {
         Date = date.Date;
         IsCurrentMonth = isCurrentMonth;
         IsEnabled = isEnabled;
         IsSelected = isSelected;
+        IsMultipleSelected = isMultipleSelected;
+        IsRangeStart = isRangeStart;
+        IsRangeMiddle = isRangeMiddle;
+        IsRangeEnd = isRangeEnd;
     }
 
     public DateTime Date { get; }
@@ -721,6 +923,21 @@ public class CalendarDay
     public bool IsEnabled { get; }
 
     public bool IsSelected { get; }
+
+    public bool IsMultipleSelected { get; }
+
+    public bool IsRangeStart { get; }
+
+    public bool IsRangeMiddle { get; }
+
+    public bool IsRangeEnd { get; }
+}
+
+public enum CalendarSelectionMode
+{
+    Single,
+    Multiple,
+    Range
 }
 
 public class CalendarDateSelectedEventArgs : EventArgs

--- a/test/UraniumUI.Tests/Controls/CalendarView_Test.cs
+++ b/test/UraniumUI.Tests/Controls/CalendarView_Test.cs
@@ -1,3 +1,4 @@
+using System.Collections.ObjectModel;
 using UraniumUI.Controls;
 using UraniumUI.Tests.Core;
 
@@ -115,6 +116,165 @@ public class CalendarView_Test
         calendarView.ClearSelection();
 
         Assert.Null(calendarView.SelectedDate);
+    }
+
+    [Fact]
+    public void TrySelectDate_ShouldToggleSelectedDates_WhenSelectionModeIsMultiple()
+    {
+        var firstDate = new DateTime(2026, 5, 10);
+        var secondDate = new DateTime(2026, 5, 12);
+        var calendarView = new CalendarView
+        {
+            SelectionMode = CalendarSelectionMode.Multiple,
+            DisplayDate = new DateTime(2026, 5, 1)
+        };
+
+        Assert.True(calendarView.TrySelectDate(firstDate));
+        Assert.True(calendarView.TrySelectDate(secondDate));
+
+        Assert.Equal(new[] { firstDate, secondDate }, calendarView.SelectedDates);
+        Assert.True(calendarView.VisibleDates.Single(day => day.Date == firstDate).IsMultipleSelected);
+        Assert.True(calendarView.VisibleDates.Single(day => day.Date == firstDate).IsSelected);
+
+        Assert.True(calendarView.TrySelectDate(firstDate));
+
+        Assert.Equal(new[] { secondDate }, calendarView.SelectedDates);
+        Assert.False(calendarView.VisibleDates.Single(day => day.Date == firstDate).IsSelected);
+    }
+
+    [Fact]
+    public void VisibleDates_ShouldUpdate_WhenSelectedDatesCollectionChanges()
+    {
+        var selectedDates = new ObservableCollection<DateTime>();
+        var date = new DateTime(2026, 5, 10);
+        var calendarView = new CalendarView
+        {
+            SelectionMode = CalendarSelectionMode.Multiple,
+            DisplayDate = new DateTime(2026, 5, 1),
+            SelectedDates = selectedDates
+        };
+
+        selectedDates.Add(date);
+
+        Assert.True(calendarView.VisibleDates.Single(day => day.Date == date).IsMultipleSelected);
+    }
+
+    [Fact]
+    public void TrySelectDate_ShouldSelectRange_WhenSelectionModeIsRange()
+    {
+        var startDate = new DateTime(2026, 5, 10);
+        var middleDate = new DateTime(2026, 5, 12);
+        var endDate = new DateTime(2026, 5, 15);
+        var calendarView = new CalendarView
+        {
+            SelectionMode = CalendarSelectionMode.Range,
+            DisplayDate = new DateTime(2026, 5, 1)
+        };
+
+        Assert.True(calendarView.TrySelectDate(startDate));
+
+        Assert.Equal(startDate, calendarView.RangeStartDate);
+        Assert.Null(calendarView.RangeEndDate);
+
+        Assert.True(calendarView.TrySelectDate(endDate));
+
+        Assert.Equal(startDate, calendarView.RangeStartDate);
+        Assert.Equal(endDate, calendarView.RangeEndDate);
+        Assert.True(calendarView.VisibleDates.Single(day => day.Date == startDate).IsRangeStart);
+        Assert.True(calendarView.VisibleDates.Single(day => day.Date == middleDate).IsRangeMiddle);
+        Assert.True(calendarView.VisibleDates.Single(day => day.Date == endDate).IsRangeEnd);
+    }
+
+    [Fact]
+    public void TrySelectDate_ShouldNormalizeRange_WhenEndIsBeforeStart()
+    {
+        var firstTap = new DateTime(2026, 5, 15);
+        var secondTap = new DateTime(2026, 5, 10);
+        var calendarView = new CalendarView
+        {
+            SelectionMode = CalendarSelectionMode.Range,
+            DisplayDate = new DateTime(2026, 5, 1)
+        };
+
+        Assert.True(calendarView.TrySelectDate(firstTap));
+        Assert.True(calendarView.TrySelectDate(secondTap));
+
+        Assert.Equal(secondTap, calendarView.RangeStartDate);
+        Assert.Equal(firstTap, calendarView.RangeEndDate);
+    }
+
+    [Fact]
+    public void TrySelectDate_ShouldAllowSameDateRange()
+    {
+        var date = new DateTime(2026, 5, 10);
+        var calendarView = new CalendarView
+        {
+            SelectionMode = CalendarSelectionMode.Range,
+            DisplayDate = new DateTime(2026, 5, 1)
+        };
+
+        Assert.True(calendarView.TrySelectDate(date));
+        Assert.True(calendarView.TrySelectDate(date));
+
+        var day = calendarView.VisibleDates.Single(day => day.Date == date);
+
+        Assert.Equal(date, calendarView.RangeStartDate);
+        Assert.Equal(date, calendarView.RangeEndDate);
+        Assert.True(day.IsRangeStart);
+        Assert.True(day.IsRangeEnd);
+        Assert.True(day.IsSelected);
+    }
+
+    [Fact]
+    public void TrySelectDate_ShouldStartNewRange_WhenRangeIsComplete()
+    {
+        var calendarView = new CalendarView
+        {
+            SelectionMode = CalendarSelectionMode.Range
+        };
+
+        Assert.True(calendarView.TrySelectDate(new DateTime(2026, 5, 10)));
+        Assert.True(calendarView.TrySelectDate(new DateTime(2026, 5, 15)));
+        Assert.True(calendarView.TrySelectDate(new DateTime(2026, 5, 20)));
+
+        Assert.Equal(new DateTime(2026, 5, 20), calendarView.RangeStartDate);
+        Assert.Null(calendarView.RangeEndDate);
+    }
+
+    [Fact]
+    public void TrySelectDate_ShouldIgnoreDisabledDate_WhenSelectionModeIsRange()
+    {
+        var calendarView = new CalendarView
+        {
+            SelectionMode = CalendarSelectionMode.Range,
+            MinimumDate = new DateTime(2026, 5, 10),
+            MaximumDate = new DateTime(2026, 5, 20)
+        };
+
+        var selected = calendarView.TrySelectDate(new DateTime(2026, 5, 9));
+
+        Assert.False(selected);
+        Assert.Null(calendarView.RangeStartDate);
+        Assert.Null(calendarView.RangeEndDate);
+    }
+
+    [Fact]
+    public void ClearSelection_ShouldClearAllSelectionProperties()
+    {
+        var calendarView = new CalendarView
+        {
+            SelectedDate = new DateTime(2026, 5, 9),
+            RangeStartDate = new DateTime(2026, 5, 10),
+            RangeEndDate = new DateTime(2026, 5, 15)
+        };
+        calendarView.SelectedDates.Add(new DateTime(2026, 5, 11));
+
+        calendarView.ClearSelection();
+
+        Assert.Null(calendarView.SelectedDate);
+        Assert.Empty(calendarView.SelectedDates);
+        Assert.Null(calendarView.RangeStartDate);
+        Assert.Null(calendarView.RangeEndDate);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
- add `CalendarSelectionMode` with `Single`, `Multiple`, and `Range` support
- add `SelectedDates`, `RangeStartDate`, `RangeEndDate`, and day metadata/style classes for multi/range states
- document the new APIs and update the demo CalendarView page with mode switching and selection summaries
- add focused tests for toggling, range normalization, same-date ranges, disabled dates, clearing, and collection updates

<img width="665" height="673" alt="calendarview-selectionmode-demo" src="https://github.com/user-attachments/assets/1f5b2d89-0477-465c-944a-51f02d9945e4" />



## Automated Testing
- `dotnet test test/UraniumUI.Tests/UraniumUI.Tests.csproj --filter FullyQualifiedName~CalendarView_Test`
- `dotnet build demo/UraniumApp/UraniumApp.csproj -f net10.0-windows10.0.19041.0`

## Manual Testing
- Not run in a live device or simulator session.
- Suggested check: run the demo app, open the CalendarView page, switch between Single/Multiple/Range, tap selectable and disabled days, and verify the summary text and selected day/range visuals update as expected.

Closes #1014
