### PR TITLE
Fix PickerField selection after item removal

### DIFF
--- a/src/UraniumUI.Material/Controls/PickerField.cs
+++ b/src/UraniumUI.Material/Controls/PickerField.cs
@@ -1,6 +1,7 @@
 ﻿using Plainer.Maui.Controls;
 using System;
 using System.Collections;
+using System.Collections.Specialized;
 using System.ComponentModel;
 using System.Windows.Input;
 using UraniumUI.Converters;
@@ -46,7 +47,6 @@ public class PickerField : InputField
         pickerView.SetBinding(PickerView.SelectedItemProperty, new Binding(nameof(SelectedItem), source: this));
         pickerView.SetBinding(PickerView.SelectedIndexProperty, new Binding(nameof(SelectedIndex), source: this));
         pickerView.SetBinding(PickerView.IsEnabledProperty, new Binding(nameof(IsEnabled), source: this));
-        pickerView.SetBinding(PickerView.ItemsSourceProperty, new Binding(nameof(ItemsSource), source: this));
         pickerView.SetBinding(PickerView.FontAttributesProperty, new Binding(nameof(FontAttributes), source: this));
         pickerView.SetBinding(PickerView.FontFamilyProperty, new Binding(nameof(FontFamily), source: this));
         pickerView.SetBinding(PickerView.FontSizeProperty, new Binding(nameof(FontSize), source: this));
@@ -141,6 +141,66 @@ public class PickerField : InputField
 #if WINDOWS
         UpdateSelectedItemLabel();
 #endif
+    }
+
+    protected virtual void OnItemsSourceChanged(IList oldValue, IList newValue)
+    {
+        if (oldValue is INotifyCollectionChanged oldObservable)
+        {
+            oldObservable.CollectionChanged -= ItemsSource_CollectionChanged;
+        }
+
+        if (newValue is INotifyCollectionChanged newObservable)
+        {
+            newObservable.CollectionChanged += ItemsSource_CollectionChanged;
+        }
+
+        if (Content is PickerView pickerView)
+        {
+            pickerView.ItemsSource = newValue;
+        }
+
+        SyncSelectionWithItemsSource(SelectedItem);
+    }
+
+    private void ItemsSource_CollectionChanged(object sender, NotifyCollectionChangedEventArgs e)
+    {
+        if (SelectedItem is null)
+        {
+            return;
+        }
+
+        var selectedItem = SelectedItem;
+        if (Dispatcher?.DispatchDelayed(TimeSpan.Zero, () => SyncSelectionWithItemsSource(selectedItem)) != true)
+        {
+            SyncSelectionWithItemsSource(selectedItem);
+        }
+    }
+
+    private void SyncSelectionWithItemsSource(object selectedItem)
+    {
+        if (selectedItem is null)
+        {
+            return;
+        }
+
+        var selectedIndex = ItemsSource?.IndexOf(selectedItem) ?? -1;
+        if (selectedIndex < 0)
+        {
+            SelectedItem = null;
+            SelectedIndex = -1;
+            return;
+        }
+
+        if (!Equals(SelectedItem, selectedItem))
+        {
+            SelectedItem = selectedItem;
+        }
+
+        if (SelectedIndex != selectedIndex)
+        {
+            SelectedIndex = selectedIndex;
+        }
     }
 
     protected virtual void OnAllowClearChanged()
@@ -260,7 +320,8 @@ public class PickerField : InputField
 
     public static readonly BindableProperty ItemsSourceProperty = BindableProperty.Create(
        nameof(ItemsSource), typeof(IList), typeof(PickerField),
-       defaultValue: Picker.ItemsSourceProperty.DefaultValue);
+       defaultValue: Picker.ItemsSourceProperty.DefaultValue,
+       propertyChanged: (bindable, oldValue, newValue) => (bindable as PickerField).OnItemsSourceChanged((IList)oldValue, (IList)newValue));
 
     public BindingBase ItemDisplayBinding { get => (BindingBase)GetValue(ItemDisplayBindingProperty); set => SetValue(ItemDisplayBindingProperty, value); }
 

--- a/test/UraniumUI.Material.Tests/Controls/PickerField_Test.cs
+++ b/test/UraniumUI.Material.Tests/Controls/PickerField_Test.cs
@@ -95,6 +95,22 @@ public class PickerField_Test
     }
 
     [Fact]
+    public void SelectedItem_ShouldBePreserved_WhenItemBeforeSelectionIsRemoved()
+    {
+        var control = AnimationReadyHandler.Prepare(new PickerField());
+        var itemsSource = new ObservableCollection<string>(new[] { "Item0", "Item1", "Item2" });
+        control.ItemsSource = itemsSource;
+        control.PickerView.SelectedIndex = 1;
+
+        control.SelectedItem.ShouldBe("Item1");
+
+        itemsSource.RemoveAt(0);
+
+        control.SelectedItem.ShouldBe("Item1");
+        control.SelectedIndex.ShouldBe(0);
+    }
+
+    [Fact]
     public void ItemDisplayBinding_ShouldBeSet_FromBindableProperty()
     {
         var control = AnimationReadyHandler.Prepare(new PickerField());


### PR DESCRIPTION
## Summary
- keep `PickerField.SelectedItem` stable when an observable `ItemsSource` changes
- resync `SelectedIndex` to the selected value's new index after collection mutations
- add regression coverage for removing an item before the current picker selection

## Automated Testing
- `dotnet test "test/UraniumUI.Material.Tests/UraniumUI.Material.Tests.csproj"`
- `dotnet build "src/UraniumUI.Material/UraniumUI.Material.csproj" -f net10.0-windows10.0.19041.0`
- `dotnet build "src/UraniumUI.Material/UraniumUI.Material.csproj" -f net10.0-android`

## Manual Testing
- Windows or Android MAUI app using the issue repro.
- Select the second `PickerField` item.
- Remove the first item from the bound `ObservableCollection`.
- Expected: the same selected value remains selected and `SelectedIndex` updates to the value's new index.

Closes #882
