### PR TITLE
Use source items for TabView header templates

### DIFF
--- a/demo/UraniumApp/Pages/TabViews/WebTabViewPage.xaml
+++ b/demo/UraniumApp/Pages/TabViews/WebTabViewPage.xaml
@@ -29,25 +29,25 @@
                         TabHeaderItemColumnWidth="Auto"
                         CachingStrategy="CacheOnLayout">
                     <material:TabView.TabHeaderItemTemplate>
-                        <DataTemplate>
-                            <uranium:StatefulContentView TappedCommand="{Binding Command}" WidthRequest="160">
+                        <DataTemplate x:DataType="vm:WebTabItem">
+                            <uranium:StatefulContentView WidthRequest="160">
                                 <Grid ColumnDefinitions="*,Auto" Padding="5,10" BackgroundColor="{AppThemeBinding {StaticResource Primary}, Dark={StaticResource PrimaryDark}}">
 
-                                    <Label Text="{Binding Data.Title}" VerticalOptions="Center" />
+                                    <Label Text="{Binding Title}" VerticalOptions="Center" />
 
                                     <uranium:StatefulContentView Grid.Column="1"
-                                                                 Margin="5"
-                                                VerticalOptions="Center"
-                                                CommandParameter="{Binding Data}"
-                                                TappedCommand="{Binding Source={x:Reference page}, Path=BindingContext.RemoveTabCommand}">
+                                                                  Margin="5"
+                                                 VerticalOptions="Center"
+                                                 CommandParameter="{Binding .}"
+                                                 TappedCommand="{Binding Source={x:Reference page}, Path=BindingContext.RemoveTabCommand}">
                                         <Path Data="{x:Static uranium:UraniumShapes.X}" Fill="{AppThemeBinding {StaticResource OnSurface},Dark={StaticResource OnSurfaceDark}}" />
                                     </uranium:StatefulContentView>
-                                    
+
                                     <Grid.Triggers>
-                                        <DataTrigger TargetType="Grid" Binding="{Binding IsSelected}" Value="True">
+                                        <DataTrigger TargetType="Grid" Binding="{Binding Source={RelativeSource Self}, Path=(material:TabView.IsHeaderSelected)}" Value="True">
                                             <Setter Property="uranium:DynamicTint.BackgroundColorOpacity" Value="0.6" />
                                         </DataTrigger>
-                                        <DataTrigger TargetType="Grid" Binding="{Binding IsSelected}" Value="False">
+                                        <DataTrigger TargetType="Grid" Binding="{Binding Source={RelativeSource Self}, Path=(material:TabView.IsHeaderSelected)}" Value="False">
                                             <Setter Property="uranium:DynamicTint.BackgroundColorOpacity" Value="0.05" />
                                         </DataTrigger>
                                     </Grid.Triggers>

--- a/docs/en/docs-nav.json
+++ b/docs/en/docs-nav.json
@@ -319,6 +319,10 @@
         {
           "text": "Migration to v3.0",
           "path": "migration-guides/Migrating-To-3.0.md"
+        },
+        {
+          "text": "Migration to v3.1",
+          "path": "migration-guides/Migrating-To-3.1.md"
         }
       ]
     },

--- a/docs/en/migration-guides/Migrating-To-3.1.md
+++ b/docs/en/migration-guides/Migrating-To-3.1.md
@@ -1,0 +1,114 @@
+# Migration Guide to v3.1
+
+Version 3.1 currently has one breaking change. This guide will be updated if more v3.1 breaking changes are introduced before release.
+
+You can see related PRs with breaking changes [from here](https://github.com/enisn/UraniumUI/pulls?q=is%3Apr+milestone%3Av3.1+label%3A%22breaking-change+%F0%9F%92%94%22).
+
+## TabHeaderItemTemplate uses ItemsSource items
+
+When `material:TabView` uses `ItemsSource`, `TabHeaderItemTemplate` now receives the original source item as its binding context instead of the generated `TabItem` wrapper.
+
+This is a breaking change for custom header templates that bind through `Data`, `Command`, or `IsSelected`. The new behavior allows trim/AOT-friendly compiled bindings with `x:DataType` because the template can bind to the real item type directly.
+
+No change is required for tabs declared directly with `<material:TabItem>`. Their header templates still bind to `TabItem`.
+
+### Source item bindings
+
+Replace `Data` bindings with direct source-item bindings.
+
+**Before:**
+
+```xml
+<material:TabView ItemsSource="{Binding Tabs}">
+    <material:TabView.TabHeaderItemTemplate>
+        <DataTemplate>
+            <Label Text="{Binding Data.Title}" />
+        </DataTemplate>
+    </material:TabView.TabHeaderItemTemplate>
+</material:TabView>
+```
+
+**After:**
+
+```xml
+<material:TabView ItemsSource="{Binding Tabs}">
+    <material:TabView.TabHeaderItemTemplate>
+        <DataTemplate x:DataType="vm:BrowserTab">
+            <Label Text="{Binding Title}" />
+        </DataTemplate>
+    </material:TabView.TabHeaderItemTemplate>
+</material:TabView>
+```
+
+### Tab selection commands
+
+Custom `ItemsSource` header templates no longer need to bind `Command` just to select the tab. `TabView` wires the header activation internally.
+
+**Before:**
+
+```xml
+<uranium:StatefulContentView TappedCommand="{Binding Command}">
+    <Label Text="{Binding Data.Title}" />
+</uranium:StatefulContentView>
+```
+
+**After:**
+
+```xml
+<uranium:StatefulContentView>
+    <Label Text="{Binding Title}" />
+</uranium:StatefulContentView>
+```
+
+If your header has another command, bind that command to your view model as usual. Pass the current source item with `{Binding .}`.
+
+```xml
+<Button Text="Close"
+        Command="{Binding Source={x:Reference page}, Path=BindingContext.CloseTabCommand}"
+        CommandParameter="{Binding .}" />
+```
+
+### Selected header styling
+
+Replace `IsSelected` bindings with the attached `TabView.IsHeaderSelected` state on the rendered header view.
+
+**Before:**
+
+```xml
+<Grid.Triggers>
+    <DataTrigger TargetType="Grid" Binding="{Binding IsSelected}" Value="True">
+        <Setter Property="BackgroundColor" Value="{StaticResource Primary}" />
+    </DataTrigger>
+</Grid.Triggers>
+```
+
+**After:**
+
+```xml
+<Grid.Triggers>
+    <DataTrigger TargetType="Grid"
+                 Binding="{Binding Source={RelativeSource Self}, Path=(material:TabView.IsHeaderSelected)}"
+                 Value="True">
+        <Setter Property="BackgroundColor" Value="{StaticResource Primary}" />
+    </DataTrigger>
+</Grid.Triggers>
+```
+
+### Direct TabItem templates are unchanged
+
+This migration only affects `TabHeaderItemTemplate` when the tab comes from `ItemsSource`.
+
+This still binds to `TabItem`:
+
+```xml
+<material:TabView>
+    <material:TabView.TabHeaderItemTemplate>
+        <DataTemplate>
+            <Button Text="{Binding Title}" Command="{Binding Command}" />
+        </DataTemplate>
+    </material:TabView.TabHeaderItemTemplate>
+
+    <material:TabItem Title="Overview" />
+    <material:TabItem Title="Details" />
+</material:TabView>
+```

--- a/docs/en/themes/material/components/TabView.md
+++ b/docs/en/themes/material/components/TabView.md
@@ -64,14 +64,42 @@ Table tabs can be placed at the top, bottom, start or left of the tab view. You 
 | ![MAUI TabView Tab Placement](../../../../images/tabview-tabplacement-light-android.gif)| ![MAUI TabView Tab Placement](../../../../images/tabview-tabplacement-dark-windows.gif)  | ![MAUI TabView Tab Placement](../../../../images/tabview-tabplacement-light-ios.gif) |
 
 ### Custom Tab Header
-You can customize the tab header by setting the `TabHeaderItemTemplate` property. The `TabHeaderItemTemplate` property is a **DataTemplate** that is used to render the tab header. The `TabHeaderItemTemplate` property is useful when you want to customize the tab header. In the datatemplate `Command` must be used in binding. That Command must be triggered when use tapped in the custom tab header.
+You can customize the tab header by setting the `TabHeaderItemTemplate` property. The `TabHeaderItemTemplate` property is a **DataTemplate** that is used to render the tab header.
 
-Following parameters can be used in DataTemplate for binding:
+When `TabView` uses an `ItemsSource`, the header template binding context is the current source item. This allows compiled bindings with `x:DataType` and works better with trimming and AOT. The tab selection action is wired by `TabView`, so the template does not need to bind a command just to select the tab.
+
+When tabs are declared directly with `<material:TabItem>`, the header template binding context remains the `TabItem`.
+
+Use `TabView.IsHeaderSelected` to style the selected header when the binding context is an `ItemsSource` item.
+
+```xml
+<material:TabView ItemsSource="{Binding Tabs}">
+    <material:TabView.TabHeaderItemTemplate>
+        <DataTemplate x:DataType="vm:BrowserTab">
+            <Grid Padding="12,8">
+                <Label Text="{Binding Title}" />
+
+                <Grid.Triggers>
+                    <DataTrigger TargetType="Grid"
+                                 Binding="{Binding Source={RelativeSource Self}, Path=(material:TabView.IsHeaderSelected)}"
+                                 Value="True">
+                        <Setter Property="BackgroundColor" Value="{StaticResource Primary}" />
+                    </DataTrigger>
+                </Grid.Triggers>
+            </Grid>
+        </DataTemplate>
+    </material:TabView.TabHeaderItemTemplate>
+</material:TabView>
+```
+
+For directly declared `TabItem` headers, following parameters can be used in DataTemplate for binding:
+
 - `Command`: Command that is triggered when user tapped in the tab header.**Must be used** for functionality of tab view.
 - `Title`: Title of tab.
 - `Data`: It's used to bind custom data to tab header. You can pass this while defining `TabItem`.
+- `IsSelected`: Indicates whether the tab is selected.
 
-For accessible custom headers, use a focusable control such as `Button`, `ButtonView`, `CheckBox`, or `StatefulContentView` and bind its command to `Command`. Avoid using a passive layout with only `TapGestureRecognizer` as the tab header action. Add semantic descriptions when the tab header uses icons or abbreviated text.
+For accessible directly declared `TabItem` headers, use a focusable control such as `Button`, `ButtonView`, `CheckBox`, or `StatefulContentView` and bind its command to `Command`. Avoid using a passive layout with only `TapGestureRecognizer` as the tab header action. Add semantic descriptions when the tab header uses icons or abbreviated text.
 
 ```xml
 <material:TabView>
@@ -92,7 +120,7 @@ For accessible custom headers, use a focusable control such as `Button`, `Button
 | ![MAUI TabView](../../../../images/tabview-simple-custom-light-android.gif) | ![MAUI TabView](../../../../images/tabview-simple-custom-dark-windows.gif)  |
 
 
-Also, tabs can be customized using [Triggers](https://docs.microsoft.com/en-us/dotnet/maui/fundamentals/triggers) according to the state of tab. `DataTrigger` can be used for styling tab item according to the state of tab. `IsSelected` property of `TabItem` can be used in DataTrigger.
+Also, directly declared `TabItem` headers can be customized using [Triggers](https://docs.microsoft.com/en-us/dotnet/maui/fundamentals/triggers) according to the state of tab. `DataTrigger` can be used for styling tab item according to the state of tab. `IsSelected` property of `TabItem` can be used in DataTrigger.
 
 ```xml
 <material:TabView>

--- a/docs/en/toc.yml
+++ b/docs/en/toc.yml
@@ -153,6 +153,8 @@
       href: migration-guides/Migrating-To-2.11.md
     - name: Migration to v3.0
       href: migration-guides/Migrating-To-3.0.md
+    - name: Migration to v3.1
+      href: migration-guides/Migrating-To-3.1.md
 - name: Support
   href: Support.md
   items:

--- a/src/UraniumUI.Material/Controls/TabItem.cs
+++ b/src/UraniumUI.Material/Controls/TabItem.cs
@@ -28,7 +28,9 @@ public class TabItem : UraniumBindableObject
     public View Header { get; set; }
     public object Data { get; set; }
     public TabView TabView { get; internal set; }
-    public bool IsSelected { get => TabView.SelectedTab == this || (TabView.CurrentItem != null && TabView.CurrentItem == Data); }
+    internal bool IsGeneratedFromItemsSource { get; set; }
+    public bool IsSelected => TabView.SelectedTab == this
+        || (TabView.SelectedTab is null && TabView.CurrentItem != null && TabView.CurrentItem == Data);
 
     public bool IsVisible { get => (bool)GetValue(IsVisibleProperty); set => SetValue(IsVisibleProperty, value); }
 

--- a/src/UraniumUI.Material/Controls/TabView.BindableProperties.cs
+++ b/src/UraniumUI.Material/Controls/TabView.BindableProperties.cs
@@ -23,7 +23,17 @@ public partial class TabView
     public static readonly BindableProperty TabHeaderItemTemplateProperty =
         BindableProperty.Create(nameof(TabHeaderItemTemplate), typeof(DataTemplate), typeof(TabView),
             defaultValueCreator: (bindable) => TabView.DefaultTabHeaderItemTemplate,
-            propertyChanged: (bo, ov, nv) => (bo as TabView).RenderHeaders());
+            propertyChanged: (bo, ov, nv) => (bo as TabView).OnTabHeaderItemTemplateChanged());
+
+    public static readonly BindableProperty IsHeaderSelectedProperty = BindableProperty.CreateAttached(
+        "IsHeaderSelected",
+        typeof(bool),
+        typeof(TabView),
+        false);
+
+    public static bool GetIsHeaderSelected(BindableObject bindable) => (bool)bindable.GetValue(IsHeaderSelectedProperty);
+
+    public static void SetIsHeaderSelected(BindableObject bindable, bool value) => bindable.SetValue(IsHeaderSelectedProperty, value);
 
     [TypeConverter(typeof(GridLengthTypeConverter))]
     public GridLength TabHeaderItemColumnWidth { get => (GridLength)GetValue(TabHeaderItemColumnWidthProperty); set => SetValue(TabHeaderItemColumnWidthProperty, value); }

--- a/src/UraniumUI.Material/Controls/TabView.cs
+++ b/src/UraniumUI.Material/Controls/TabView.cs
@@ -118,6 +118,8 @@ public partial class TabView : Grid
         Orientation = ScrollOrientation.Horizontal,
     };
 
+    private bool hasCustomTabHeaderItemTemplate;
+
     public TabView()
     {
         Tabs = new ObservableCollection<TabItem>();
@@ -152,6 +154,12 @@ public partial class TabView : Grid
     private void OnItemTemplateChanged()
     {
         Render();
+    }
+
+    private void OnTabHeaderItemTemplateChanged()
+    {
+        hasCustomTabHeaderItemTemplate = true;
+        RenderHeaders();
     }
 
     protected virtual void InitializeLayout()
@@ -326,7 +334,15 @@ public partial class TabView : Grid
 
     internal virtual void RenderHeaders()
     {
+        foreach (var item in Tabs)
+        {
+            ClearHeaderBindingContext(item.Header);
+        }
+
         _headerContainer.Children.Clear();
+        _headerContainer.RowDefinitions.Clear();
+        _headerContainer.ColumnDefinitions.Clear();
+
         foreach (var item in Tabs)
         {
             AddHeaderFor(item);
@@ -336,7 +352,10 @@ public partial class TabView : Grid
         {
             foreach (var item in ItemsSource)
             {
-                AddHeaderForItem(item);
+                if (!Tabs.Any(x => x.IsGeneratedFromItemsSource && Equals(x.Data, item)))
+                {
+                    AddHeaderForItem(item);
+                }
             }
         }
     }
@@ -369,19 +388,20 @@ public partial class TabView : Grid
     protected virtual void AddHeaderFor(TabItem tabItem)
     {
         tabItem.TabView = this;
+        var useItemsSourceHeaderContext = ShouldUseItemsSourceHeaderContext(tabItem);
         var headerContent =
             tabItem.HeaderTemplate?.CreateContent() as View
             ?? TabHeaderItemTemplate?.CreateContent() as View
             //?? DefaultTabHeaderItemTemplate.CreateContent() as View
             ?? throw new InvalidOperationException("TabView requires a HeaderTemplate or TabHeaderItemTemplate to be set.");
 
-        headerContent.BindingContext = tabItem;
+        headerContent.BindingContext = useItemsSourceHeaderContext ? tabItem.Data : tabItem;
 
-        tabItem.Header = CreateAccessibleHeader(tabItem, headerContent);
+        tabItem.Header = CreateAccessibleHeader(tabItem, headerContent, useItemsSourceHeaderContext);
 
         UpdateHeaderSemantics(tabItem);
 
-        if (!_headerContainer.Children.Any())
+        if (!_headerContainer.Children.Any() && SelectedTab is null)
         {
             SelectedTab = tabItem;
         }
@@ -399,9 +419,45 @@ public partial class TabView : Grid
         _headerContainer.Add(tabItem.Header);
     }
 
-    private View CreateAccessibleHeader(TabItem tabItem, View headerContent)
+    private static void ClearHeaderBindingContext(View header)
+    {
+        if (header is null)
+        {
+            return;
+        }
+
+        foreach (var view in header.FindManyInChildrenHierarchy<View>())
+        {
+            view.Triggers.Clear();
+            view.BindingContext = null;
+        }
+    }
+
+    private bool ShouldUseItemsSourceHeaderContext(TabItem tabItem)
+    {
+        return tabItem.IsGeneratedFromItemsSource
+            && tabItem.HeaderTemplate is null
+            && hasCustomTabHeaderItemTemplate;
+    }
+
+    private View CreateAccessibleHeader(TabItem tabItem, View headerContent, bool controlOwnsActivation)
     {
         var selectCommand = new Command(() => SelectedTab = tabItem);
+
+        if (controlOwnsActivation)
+        {
+            if (TrySetHeaderActivationCommand(headerContent, selectCommand))
+            {
+                return headerContent;
+            }
+
+            return new StatefulContentView
+            {
+                Content = headerContent,
+                TappedCommand = selectCommand,
+                BindingContext = headerContent.BindingContext,
+            };
+        }
 
         if (HasKeyboardReachableElement(headerContent))
         {
@@ -415,6 +471,24 @@ public partial class TabView : Grid
             TappedCommand = selectCommand,
             BindingContext = tabItem,
         };
+    }
+
+    private static bool TrySetHeaderActivationCommand(View headerContent, ICommand selectCommand)
+    {
+        switch (headerContent)
+        {
+            case Button button:
+                button.Command = selectCommand;
+                return true;
+            case ButtonView buttonView:
+                buttonView.TappedCommand = selectCommand;
+                return true;
+            case StatefulContentView statefulContentView:
+                statefulContentView.TappedCommand = selectCommand;
+                return true;
+            default:
+                return false;
+        }
     }
 
     private static bool HasKeyboardReachableElement(View view)
@@ -432,6 +506,8 @@ public partial class TabView : Grid
             return;
         }
 
+        UpdateHeaderSelectionState(tabItem);
+
         var options = AccessibilityOptionsProvider.Get();
         var title = tabItem.Title ?? tabItem.Data?.ToString() ?? nameof(TabItem);
         var description = tabItem.IsSelected ? options.FormatSelectedTabDescription(title) : title;
@@ -439,6 +515,14 @@ public partial class TabView : Grid
 
         SemanticProperties.SetDescription(semanticTarget, description);
         SemanticProperties.SetHint(semanticTarget, options.SelectTabHint);
+    }
+
+    private static void UpdateHeaderSelectionState(TabItem tabItem)
+    {
+        foreach (var view in tabItem.Header.FindManyInChildrenHierarchy<View>())
+        {
+            SetIsHeaderSelected(view, tabItem.IsSelected);
+        }
     }
 
     private static VisualElement GetHeaderSemanticTarget(View header)
@@ -455,14 +539,14 @@ public partial class TabView : Grid
 
     protected virtual void AddHeaderForItem(object item)
     {
-        var tabItem = new TabItem { Data = item, Title = item?.ToString() };
+        var tabItem = new TabItem { Data = item, Title = item?.ToString(), IsGeneratedFromItemsSource = true };
 
         Tabs.Add(tabItem);
     }
 
     protected virtual void RemoveHeaderFor(TabItem tabItem)
     {
-        var existing = _headerContainer.Children.FirstOrDefault(x => x is View view && view.BindingContext == tabItem);
+        var existing = tabItem.Header ?? _headerContainer.Children.FirstOrDefault(x => x is View view && view.BindingContext == tabItem);
 
         if (tabItem == SelectedTab)
         {
@@ -513,11 +597,20 @@ public partial class TabView : Grid
             return;
         }
 
-        var content = newValue.Content ??=
-            ((View)newValue.ContentTemplate?.CreateContent()
-                ?? (View)ItemTemplate?.CreateContent());
+        if (newValue.Data is not null && CurrentItem != newValue.Data)
+        {
+            CurrentItem = newValue.Data;
+        }
 
-        ApplyContentBindingContext(newValue, content);
+        var content = newValue.Content
+            ?? (View)newValue.ContentTemplate?.CreateContent()
+            ?? (View)ItemTemplate?.CreateContent();
+
+        if (content is not null)
+        {
+            newValue.Content ??= content;
+            ApplyContentBindingContext(newValue, content);
+        }
 
         foreach (var item in Tabs)
         {
@@ -530,13 +623,14 @@ public partial class TabView : Grid
             oldValue.Content = null; // Make it null, in the next visit of this method, a new instance will be created.
         }
 
-        await PresentContentAsync(content);
-
-        content.Opacity = 1;
-
-        if (SelectedTab?.Data != null)
+        if (content is not null)
         {
-            CurrentItem = SelectedTab.Data;
+            await PresentContentAsync(content);
+            content.Opacity = 1;
+        }
+        else
+        {
+            _contentContainer.Content = null;
         }
 
         SelectedTabChanged?.Invoke(this, newValue);

--- a/test/UraniumUI.Material.Tests/Controls/TabView_Test.cs
+++ b/test/UraniumUI.Material.Tests/Controls/TabView_Test.cs
@@ -112,6 +112,84 @@ public class TabView_Test
         SemanticProperties.GetDescription(secondHeader).ShouldBe("Second, selected");
     }
 
+    [Fact]
+    public void TabHeaderItemTemplate_ShouldUseItemsSourceItemBindingContext()
+    {
+        var items = new ObservableCollection<HeaderItem>
+        {
+            new("First"),
+            new("Second"),
+        };
+
+        var tabView = AnimationReadyHandler.Prepare(new TabView
+        {
+            TabHeaderItemTemplate = CreateItemsSourceHeaderTemplate(),
+            ItemTemplate = CreateTestHeaderTemplate(),
+            ItemsSource = items,
+            UseAnimation = false,
+        });
+
+        tabView.Tabs.Count.ShouldBe(2);
+        var firstHeaderContent = GetWrappedHeaderContent<Label>(tabView.Tabs[0]);
+
+        firstHeaderContent.BindingContext.ShouldBeSameAs(items[0]);
+        firstHeaderContent.Text.ShouldBe("First");
+    }
+
+    [Fact]
+    public void TabHeaderItemTemplate_ShouldExposeSelectedStateForItemsSourceHeaders()
+    {
+        var items = new ObservableCollection<HeaderItem>
+        {
+            new("First"),
+            new("Second"),
+        };
+
+        var tabView = AnimationReadyHandler.Prepare(new TabView
+        {
+            TabHeaderItemTemplate = CreateItemsSourceHeaderTemplate(),
+            ItemTemplate = CreateTestHeaderTemplate(),
+            ItemsSource = items,
+            UseAnimation = false,
+        });
+
+        var firstHeaderContent = GetWrappedHeaderContent<Label>(tabView.Tabs[0]);
+        var secondHeaderContent = GetWrappedHeaderContent<Label>(tabView.Tabs[1]);
+
+        TabView.GetIsHeaderSelected(firstHeaderContent).ShouldBeTrue();
+        TabView.GetIsHeaderSelected(secondHeaderContent).ShouldBeFalse();
+
+        tabView.SelectedTab = tabView.Tabs[1];
+
+        TabView.GetIsHeaderSelected(firstHeaderContent).ShouldBeFalse();
+        TabView.GetIsHeaderSelected(secondHeaderContent).ShouldBeTrue();
+    }
+
+    [Fact]
+    public void TabHeaderItemTemplate_ShouldSelectItemsSourceTabWithoutTemplateCommand()
+    {
+        var items = new ObservableCollection<HeaderItem>
+        {
+            new("First"),
+            new("Second"),
+        };
+
+        var tabView = AnimationReadyHandler.Prepare(new TabView
+        {
+            TabHeaderItemTemplate = CreateItemsSourceHeaderTemplate(),
+            ItemTemplate = CreateTestHeaderTemplate(),
+            ItemsSource = items,
+            UseAnimation = false,
+        });
+
+        var secondHeader = tabView.Tabs[1].Header.ShouldBeOfType<StatefulContentView>();
+
+        secondHeader.TappedCommand.Execute(null);
+
+        tabView.SelectedTab.ShouldBeSameAs(tabView.Tabs[1]);
+        tabView.CurrentItem.ShouldBeSameAs(items[1]);
+    }
+
     private sealed class TestMultiplePickerField : MultiplePickerField
     {
         public string[] GetChipTexts()
@@ -123,6 +201,33 @@ public class TabView_Test
     private static DataTemplate CreateTestHeaderTemplate()
     {
         return new DataTemplate(() => new Label());
+    }
+
+    private static DataTemplate CreateItemsSourceHeaderTemplate()
+    {
+        return new DataTemplate(() =>
+        {
+            var label = new Label();
+            label.SetBinding(Label.TextProperty, nameof(HeaderItem.Title));
+            return label;
+        });
+    }
+
+    private static TView GetWrappedHeaderContent<TView>(TabItem tabItem)
+        where TView : View
+    {
+        var header = tabItem.Header.ShouldBeOfType<StatefulContentView>();
+        return header.Content.ShouldBeOfType<TView>();
+    }
+
+    private sealed class HeaderItem
+    {
+        public HeaderItem(string title)
+        {
+            Title = title;
+        }
+
+        public string Title { get; }
     }
 
     private sealed class MultiplePickerViewModel


### PR DESCRIPTION
## Summary
- change `TabHeaderItemTemplate` for `ItemsSource` tabs to bind to the original source item instead of the generated `TabItem`
- wire ItemsSource header activation from `TabView` and expose `TabView.IsHeaderSelected` for selected-state styling
- update the WebTabView demo, TabView docs, and add the v3.1 migration guide entry

## Automated Testing
- `dotnet test "test/UraniumUI.Material.Tests/UraniumUI.Material.Tests.csproj" --filter FullyQualifiedName~TabView_Test`
- `dotnet build "demo/UraniumApp/UraniumApp.csproj" -f net10.0-windows10.0.19041.0 --no-restore`

## Manual Testing
- Not run in an interactive MAUI app session.
- Suggested check: run the Windows demo app, open `TabView > WebView TabItem`, switch between generated tabs, and close a tab.
- Expected result: headers bind directly to `WebTabItem`, selected styling follows `TabView.IsHeaderSelected`, and the close command receives the source tab item.

Closes #889