### PR TITLE
Add AutoFormView property descriptors

### DIFF
--- a/docs/en/infrastructure/AutoFormView.md
+++ b/docs/en/infrastructure/AutoFormView.md
@@ -15,7 +15,7 @@ xmlns:uranium="http://schemas.enisn-projects.io/dotnet/maui/uraniumui"
 Then you can use it like this:
 
 ```xml
-<uranium:FormView Source="{Binding .}" />
+<uranium:AutoFormView Source="{Binding .}" />
 ```
 
 ### Example
@@ -39,6 +39,9 @@ public class AutoFormViewPageViewModel : ViewModelBase
 
 ![AutoFormView](../images/autoformview-example-dark.png)
 
+> [!NOTE]
+> `[Reactive]` is not required by `AutoFormView`. It works with public properties from plain classes, ReactiveUI, or source generators such as MVVM Toolkit `[ObservableProperty]` as long as the generated property is public.
+
 
 ## Configuration
 
@@ -51,6 +54,41 @@ builder.Services.Configure<AutoFormViewOptions>(options =>
 });
 ```
 
+### AOT-safe property definitions
+
+By default, `AutoFormView` discovers public properties from `Source` by reflection. For NativeAOT or trimming-sensitive apps, provide property metadata explicitly with `PropertyDefinitions` or `PropertyProvider`.
+
+```csharp
+using UraniumUI.Options;
+
+public class RegisterViewModel
+{
+    public string Email { get; set; }
+    public int? NumberOfSeats { get; set; }
+    public bool AcceptTerms { get; set; }
+
+    public IReadOnlyList<AutoFormProperty> FormProperties { get; } = new AutoFormProperty[]
+    {
+        new(nameof(Email), typeof(string), "Email"),
+        new(nameof(NumberOfSeats), typeof(int?), "Number of seats", isNullable: true),
+        new(nameof(AcceptTerms), typeof(bool), "I accept terms and conditions")
+    };
+}
+```
+
+```xml
+<uranium:AutoFormView Source="{Binding .}"
+                      PropertyDefinitions="{Binding FormProperties}" />
+```
+
+You can also provide metadata in code:
+
+```csharp
+formView.PropertyProvider = source => RegisterFormMetadata.Properties;
+```
+
+If neither `PropertyDefinitions` nor `PropertyProvider` is set, `AutoFormView` keeps the reflection-based behavior for compatibility.
+
 ### DataAnnotations
 It's not supported DataAnnotations by default. You can add `UraniumUI.Validations.DataAnnotations` package to project and configure `AutoFormViewOptions` to use DataAnnotations.
 
@@ -58,6 +96,17 @@ It's not supported DataAnnotations by default. You can add `UraniumUI.Validation
 builder.Services.Configure<AutoFormViewOptions>(options =>
 {
     options.ValidationFactory = DataAnnotationValidation.CreateValidations;
+});
+```
+
+For AOT-safe descriptors, provide validation metadata through `PropertyValidationFactory`:
+
+```csharp
+builder.Services.Configure<AutoFormViewOptions>(options =>
+{
+    options.PropertyValidationFactory = property => property
+        .GetCustomAttributes<ValidationAttribute>()
+        .Select(attribute => new DataAnnotationValidation(attribute, property.GetDefaultDisplayName()));
 });
 ```
 
@@ -97,12 +146,12 @@ For busy UI, place your own indicator in the form and mark it with `uranium:Form
 > Unlike manually created `uranium:FormView` fields, `AutoFormView` assigns `uranium:FormView.ValidationPath` automatically for generated editors. Property errors returned with `FormValidationResult.PropertyError(nameof(UserName), "...")` can therefore map to the generated field without extra XAML.
 
 ### EditorMapping
-You can configure the `AutoFormView` to use a specific editor for a type. For example, you can configure the `AutoFormViewOptions` to use a `Editor` for `string` properties.
+You can configure the `AutoFormView` to use a specific editor for a type. For descriptor-based metadata, configure `PropertyEditorMapping`.
 
 ```csharp
 builder.Services.Configure<AutoFormViewOptions>(options =>
 {
-    options.EditorMapping[typeof(string)] = (property, propertyNameFactory, source) =>
+    options.PropertyEditorMapping[typeof(string)] = (property, propertyNameFactory, source) =>
     {
         var editor = new Entry();
         editor.Placeholder = propertyNameFactory(property);
@@ -114,6 +163,8 @@ builder.Services.Configure<AutoFormViewOptions>(options =>
 
 > [!NOTE]  
 > The following types are already mapped by default: `string`, `int`, `float`, `double`, `DateTime`, `TimeSpan`, `bool`, `Enum`, `Keyboard`.
+
+`EditorMapping` is still available for existing `PropertyInfo`-based customizations when `AutoFormView` uses reflection-discovered properties.
 
 
 ### Property Name Mapping
@@ -139,6 +190,8 @@ builder.Services.Configure<AutoFormViewOptions>(options =>
     };
 });
 ```
+
+For descriptor-based property metadata, set `displayName` on `AutoFormProperty` or configure `PropertyDisplayNameFactory`.
 
 ## Customization
 
@@ -188,7 +241,7 @@ You can configure the `AutoFormView` to show missing properties using the `ShowM
 ## Other Properties
 
 - `ShowSubmitButton`: Indicates whether the submit button is visible. The default value is `true`.
-- `SohwResetButton`: Indicates whether the reset button is visible. The default value is `true`.
+- `ShowResetButton`: Indicates whether the reset button is visible. The default value is `true`.
 - `SubmitButtonText`: The text of the submit button. The default value is `Submit`.
 - `ResetButtonText`: The text of the reset button. The default value is `Reset`.
 

--- a/src/UraniumUI.Material/Extensions/AutoFormViewMaterialConfigurationExtensions.cs
+++ b/src/UraniumUI.Material/Extensions/AutoFormViewMaterialConfigurationExtensions.cs
@@ -22,6 +22,16 @@ public static class AutoFormViewMaterialConfigurationExtensions
             options.EditorMapping[typeof(Enum)] = EditorForEnum;
             options.EditorMapping[typeof(DateTime)] = EditorForDateTime;
             options.EditorMapping[typeof(TimeSpan)] = EditorForTimeSpan;
+
+            options.PropertyEditorMapping[typeof(string)] = EditorForString;
+            options.PropertyEditorMapping[typeof(int)] = EditorForNumeric;
+            options.PropertyEditorMapping[typeof(double)] = EditorForNumeric;
+            options.PropertyEditorMapping[typeof(float)] = EditorForNumeric;
+            options.PropertyEditorMapping[typeof(bool)] = EditorForBoolean;
+            options.PropertyEditorMapping[typeof(Keyboard)] = EditorForKeyboard;
+            options.PropertyEditorMapping[typeof(Enum)] = EditorForEnum;
+            options.PropertyEditorMapping[typeof(DateTime)] = EditorForDateTime;
+            options.PropertyEditorMapping[typeof(TimeSpan)] = EditorForTimeSpan;
         });
 
         return builder;
@@ -29,9 +39,14 @@ public static class AutoFormViewMaterialConfigurationExtensions
 
     public static View EditorForString(PropertyInfo property, Func<PropertyInfo, string> propertyNameFactory, object source)
     {
+        return EditorForString(AutoFormProperty.FromPropertyInfo(property), _ => propertyNameFactory(property), source);
+    }
+
+    public static View EditorForString(AutoFormProperty property, Func<AutoFormProperty, string> propertyNameFactory, object source)
+    {
         var editor = new TextField();
         editor.SetBinding(TextField.TextProperty, new Binding(property.Name, source: source));
-        editor.AllowClear = property.PropertyType.IsNullable();
+        editor.AllowClear = property.IsNullable;
         editor.Title = propertyNameFactory(property);
 
         return editor;
@@ -39,16 +54,26 @@ public static class AutoFormViewMaterialConfigurationExtensions
 
     public static View EditorForNumeric(PropertyInfo property, Func<PropertyInfo, string> propertyNameFactory, object source)
     {
+        return EditorForNumeric(AutoFormProperty.FromPropertyInfo(property), _ => propertyNameFactory(property), source);
+    }
+
+    public static View EditorForNumeric(AutoFormProperty property, Func<AutoFormProperty, string> propertyNameFactory, object source)
+    {
         var editor = new TextField();
         editor.SetBinding(TextField.TextProperty, new Binding(property.Name, source: source));
         editor.Title = propertyNameFactory(property);
-        editor.AllowClear = property.PropertyType.IsNullable();
+        editor.AllowClear = property.IsNullable;
         editor.Keyboard = Keyboard.Numeric;
 
         return editor;
     }
 
     public static View EditorForBoolean(PropertyInfo property, Func<PropertyInfo, string> propertyNameFactory, object source)
+    {
+        return EditorForBoolean(AutoFormProperty.FromPropertyInfo(property), _ => propertyNameFactory(property), source);
+    }
+
+    public static View EditorForBoolean(AutoFormProperty property, Func<AutoFormProperty, string> propertyNameFactory, object source)
     {
         var editor = new UraniumUI.Material.Controls.CheckBox();
         editor.SetBinding(UraniumUI.Material.Controls.CheckBox.IsCheckedProperty, new Binding(property.Name, source: source));
@@ -58,6 +83,11 @@ public static class AutoFormViewMaterialConfigurationExtensions
     }
 
     public static View EditorForEnum(PropertyInfo property, Func<PropertyInfo, string> propertyNameFactory, object source)
+    {
+        return EditorForEnum(AutoFormProperty.FromPropertyInfo(property), _ => propertyNameFactory(property), source);
+    }
+
+    public static View EditorForEnum(AutoFormProperty property, Func<AutoFormProperty, string> propertyNameFactory, object source)
     {
         var editor = new PickerField();
 
@@ -70,11 +100,16 @@ public static class AutoFormViewMaterialConfigurationExtensions
         editor.ItemsSource = values;
         editor.SetBinding(PickerField.SelectedItemProperty, new Binding(property.Name, source: source));
         editor.Title = propertyNameFactory(property);
-        editor.AllowClear = property.PropertyType.IsNullable();
+        editor.AllowClear = property.IsNullable;
         return editor;
     }
 
     private static View CreateSelectionViewForValues(Array values, PropertyInfo property, Func<PropertyInfo, string> propertyNameFactory, object source)
+    {
+        return CreateSelectionViewForValues(values, AutoFormProperty.FromPropertyInfo(property), _ => propertyNameFactory(property), source);
+    }
+
+    private static View CreateSelectionViewForValues(Array values, AutoFormProperty property, Func<AutoFormProperty, string> propertyNameFactory, object source)
     {
         var shouldUseSingleColumn = values.Length > 3;
         var editor = new SelectionView
@@ -101,6 +136,11 @@ public static class AutoFormViewMaterialConfigurationExtensions
 
     public static View EditorForKeyboard(PropertyInfo property, Func<PropertyInfo, string> propertyNameFactory, object source)
     {
+        return EditorForKeyboard(AutoFormProperty.FromPropertyInfo(property), _ => propertyNameFactory(property), source);
+    }
+
+    public static View EditorForKeyboard(AutoFormProperty property, Func<AutoFormProperty, string> propertyNameFactory, object source)
+    {
         var editor = new PickerField();
 
         editor.ItemsSource = typeof(Keyboard)
@@ -110,25 +150,35 @@ public static class AutoFormViewMaterialConfigurationExtensions
 
         editor.SetBinding(PickerField.SelectedItemProperty, new Binding(property.Name, source: source));
         editor.Title = propertyNameFactory(property);
-        editor.AllowClear = property.PropertyType.IsNullable();
+        editor.AllowClear = property.IsNullable;
         return editor;
     }
 
     public static View EditorForDateTime(PropertyInfo property, Func<PropertyInfo, string> propertyNameFactory, object source)
     {
+        return EditorForDateTime(AutoFormProperty.FromPropertyInfo(property), _ => propertyNameFactory(property), source);
+    }
+
+    public static View EditorForDateTime(AutoFormProperty property, Func<AutoFormProperty, string> propertyNameFactory, object source)
+    {
         var editor = new DatePickerField();
         editor.SetBinding(DatePickerField.DateProperty, new Binding(property.Name, source: source));
         editor.Title = propertyNameFactory(property);
-        editor.AllowClear = property.PropertyType.IsNullable();
+        editor.AllowClear = property.IsNullable;
         return editor;
     }
 
     public static View EditorForTimeSpan(PropertyInfo property, Func<PropertyInfo, string> propertyNameFactory, object source)
     {
+        return EditorForTimeSpan(AutoFormProperty.FromPropertyInfo(property), _ => propertyNameFactory(property), source);
+    }
+
+    public static View EditorForTimeSpan(AutoFormProperty property, Func<AutoFormProperty, string> propertyNameFactory, object source)
+    {
         var editor = new TimePickerField();
         editor.SetBinding(TimePickerField.TimeProperty, new Binding(property.Name, source: source));
         editor.Title = propertyNameFactory(property);
-        editor.AllowClear = property.PropertyType.IsNullable();
+        editor.AllowClear = property.IsNullable;
         return editor;
     }
 }

--- a/src/UraniumUI/Controls/AutoFormView.cs
+++ b/src/UraniumUI/Controls/AutoFormView.cs
@@ -17,7 +17,23 @@ public class AutoFormView : FormView
         typeof(AutoFormView),
         propertyChanged: (bindable, oldValue, newValue) => (bindable as AutoFormView).OnSourceChanged());
 
-    public PropertyInfo[] EditingProperties { get; protected set; }
+    public IEnumerable<AutoFormProperty> PropertyDefinitions { get => (IEnumerable<AutoFormProperty>)GetValue(PropertyDefinitionsProperty); set => SetValue(PropertyDefinitionsProperty, value); }
+    public static readonly BindableProperty PropertyDefinitionsProperty = BindableProperty.Create(
+        nameof(PropertyDefinitions),
+        typeof(IEnumerable<AutoFormProperty>),
+        typeof(AutoFormView),
+        propertyChanged: (bindable, oldValue, newValue) => (bindable as AutoFormView).OnSourceChanged());
+
+    public Func<object, IEnumerable<AutoFormProperty>> PropertyProvider { get => (Func<object, IEnumerable<AutoFormProperty>>)GetValue(PropertyProviderProperty); set => SetValue(PropertyProviderProperty, value); }
+    public static readonly BindableProperty PropertyProviderProperty = BindableProperty.Create(
+        nameof(PropertyProvider),
+        typeof(Func<object, IEnumerable<AutoFormProperty>>),
+        typeof(AutoFormView),
+        propertyChanged: (bindable, oldValue, newValue) => (bindable as AutoFormView).OnSourceChanged());
+
+    public PropertyInfo[] EditingProperties { get; protected set; } = Array.Empty<PropertyInfo>();
+
+    public IReadOnlyList<AutoFormProperty> EditingPropertyDefinitions { get; protected set; } = Array.Empty<AutoFormProperty>();
 
     public bool ShowSubmitButton { get => (bool)GetValue(ShowSubmitbuttonProperty); set => SetValue(ShowSubmitbuttonProperty, value); }
 
@@ -97,34 +113,62 @@ public class AutoFormView : FormView
         }
     }
 
-    protected Dictionary<Type, AutoFormViewOptions.EditorForType> EditorMapping { get; }
-
     protected AutoFormViewOptions Options { get; }
     public AutoFormView()
     {
         Children.Add(_itemsLayout);
 
         Options = UraniumServiceProvider.Current.GetRequiredService<IOptions<AutoFormViewOptions>>().Value;
-        EditorMapping = Options.EditorMapping;
     }
 
     protected void OnSourceChanged()
     {
         ValidationModel = Source;
 
+        EditingPropertyDefinitions = Source is null
+            ? Array.Empty<AutoFormProperty>()
+            : ResolvePropertyDefinitions().ToArray();
+        EditingProperties = EditingPropertyDefinitions
+            .Select(x => x.PropertyInfo)
+            .Where(x => x != null)
+            .ToArray();
+
+        Render();
+    }
+
+    protected virtual IEnumerable<AutoFormProperty> ResolvePropertyDefinitions()
+    {
+        if (PropertyDefinitions != null)
+        {
+            return PropertyDefinitions;
+        }
+
+        if (PropertyProvider != null)
+        {
+            return PropertyProvider(Source) ?? Enumerable.Empty<AutoFormProperty>();
+        }
+
+        if (Options.PropertyProvider != null)
+        {
+            return Options.PropertyProvider(Source) ?? Enumerable.Empty<AutoFormProperty>();
+        }
+
+        return CreatePropertyDefinitionsFromReflection();
+    }
+
+    protected virtual IEnumerable<AutoFormProperty> CreatePropertyDefinitionsFromReflection()
+    {
         var flags = BindingFlags.Public | BindingFlags.Instance;
         if (Hierarchical)
         {
             flags |= BindingFlags.FlattenHierarchy;
         }
-        var props = Source?.GetType()
+
+        return Source?.GetType()
             .GetProperties(flags)
             .Where(x => HierarchyLimitType.IsAssignableFrom(x.PropertyType))
-            .ToArray();
-
-        EditingProperties = props;
-
-        Render();
+            .Select(AutoFormProperty.FromPropertyInfo)
+            ?? Enumerable.Empty<AutoFormProperty>();
     }
 
     private void Render()
@@ -137,22 +181,31 @@ public class AutoFormView : FormView
 
         using (_itemsLayout.Batch())
         {
-            foreach (var property in EditingProperties)
+            _itemsLayout.Children.Clear();
+
+            foreach (var property in EditingPropertyDefinitions)
             {
-                var createEditor = EditorMapping.FirstOrDefault(x => x.Key.IsAssignableFrom(property.PropertyType.AsNonNullable())).Value;
-                if (createEditor != null)
+                var editor = CreateEditor(property);
+                if (editor != null)
                 {
-                    var editor = createEditor(property, Options.PropertyNameFactory, Source);
                     SetEditorValidationPath(editor, property.Name);
 
-                    foreach (var action in Options.PostEditorActions)
+                    if (property.PropertyInfo != null)
+                    {
+                        foreach (var action in Options.PostEditorActions)
+                        {
+                            action(editor, property.PropertyInfo);
+                        }
+                    }
+
+                    foreach (var action in Options.PostPropertyEditorActions)
                     {
                         action(editor, property);
                     }
 
-                    if (editor is IValidatable validatable && Options.ValidationFactory != null)
+                    if (editor is IValidatable validatable)
                     {
-                        validatable.Validations.AddRange(Options.ValidationFactory(property));
+                        validatable.Validations.AddRange(Options.CreateValidations(property));
                     }
 
                     _itemsLayout.Children.Add(editor);
@@ -174,6 +227,18 @@ public class AutoFormView : FormView
                 OnShowResetButtonChanged();
             }
         }
+    }
+
+    protected virtual View CreateEditor(AutoFormProperty property)
+    {
+        var createLegacyEditor = Options.GetLegacyEditor(property);
+        if (createLegacyEditor != null)
+        {
+            return createLegacyEditor(property.PropertyInfo, Options.PropertyNameFactory, Source);
+        }
+
+        var createEditor = Options.GetPropertyEditor(property);
+        return createEditor?.Invoke(property, Options.GetPropertyDisplayName, Source);
     }
 
     Button? submitButton;
@@ -287,6 +352,11 @@ public class AutoFormView : FormView
 
     public static View EditorForString(PropertyInfo property, Func<PropertyInfo, string> propertyNameFactory, object source)
     {
+        return EditorForString(AutoFormProperty.FromPropertyInfo(property), _ => propertyNameFactory(property), source);
+    }
+
+    public static View EditorForString(AutoFormProperty property, Func<AutoFormProperty, string> propertyNameFactory, object source)
+    {
         var editor = new Entry();
         editor.SetBinding(Entry.TextProperty, new Binding(property.Name, source: source));
 
@@ -298,6 +368,11 @@ public class AutoFormView : FormView
     }
 
     public static View EditorForNumeric(PropertyInfo property, Func<PropertyInfo, string> propertyNameFactory, object source)
+    {
+        return EditorForNumeric(AutoFormProperty.FromPropertyInfo(property), _ => propertyNameFactory(property), source);
+    }
+
+    public static View EditorForNumeric(AutoFormProperty property, Func<AutoFormProperty, string> propertyNameFactory, object source)
     {
         var editor = new Entry();
         editor.SetBinding(Entry.TextProperty, new Binding(property.Name, source: source));
@@ -312,6 +387,11 @@ public class AutoFormView : FormView
 
     public static View EditorForBoolean(PropertyInfo property, Func<PropertyInfo, string> propertyNameFactory, object source)
     {
+        return EditorForBoolean(AutoFormProperty.FromPropertyInfo(property), _ => propertyNameFactory(property), source);
+    }
+
+    public static View EditorForBoolean(AutoFormProperty property, Func<AutoFormProperty, string> propertyNameFactory, object source)
+    {
         var editor = new InputCheckBox();
         editor.SetBinding(InputCheckBox.IsCheckedProperty, new Binding(property.Name, source: source));
         editor.Text = propertyNameFactory(property);
@@ -320,6 +400,11 @@ public class AutoFormView : FormView
     }
 
     public static View EditorForEnum(PropertyInfo property, Func<PropertyInfo, string> propertyNameFactory, object source)
+    {
+        return EditorForEnum(AutoFormProperty.FromPropertyInfo(property), _ => propertyNameFactory(property), source);
+    }
+
+    public static View EditorForEnum(AutoFormProperty property, Func<AutoFormProperty, string> propertyNameFactory, object source)
     {
         var editor = new Picker();
 
@@ -341,6 +426,11 @@ public class AutoFormView : FormView
     }
 
     public static View CreateSelectionViewForValues(Array values, PropertyInfo property, Func<PropertyInfo, string> propertyNameFactory, object source)
+    {
+        return CreateSelectionViewForValues(values, AutoFormProperty.FromPropertyInfo(property), _ => propertyNameFactory(property), source);
+    }
+
+    public static View CreateSelectionViewForValues(Array values, AutoFormProperty property, Func<AutoFormProperty, string> propertyNameFactory, object source)
     {
         var shouldUseSingleColumn = values.Length > 3;
         var editor = new SelectionView
@@ -367,6 +457,11 @@ public class AutoFormView : FormView
 
     public static View EditorForKeyboard(PropertyInfo property, Func<PropertyInfo, string> propertyNameFactory, object source)
     {
+        return EditorForKeyboard(AutoFormProperty.FromPropertyInfo(property), _ => propertyNameFactory(property), source);
+    }
+
+    public static View EditorForKeyboard(AutoFormProperty property, Func<AutoFormProperty, string> propertyNameFactory, object source)
+    {
         var editor = new Picker();
 
         editor.ItemsSource = typeof(Keyboard)
@@ -386,6 +481,11 @@ public class AutoFormView : FormView
 
     public static View EditorForDateTime(PropertyInfo property, Func<PropertyInfo, string> propertyNameFactory, object source)
     {
+        return EditorForDateTime(AutoFormProperty.FromPropertyInfo(property), _ => propertyNameFactory(property), source);
+    }
+
+    public static View EditorForDateTime(AutoFormProperty property, Func<AutoFormProperty, string> propertyNameFactory, object source)
+    {
         var editor = new DatePicker();
         editor.SetBinding(DatePicker.DateProperty, new Binding(property.Name, source: source));
 
@@ -397,6 +497,11 @@ public class AutoFormView : FormView
     }
 
     public static View EditorForTimeSpan(PropertyInfo property, Func<PropertyInfo, string> propertyNameFactory, object source)
+    {
+        return EditorForTimeSpan(AutoFormProperty.FromPropertyInfo(property), _ => propertyNameFactory(property), source);
+    }
+
+    public static View EditorForTimeSpan(AutoFormProperty property, Func<AutoFormProperty, string> propertyNameFactory, object source)
     {
         var editor = new TimePicker();
         editor.SetBinding(TimePicker.TimeProperty, new Binding(property.Name, source: source));

--- a/src/UraniumUI/Options/AutoFormProperty.cs
+++ b/src/UraniumUI/Options/AutoFormProperty.cs
@@ -1,0 +1,81 @@
+using System.ComponentModel.DataAnnotations;
+using System.Reflection;
+using UraniumUI.Extensions;
+
+namespace UraniumUI.Options;
+
+public sealed class AutoFormProperty
+{
+    private readonly IReadOnlyList<Attribute> attributes;
+
+    public AutoFormProperty(
+        string name,
+        Type propertyType,
+        string displayName = null,
+        bool isNullable = false,
+        IEnumerable<Attribute> attributes = null)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(name);
+
+        Name = name;
+        PropertyType = propertyType ?? throw new ArgumentNullException(nameof(propertyType));
+        DisplayName = displayName;
+        IsNullable = isNullable;
+        this.attributes = attributes?.ToArray() ?? Array.Empty<Attribute>();
+    }
+
+    private AutoFormProperty(PropertyInfo propertyInfo)
+        : this(
+            propertyInfo.Name,
+            propertyInfo.PropertyType,
+            isNullable: propertyInfo.PropertyType.IsNullable(),
+            attributes: propertyInfo.GetCustomAttributes().OfType<Attribute>())
+    {
+        PropertyInfo = propertyInfo;
+    }
+
+    public string Name { get; }
+
+    public Type PropertyType { get; }
+
+    public string DisplayName { get; }
+
+    public bool IsNullable { get; }
+
+    public IReadOnlyList<Attribute> Attributes => attributes;
+
+    public PropertyInfo PropertyInfo { get; }
+
+    public static AutoFormProperty FromPropertyInfo(PropertyInfo propertyInfo)
+    {
+        ArgumentNullException.ThrowIfNull(propertyInfo);
+
+        return new AutoFormProperty(propertyInfo);
+    }
+
+    public TAttribute GetCustomAttribute<TAttribute>() where TAttribute : Attribute
+    {
+        return attributes.OfType<TAttribute>().FirstOrDefault();
+    }
+
+    public IEnumerable<TAttribute> GetCustomAttributes<TAttribute>() where TAttribute : Attribute
+    {
+        return attributes.OfType<TAttribute>();
+    }
+
+    public string GetDefaultDisplayName()
+    {
+        if (!string.IsNullOrWhiteSpace(DisplayName))
+        {
+            return DisplayName;
+        }
+
+        var displayAttribute = GetCustomAttribute<DisplayAttribute>();
+        if (displayAttribute != null)
+        {
+            return displayAttribute.GetName() ?? Name;
+        }
+
+        return Name;
+    }
+}

--- a/src/UraniumUI/Options/AutoFormViewOptions.cs
+++ b/src/UraniumUI/Options/AutoFormViewOptions.cs
@@ -1,19 +1,85 @@
 ﻿using InputKit.Shared.Validations;
 using System.ComponentModel.DataAnnotations;
 using System.Reflection;
+using UraniumUI.Extensions;
 
 namespace UraniumUI.Options;
 public sealed class AutoFormViewOptions
 {
     public Dictionary<Type, EditorForType> EditorMapping { get; } = new();
 
+    public Dictionary<Type, EditorForProperty> PropertyEditorMapping { get; } = new();
+
     public delegate View EditorForType(PropertyInfo property, Func<PropertyInfo, string> propertyNameFactory, object source);
+
+    public delegate View EditorForProperty(AutoFormProperty property, Func<AutoFormProperty, string> propertyNameFactory, object source);
 
     public List<Action<View, PropertyInfo>> PostEditorActions { get; } = new();
 
+    public List<Action<View, AutoFormProperty>> PostPropertyEditorActions { get; } = new();
+
     public Func<PropertyInfo, string> PropertyNameFactory { get; set; } = DefaultPropertyNameFactory;
 
+    public Func<AutoFormProperty, string> PropertyDisplayNameFactory { get; set; }
+
     public Func<PropertyInfo, IEnumerable<IValidation>> ValidationFactory { get; set; }
+
+    public Func<AutoFormProperty, IEnumerable<IValidation>> PropertyValidationFactory { get; set; }
+
+    public Func<object, IEnumerable<AutoFormProperty>> PropertyProvider { get; set; }
+
+    public string GetPropertyDisplayName(AutoFormProperty property)
+    {
+        ArgumentNullException.ThrowIfNull(property);
+
+        if (PropertyDisplayNameFactory != null)
+        {
+            return PropertyDisplayNameFactory(property);
+        }
+
+        if (property.PropertyInfo != null)
+        {
+            return PropertyNameFactory(property.PropertyInfo);
+        }
+
+        return property.GetDefaultDisplayName();
+    }
+
+    public IEnumerable<IValidation> CreateValidations(AutoFormProperty property)
+    {
+        ArgumentNullException.ThrowIfNull(property);
+
+        if (PropertyValidationFactory != null)
+        {
+            return PropertyValidationFactory(property) ?? Enumerable.Empty<IValidation>();
+        }
+
+        if (ValidationFactory != null && property.PropertyInfo != null)
+        {
+            return ValidationFactory(property.PropertyInfo) ?? Enumerable.Empty<IValidation>();
+        }
+
+        return Enumerable.Empty<IValidation>();
+    }
+
+    public EditorForProperty GetPropertyEditor(AutoFormProperty property)
+    {
+        ArgumentNullException.ThrowIfNull(property);
+
+        return PropertyEditorMapping.FirstOrDefault(x => x.Key.IsAssignableFrom(property.PropertyType.AsNonNullable())).Value;
+    }
+
+    public EditorForType GetLegacyEditor(AutoFormProperty property)
+    {
+        ArgumentNullException.ThrowIfNull(property);
+
+        if (property.PropertyInfo is null)
+        {
+            return null;
+        }
+
+        return EditorMapping.FirstOrDefault(x => x.Key.IsAssignableFrom(property.PropertyType.AsNonNullable())).Value;
+    }
 
     private static string DefaultPropertyNameFactory(PropertyInfo property)
     {

--- a/src/UraniumUI/Options/AutoFormViewOptionsExtensions.cs
+++ b/src/UraniumUI/Options/AutoFormViewOptionsExtensions.cs
@@ -16,6 +16,16 @@ public static class AutoFormViewOptionsExtensions
             options.EditorMapping[typeof(Enum)] = AutoFormView.EditorForEnum;
             options.EditorMapping[typeof(DateTime)] = AutoFormView.EditorForDateTime;
             options.EditorMapping[typeof(TimeSpan)] = AutoFormView.EditorForTimeSpan;
+
+            options.PropertyEditorMapping[typeof(string)] = AutoFormView.EditorForString;
+            options.PropertyEditorMapping[typeof(int)] = AutoFormView.EditorForNumeric;
+            options.PropertyEditorMapping[typeof(double)] = AutoFormView.EditorForNumeric;
+            options.PropertyEditorMapping[typeof(float)] = AutoFormView.EditorForNumeric;
+            options.PropertyEditorMapping[typeof(bool)] = AutoFormView.EditorForBoolean;
+            options.PropertyEditorMapping[typeof(Keyboard)] = AutoFormView.EditorForKeyboard;
+            options.PropertyEditorMapping[typeof(Enum)] = AutoFormView.EditorForEnum;
+            options.PropertyEditorMapping[typeof(DateTime)] = AutoFormView.EditorForDateTime;
+            options.PropertyEditorMapping[typeof(TimeSpan)] = AutoFormView.EditorForTimeSpan;
         });
 
         return builder;

--- a/test/UraniumUI.Tests/Controls/AutoFormView_Test.cs
+++ b/test/UraniumUI.Tests/Controls/AutoFormView_Test.cs
@@ -1,0 +1,221 @@
+using InputKit.Shared.Abstraction;
+using InputKit.Shared.Validations;
+using UraniumUI.Controls;
+using UraniumUI.Options;
+using UraniumUI.Tests.Core;
+
+namespace UraniumUI.Tests.Controls;
+
+public class AutoFormView_Test
+{
+    public AutoFormView_Test()
+    {
+        ApplicationExtensions.CreateAndSetMockApplication();
+    }
+
+    [Fact]
+    public void PropertyDefinitions_ShouldRenderDescriptorsWithoutPropertyInfo()
+    {
+        var source = new TestModel { Name = "Jane" };
+        var formView = new AutoFormView
+        {
+            ShowSubmitButton = false,
+            ShowResetButton = false,
+            PropertyDefinitions = new[]
+            {
+                new AutoFormProperty(nameof(TestModel.Name), typeof(string), "Full name")
+            },
+            Source = source
+        };
+
+        Assert.Empty(formView.EditingProperties);
+        var property = Assert.Single(formView.EditingPropertyDefinitions);
+        Assert.Null(property.PropertyInfo);
+
+        var editor = Assert.Single(GetRenderedEditors(formView));
+        var layout = Assert.IsType<VerticalStackLayout>(editor);
+        var label = Assert.IsType<Label>(layout.Children[0]);
+        var entry = Assert.IsType<Entry>(layout.Children[1]);
+
+        Assert.Equal("Full name", label.Text);
+        Assert.Equal(nameof(TestModel.Name), FormView.GetValidationPath(entry));
+    }
+
+    [Fact]
+    public void PropertyProvider_ShouldOverrideReflectionDiscovery()
+    {
+        var providerCalled = false;
+        var formView = new AutoFormView
+        {
+            ShowSubmitButton = false,
+            ShowResetButton = false,
+            PropertyProvider = source =>
+            {
+                providerCalled = true;
+                Assert.IsType<TestModel>(source);
+
+                return new[]
+                {
+                    new AutoFormProperty(nameof(TestModel.Seats), typeof(int?), "Seats", isNullable: true)
+                };
+            },
+            Source = new TestModel()
+        };
+
+        Assert.True(providerCalled);
+        Assert.Empty(formView.EditingProperties);
+        Assert.Equal(nameof(TestModel.Seats), Assert.Single(formView.EditingPropertyDefinitions).Name);
+
+        var editor = Assert.Single(GetRenderedEditors(formView));
+        var layout = Assert.IsType<VerticalStackLayout>(editor);
+        var label = Assert.IsType<Label>(layout.Children[0]);
+
+        Assert.Equal("Seats", label.Text);
+    }
+
+    [Fact]
+    public void ReflectionFallback_ShouldUseLegacyPropertyNameFactory()
+    {
+        ApplicationExtensions.CreateAndSetMockApplication(builder =>
+        {
+            builder.Services.Configure<AutoFormViewOptions>(options =>
+            {
+                options.PropertyNameFactory = property => $"Legacy {property.Name}";
+            });
+        });
+
+        var formView = new AutoFormView
+        {
+            ShowSubmitButton = false,
+            ShowResetButton = false,
+            Source = new NameOnlyModel()
+        };
+
+        Assert.NotEmpty(formView.EditingProperties);
+
+        var editor = Assert.Single(GetRenderedEditors(formView));
+        var layout = Assert.IsType<VerticalStackLayout>(editor);
+        var label = Assert.IsType<Label>(layout.Children[0]);
+
+        Assert.Equal("Legacy Name", label.Text);
+    }
+
+    [Fact]
+    public void ReflectionFallback_ShouldUseLegacyEditorMapping()
+    {
+        ApplicationExtensions.CreateAndSetMockApplication(builder =>
+        {
+            builder.Services.Configure<AutoFormViewOptions>(options =>
+            {
+                options.EditorMapping[typeof(string)] = (property, propertyNameFactory, source) => new Label
+                {
+                    Text = $"Legacy {propertyNameFactory(property)}"
+                };
+            });
+        });
+
+        var formView = new AutoFormView
+        {
+            ShowSubmitButton = false,
+            ShowResetButton = false,
+            Source = new NameOnlyModel()
+        };
+
+        var editor = Assert.Single(GetRenderedEditors(formView));
+        var label = Assert.IsType<Label>(editor);
+
+        Assert.Equal("Legacy Name", label.Text);
+    }
+
+    [Fact]
+    public void DescriptorOptions_ShouldApplyValidationAndPostEditorActions()
+    {
+        ApplicationExtensions.CreateAndSetMockApplication(builder =>
+        {
+            builder.Services.Configure<AutoFormViewOptions>(options =>
+            {
+                options.PropertyEditorMapping[typeof(string)] = (_, _, _) => new ValidatableView();
+                options.PropertyValidationFactory = property => property
+                    .GetCustomAttributes<MarkerAttribute>()
+                    .Select(attribute => new MarkerValidation(attribute.Message));
+                options.PostPropertyEditorActions.Add((view, property) => view.AutomationId = $"editor-{property.Name}");
+            });
+        });
+
+        var formView = new AutoFormView
+        {
+            ShowSubmitButton = false,
+            ShowResetButton = false,
+            PropertyDefinitions = new[]
+            {
+                new AutoFormProperty(
+                    nameof(TestModel.Name),
+                    typeof(string),
+                    attributes: new Attribute[] { new MarkerAttribute("Generated metadata") })
+            },
+            Source = new TestModel()
+        };
+
+        var field = Assert.IsType<ValidatableView>(Assert.Single(GetRenderedEditors(formView)));
+        var validation = Assert.IsType<MarkerValidation>(Assert.Single(field.Validations));
+
+        Assert.Equal("Generated metadata", validation.Message);
+        Assert.Equal("editor-Name", field.AutomationId);
+    }
+
+    private static IView[] GetRenderedEditors(AutoFormView formView)
+    {
+        return formView.ItemsLayout.Children
+            .Where(child => !ReferenceEquals(child, formView.FooterLayout))
+            .ToArray();
+    }
+
+    private sealed class TestModel
+    {
+        public string Name { get; set; }
+
+        public int? Seats { get; set; }
+    }
+
+    private sealed class NameOnlyModel
+    {
+        public string Name { get; set; }
+    }
+
+    private sealed class MarkerAttribute : Attribute
+    {
+        public MarkerAttribute(string message)
+        {
+            Message = message;
+        }
+
+        public string Message { get; }
+    }
+
+    private sealed class MarkerValidation : IValidation
+    {
+        public MarkerValidation(string message)
+        {
+            Message = message;
+        }
+
+        public string Message { get; }
+
+        public bool Validate(object value) => true;
+    }
+
+    private sealed class ValidatableView : ContentView, IValidatable
+    {
+        public List<IValidation> Validations { get; } = new();
+
+        public bool IsValid => true;
+
+        public void DisplayValidation()
+        {
+        }
+
+        public void ResetValidation()
+        {
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add `AutoFormProperty` descriptors plus `PropertyDefinitions` and `PropertyProvider` inputs for `AutoFormView`
- add descriptor-based editor, display-name, validation, and post-editor option hooks while preserving `PropertyInfo`-based fallback behavior
- update core and Material editor registrations, docs, and focused tests
- created follow-up #1074 for the later full source-generator implementation

## Automated Testing
- `dotnet test test/UraniumUI.Tests/UraniumUI.Tests.csproj --filter FullyQualifiedName~AutoFormView_Test`
- `dotnet build src/UraniumUI.Material/UraniumUI.Material.csproj -f net10.0`

Closes #682
