### PR TITLE
Fix Windows button state updates after popup close

### DIFF
--- a/src/UraniumUI/Handlers/StatefulButtonHandler.cs
+++ b/src/UraniumUI/Handlers/StatefulButtonHandler.cs
@@ -22,7 +22,15 @@ public class StatefulButtonHandler : ButtonHandler
     {
         if (VirtualView is Microsoft.Maui.Controls.View element)
         {
-            GoToState(element, CommonStates.Normal);
+            GoToStateIfConnected(element, CommonStates.Normal);
+        }
+    }
+
+    private void GoToStateIfConnected(Microsoft.Maui.Controls.View element, string state)
+    {
+        if (element.Handler == this && PlatformView is not null)
+        {
+            GoToState(element, state);
         }
     }
 
@@ -188,9 +196,17 @@ public class StatefulButtonHandler : ButtonHandler
 
     protected override void DisconnectHandler(Microsoft.UI.Xaml.Controls.Button platformView)
     {
+        platformView.PointerEntered -= NativeView_PointerEntered;
+        platformView.PointerExited -= NativeView_PointerExited;
         platformView.PointerCanceled -= NativeView_PointerCanceled;
         platformView.PointerCaptureLost -= NativeView_PointerCaptureLost;
         platformView.Unloaded -= NativeView_Unloaded;
+        platformView.RemoveHandler(
+            Microsoft.UI.Xaml.Controls.Button.PointerPressedEvent,
+            new PointerEventHandler(NativeView_PointerPressed));
+        platformView.RemoveHandler(
+            Microsoft.UI.Xaml.Controls.Button.PointerReleasedEvent,
+            new PointerEventHandler(NativeView_PointerReleased));
 
         DisconnectVirtualViewEvents();
         ResetState();
@@ -201,10 +217,8 @@ public class StatefulButtonHandler : ButtonHandler
     {
         var nativeView = base.CreatePlatformView();
 
-        var element = VirtualView as View;
-
-        nativeView.PointerEntered += (s, e) => VisualStateManager.GoToState(element, "Hover");
-        nativeView.PointerExited += (s, e) => VisualStateManager.GoToState(element, "Normal");
+        nativeView.PointerEntered += NativeView_PointerEntered;
+        nativeView.PointerExited += NativeView_PointerExited;
 
         nativeView.AddHandler(
             Microsoft.UI.Xaml.Controls.Button.PointerPressedEvent,
@@ -216,18 +230,37 @@ public class StatefulButtonHandler : ButtonHandler
 
         return nativeView;
     }
+
+    private void NativeView_PointerEntered(object sender, Microsoft.UI.Xaml.Input.PointerRoutedEventArgs e)
+    {
+        if (VirtualView is View element)
+        {
+            GoToStateIfConnected(element, "Hover");
+        }
+    }
+
+    private void NativeView_PointerExited(object sender, Microsoft.UI.Xaml.Input.PointerRoutedEventArgs e)
+    {
+        if (VirtualView is View element)
+        {
+            GoToStateIfConnected(element, "Normal");
+        }
+    }
+
     private void NativeView_PointerPressed(object sender, Microsoft.UI.Xaml.Input.PointerRoutedEventArgs e)
     {
-        var element = VirtualView as View;
-
-        VisualStateManager.GoToState(element, "Pressed");
+        if (VirtualView is View element)
+        {
+            GoToStateIfConnected(element, "Pressed");
+        }
     }
 
     private void NativeView_PointerReleased(object sender, Microsoft.UI.Xaml.Input.PointerRoutedEventArgs e)
     {
-        var element = VirtualView as View;
-
-        VisualStateManager.GoToState(element, "Normal");
+        if (VirtualView is View element)
+        {
+            GoToStateIfConnected(element, "Normal");
+        }
     }
 
     private void NativeView_PointerCanceled(object sender, Microsoft.UI.Xaml.Input.PointerRoutedEventArgs e) => ResetState();

--- a/src/UraniumUI/Handlers/StatefulButtonHandler.cs
+++ b/src/UraniumUI/Handlers/StatefulButtonHandler.cs
@@ -17,6 +17,17 @@ using Microsoft.UI.Xaml.Input;
 namespace UraniumUI.Handlers;
 public class StatefulButtonHandler : ButtonHandler
 {
+#if WINDOWS
+    private readonly PointerEventHandler pointerPressedHandler;
+    private readonly PointerEventHandler pointerReleasedHandler;
+
+    public StatefulButtonHandler()
+    {
+        pointerPressedHandler = NativeView_PointerPressed;
+        pointerReleasedHandler = NativeView_PointerReleased;
+    }
+#endif
+
     // Navigation can interrupt a press before the native release event arrives.
     private void ResetState()
     {
@@ -203,10 +214,10 @@ public class StatefulButtonHandler : ButtonHandler
         platformView.Unloaded -= NativeView_Unloaded;
         platformView.RemoveHandler(
             Microsoft.UI.Xaml.Controls.Button.PointerPressedEvent,
-            new PointerEventHandler(NativeView_PointerPressed));
+            pointerPressedHandler);
         platformView.RemoveHandler(
             Microsoft.UI.Xaml.Controls.Button.PointerReleasedEvent,
-            new PointerEventHandler(NativeView_PointerReleased));
+            pointerReleasedHandler);
 
         DisconnectVirtualViewEvents();
         ResetState();
@@ -222,11 +233,11 @@ public class StatefulButtonHandler : ButtonHandler
 
         nativeView.AddHandler(
             Microsoft.UI.Xaml.Controls.Button.PointerPressedEvent,
-            new PointerEventHandler(NativeView_PointerPressed), true);
+            pointerPressedHandler, true);
 
         nativeView.AddHandler(
             Microsoft.UI.Xaml.Controls.Button.PointerReleasedEvent,
-            new PointerEventHandler(NativeView_PointerReleased), true);
+            pointerReleasedHandler, true);
 
         return nativeView;
     }


### PR DESCRIPTION
## Summary
- prevent stale Windows pointer callbacks in `StatefulButtonHandler` from updating button visual states after handler disconnect
- unsubscribe pointer enter/exit and routed press/release handlers during disconnect
- guard state transitions so VisualState setters such as `Scale` are only applied while the button is still connected to this handler

## Automated Testing
- `dotnet build src/UraniumUI/UraniumUI.csproj -f net10.0`
- `dotnet build src/UraniumUI/UraniumUI.csproj -f net10.0-windows10.0.19041.0`
- `dotnet test test/UraniumUI.Tests/UraniumUI.Tests.csproj`

## Manual Testing
- Windows app with `.UseUraniumUI()` and CommunityToolkit.Maui popup support enabled
- Add a `Button` style with `Pressed` and `Normal` visual states that set `Scale`
- Open a CommunityToolkit popup containing `Entry` controls and OK/Cancel `Button` commands
- Close the popup from the button command using `ClosePopupAsync`
- Expected result: popup closes without `Unable to convert Microsoft.Maui.Controls.Button to Microsoft.UI.Xaml.FrameworkElement`

Closes #1081
