### PR TITLE
Fix PickerField ItemDisplayBinding from XAML

### DIFF
--- a/src/UraniumUI.Material/Controls/PickerField.cs
+++ b/src/UraniumUI.Material/Controls/PickerField.cs
@@ -263,7 +263,8 @@ public class PickerField : InputField
 
     public BindingBase ItemDisplayBinding { get => (BindingBase)GetValue(ItemDisplayBindingProperty); set => SetValue(ItemDisplayBindingProperty, value); }
 
-    public static readonly BindableProperty ItemDisplayBindingProperty = BindableProperty.Create(
+    // A field with this name makes MAUI bind the wrapper instead of passing the item binding through.
+    public static BindableProperty ItemDisplayBindingProperty { get; } = BindableProperty.Create(
         nameof(ItemDisplayBinding), typeof(BindingBase), typeof(PickerField),
         propertyChanged: (bindable, oldValue, newValue) => (bindable as PickerField).OnItemDisplayBindingChanged());
 

--- a/test/UraniumUI.Material.Tests/Controls/PickerField_Test.cs
+++ b/test/UraniumUI.Material.Tests/Controls/PickerField_Test.cs
@@ -2,6 +2,7 @@ using Shouldly;
 using System.Collections;
 using System.Collections.ObjectModel;
 using System.Linq;
+using Microsoft.Maui.Controls.Xaml;
 using UraniumUI.Material.Controls;
 using UraniumUI.Tests.Core;
 using UraniumUI.ViewExtensions;
@@ -106,6 +107,24 @@ public class PickerField_Test
         // Assert
         control.ItemDisplayBinding.ShouldBeSameAs(itemDisplayBinding);
         control.PickerView.ItemDisplayBinding.ShouldBeSameAs(itemDisplayBinding);
+    }
+
+    [Fact]
+    public void ItemDisplayBinding_ShouldPopulateItemText_WhenSetFromXaml()
+    {
+        var control = new PickerField().LoadFromXaml("""
+            <material:PickerField
+                xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+                xmlns:material="clr-namespace:UraniumUI.Material.Controls;assembly=UraniumUI.Material"
+                ItemDisplayBinding="{Binding DisplayName}" />
+            """);
+        AnimationReadyHandler.Prepare(control);
+        control.BindingContext = new TestViewModel();
+
+        control.ItemsSource = new[] { new TestItem { DisplayName = "Expected display name" } };
+
+        control.PickerView.Items.Count.ShouldBe(1);
+        control.PickerView.Items[0].ShouldBe("Expected display name");
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
- preserve `ItemDisplayBinding` as the binding value when it is assigned from XAML
- keep programmatic `ItemDisplayBindingProperty` access source-compatible
- add regression coverage that parses XAML and verifies object item display text

## Automated Testing
- `dotnet test test/UraniumUI.Material.Tests/UraniumUI.Material.Tests.csproj`
- `dotnet test test/UraniumUI.Material.Tests/UraniumUI.Material.Tests.csproj -p:MauiVersion=10.0.80 --filter FullyQualifiedName~PickerField_Test`
- `dotnet build demo/UraniumApp/UraniumApp.csproj -f net10.0-windows10.0.19041.0`

## Manual Testing
- Not run on an Android or iOS device.
- Repro: assign an object `ItemsSource`, set `ItemDisplayBinding="{Binding Descricao}"`, and open the picker.
- Expected: the popup displays each item's `Descricao` value instead of its object type name.

Closes #1090
