### PR TITLE
Fix InputField colors after runtime theme changes

### DIFF
--- a/src/UraniumUI.Material/Controls/InputField.cs
+++ b/src/UraniumUI.Material/Controls/InputField.cs
@@ -847,6 +847,11 @@ public partial class InputField : ContentView
             originalContentMargin = this.Content.Margin;
         }
 
+        if (!ReferenceEquals(Icon, themedIcon))
+        {
+            themedIcon = null;
+        }
+
         if (HasIcon)
         {
             imageIcon.Value.Source = Icon;

--- a/src/UraniumUI.Material/Controls/InputField.cs
+++ b/src/UraniumUI.Material/Controls/InputField.cs
@@ -118,6 +118,13 @@ public partial class InputField : ContentView
 
     private Color LastFontimageColor;
 
+    /// <summary>
+    /// The font icon whose color this field owns, i.e. one that had no explicit color of its own
+    /// and was given the theme-aware default. Tracked so focus changes can restore that default
+    /// as an app theme binding rather than a color frozen at focus time.
+    /// </summary>
+    private FontImageSource themedIcon;
+
     private Thickness? originalContentMargin;
 
     private bool hasValue;
@@ -381,11 +388,22 @@ public partial class InputField : ContentView
             return;
         }
 
+        var isThemedIcon = ReferenceEquals(fontImageSource, themedIcon);
+
         fontImageSource.Color = null;
 
         Dispatcher.Dispatch(() =>
         {
-            fontImageSource.Color = LastFontimageColor;
+            // Same reasoning as Content_Unfocused: an icon whose color this field owns has to get
+            // its app theme binding back, not the plain color captured when it was focused.
+            if (isThemedIcon)
+            {
+                ApplyDefaultIconColor(fontImageSource);
+            }
+            else
+            {
+                fontImageSource.Color = LastFontimageColor;
+            }
         });
     }
 #endif
@@ -543,8 +561,29 @@ public partial class InputField : ContentView
 
         if (Icon is FontImageSource fontImageSource)
         {
-            fontImageSource.Color = LastFontimageColor;
+            // Restoring the captured color as a plain value would clear the app theme binding
+            // that Content_Focused overwrote, freezing the icon at the theme it was focused in.
+            if (ReferenceEquals(fontImageSource, themedIcon))
+            {
+                ApplyDefaultIconColor(fontImageSource);
+            }
+            else
+            {
+                fontImageSource.Color = LastFontimageColor;
+            }
         }
+    }
+
+    /// <summary>
+    /// Applies the theme-aware default color to a font icon as an app theme binding, so it keeps
+    /// following light/dark changes for as long as the field owns that icon's color.
+    /// </summary>
+    protected virtual void ApplyDefaultIconColor(FontImageSource fontImageSource)
+    {
+        fontImageSource.SetAppThemeColor(
+            FontImageSource.ColorProperty,
+            ColorResource.GetColor("OnBackground", Colors.Gray),
+            ColorResource.GetColor("OnBackgroundDark", Colors.Gray));
     }
 
     private void Content_Focused(object sender, FocusEventArgs e)
@@ -564,6 +603,32 @@ public partial class InputField : ContentView
         if (Icon is FontImageSource fontImageSource && fontImageSource.Color != AccentColor)
         {
             LastFontimageColor = fontImageSource.Color?.WithAlpha(1); // To create a new instance.
+            fontImageSource.Color = AccentColor;
+        }
+    }
+
+    /// <summary>
+    /// Re-applies the accent color when a focused field's accent changes.
+    /// </summary>
+    protected virtual void OnAccentColorChanged()
+    {
+        if (Content?.IsFocused != true)
+        {
+            return;
+        }
+
+        if (border is not null)
+        {
+            border.Stroke = AccentColor;
+        }
+
+        if (labelTitle is not null)
+        {
+            labelTitle.TextColor = AccentColor;
+        }
+
+        if (Icon is FontImageSource fontImageSource)
+        {
             fontImageSource.Color = AccentColor;
         }
     }
@@ -787,13 +852,13 @@ public partial class InputField : ContentView
             imageIcon.Value.Source = Icon;
             imageIcon.Value.IsVisible = true;
 
-            if (Icon is FontImageSource font && font.Color.IsNullOrTransparent())
+            // TODO: Add IconColor bindable property.??? What if it's not FontImage?
+            // Re-theme an icon we already own even though its color is no longer transparent,
+            // otherwise reassigning the same source would hand its color back to the caller.
+            if (Icon is FontImageSource font && (font.Color.IsNullOrTransparent() || ReferenceEquals(font, themedIcon)))
             {
-                // TODO: Add IconColor bindable property.??? What if it's not FontImage?
-                font.SetAppThemeColor(
-                    FontImageSource.ColorProperty,
-                    ColorResource.GetColor("OnBackground", Colors.Gray),
-                    ColorResource.GetColor("OnBackgroundDark", Colors.Gray));
+                themedIcon = font;
+                ApplyDefaultIconColor(font);
             }
 
             if (innerGrid != null && !innerGrid.Contains(imageIcon.Value))
@@ -901,7 +966,8 @@ public partial class InputField : ContentView
         nameof(AccentColor),
         typeof(Color),
         typeof(InputField),
-        ColorResource.GetColor("Primary", "PrimaryDark", Colors.Purple));
+        ColorResource.GetColor("Primary", "PrimaryDark", Colors.Purple),
+        propertyChanged: (bindable, oldValue, newValue) => (bindable as InputField)?.OnAccentColorChanged());
 
     public Color TitleColor { get => (Color)GetValue(TitleColorProperty); set => SetValue(TitleColorProperty, value); }
 

--- a/src/UraniumUI.Material/Controls/InputField.cs
+++ b/src/UraniumUI.Material/Controls/InputField.cs
@@ -385,17 +385,25 @@ public partial class InputField : ContentView
 
     void AlignIconColor()
     {
-        if (Icon is not FontImageSource fontImageSource || LastFontimageColor.IsNullOrTransparent())
+        if (Icon is not FontImageSource fontImageSource
+            || !ReferenceEquals(fontImageSource, focusedIcon)
+            || focusedIconColor.IsNullOrTransparent())
         {
             return;
         }
 
+        var colorToRestore = focusedIconColor;
         var isThemedIcon = ReferenceEquals(fontImageSource, themedIcon);
 
         fontImageSource.Color = null;
 
         Dispatcher.Dispatch(() =>
         {
+            if (!ReferenceEquals(fontImageSource, focusedIcon))
+            {
+                return;
+            }
+
             // Same reasoning as Content_Unfocused: an icon whose color this field owns has to get
             // its app theme binding back, not the plain color captured when it was focused.
             if (isThemedIcon)
@@ -404,7 +412,7 @@ public partial class InputField : ContentView
             }
             else
             {
-                fontImageSource.Color = LastFontimageColor;
+                fontImageSource.Color = colorToRestore;
             }
         });
     }

--- a/src/UraniumUI.Material/Controls/InputField.cs
+++ b/src/UraniumUI.Material/Controls/InputField.cs
@@ -116,7 +116,9 @@ public partial class InputField : ContentView
 
     public IList<IView> Attachments { get => endIconsContainer?.Children ?? BindableAttachments; set => SetValue(AttachmentsProperty, value); }
 
-    private Color LastFontimageColor;
+    private Color focusedIconColor;
+
+    private FontImageSource focusedIcon;
 
     /// <summary>
     /// The font icon whose color this field owns, i.e. one that had no explicit color of its own
@@ -559,19 +561,48 @@ public partial class InputField : ContentView
         currentLabelTitle?.SetBinding(Label.TextColorProperty, GetRelativeBinding(nameof(TitleColor)));
         UpdateState();
 
-        if (Icon is FontImageSource fontImageSource)
+        RestoreFocusedIconColor();
+    }
+
+    private void ApplyFocusedIconColor()
+    {
+        if (Icon is not FontImageSource fontImageSource || fontImageSource.Color == AccentColor)
         {
-            // Restoring the captured color as a plain value would clear the app theme binding
-            // that Content_Focused overwrote, freezing the icon at the theme it was focused in.
-            if (ReferenceEquals(fontImageSource, themedIcon))
-            {
-                ApplyDefaultIconColor(fontImageSource);
-            }
-            else
-            {
-                fontImageSource.Color = LastFontimageColor;
-            }
+            return;
         }
+
+        if (!ReferenceEquals(fontImageSource, focusedIcon))
+        {
+            RestoreFocusedIconColor();
+            focusedIcon = fontImageSource;
+            focusedIconColor = fontImageSource.Color?.WithAlpha(1);
+        }
+
+        fontImageSource.Color = AccentColor;
+    }
+
+    private void RestoreFocusedIconColor()
+    {
+        var icon = focusedIcon;
+        if (icon is null)
+        {
+            return;
+        }
+
+        focusedIcon = null;
+
+        // Restoring the captured color as a plain value would clear the app theme binding
+        // that focus overwrote, freezing an owned icon at the theme it was focused in.
+        if (ReferenceEquals(icon, themedIcon))
+        {
+            ApplyDefaultIconColor(icon);
+        }
+        else
+        {
+            icon.Color = focusedIconColor;
+        }
+
+        focusedIconColor = null;
     }
 
     /// <summary>
@@ -600,11 +631,7 @@ public partial class InputField : ContentView
 
         UpdateState();
 
-        if (Icon is FontImageSource fontImageSource && fontImageSource.Color != AccentColor)
-        {
-            LastFontimageColor = fontImageSource.Color?.WithAlpha(1); // To create a new instance.
-            fontImageSource.Color = AccentColor;
-        }
+        ApplyFocusedIconColor();
     }
 
     /// <summary>
@@ -627,10 +654,7 @@ public partial class InputField : ContentView
             labelTitle.TextColor = AccentColor;
         }
 
-        if (Icon is FontImageSource fontImageSource)
-        {
-            fontImageSource.Color = AccentColor;
-        }
+        ApplyFocusedIconColor();
     }
 
     protected virtual bool IsContentReadOnly => false;
@@ -845,6 +869,11 @@ public partial class InputField : ContentView
         if (this.Content != null && originalContentMargin == null)
         {
             originalContentMargin = this.Content.Margin;
+        }
+
+        if (!ReferenceEquals(Icon, focusedIcon))
+        {
+            RestoreFocusedIconColor();
         }
 
         if (!ReferenceEquals(Icon, themedIcon))

--- a/src/UraniumUI/Handlers/AutoCompleteViewHandler.Android.cs
+++ b/src/UraniumUI/Handlers/AutoCompleteViewHandler.Android.cs
@@ -128,6 +128,16 @@ public partial class AutoCompleteViewHandler : ViewHandler<IAutoCompleteView, Ap
         }
     }
 
+    public static void MapTextColor(AutoCompleteViewHandler handler, AutoCompleteView view)
+    {
+        if (view.TextColor is null)
+        {
+            return;
+        }
+
+        handler.PlatformView.SetTextColor(view.TextColor.ToPlatform());
+    }
+
     public static void MapItemsSource(AutoCompleteViewHandler handler, AutoCompleteView view)
     {
         handler.SetItemsSource();

--- a/src/UraniumUI/Handlers/AutoCompleteViewHandler.Apple.cs
+++ b/src/UraniumUI/Handlers/AutoCompleteViewHandler.Apple.cs
@@ -98,6 +98,16 @@ public partial class AutoCompleteViewHandler : ViewHandler<IAutoCompleteView, UI
         }
     }
 
+    public static void MapTextColor(AutoCompleteViewHandler handler, AutoCompleteView view)
+    {
+        if (view.TextColor is null)
+        {
+            return;
+        }
+
+        handler.PlatformView.TextColor = view.TextColor.ToPlatform();
+    }
+
     public static void MapItemsSource(AutoCompleteViewHandler handler, AutoCompleteView view)
     {
         handler.SetItemsSource();

--- a/src/UraniumUI/Handlers/AutoCompleteViewHandler.Windows.cs
+++ b/src/UraniumUI/Handlers/AutoCompleteViewHandler.Windows.cs
@@ -7,6 +7,7 @@ using Microsoft.UI.Xaml.Media;
 using UraniumUI.Controls;
 
 namespace UraniumUI.Handlers;
+
 public partial class AutoCompleteViewHandler : ViewHandler<IAutoCompleteView, AutoSuggestBox>
 {
     protected override AutoSuggestBox CreatePlatformView()
@@ -89,6 +90,16 @@ public partial class AutoCompleteViewHandler : ViewHandler<IAutoCompleteView, Au
         {
             handler.PlatformView.Text = view.Text;
         }
+    }
+
+    public static void MapTextColor(AutoCompleteViewHandler handler, AutoCompleteView view)
+    {
+        if (view.TextColor is null)
+        {
+            return;
+        }
+
+        handler.PlatformView.Foreground = view.TextColor.ToPlatform();
     }
 
     public static void MapItemsSource(AutoCompleteViewHandler handler, AutoCompleteView view)

--- a/src/UraniumUI/Handlers/AutoCompleteViewHandler.cs
+++ b/src/UraniumUI/Handlers/AutoCompleteViewHandler.cs
@@ -16,6 +16,7 @@ public partial class AutoCompleteViewHandler
         => new PropertyMapper<AutoCompleteView, AutoCompleteViewHandler>(ViewHandler.ViewMapper)
         {
             [nameof(AutoCompleteView.Text)] = MapText,
+            [nameof(AutoCompleteView.TextColor)] = MapTextColor,
             [nameof(AutoCompleteView.ItemsSource)] = MapItemsSource,
             [nameof(AutoCompleteView.Threshold)] = MapThreshold,
             [nameof(AutoCompleteView.Keyboard)] = MapKeyboard,
@@ -38,6 +39,10 @@ public partial class AutoCompleteViewHandler : ViewHandler<AutoCompleteView, obj
     }
     
     public static void MapText(AutoCompleteViewHandler handler, AutoCompleteView view)
+    {
+    }
+
+    public static void MapTextColor(AutoCompleteViewHandler handler, AutoCompleteView view)
     {
     }
 

--- a/test/UraniumUI.Material.Tests/Controls/TextField_Test.cs
+++ b/test/UraniumUI.Material.Tests/Controls/TextField_Test.cs
@@ -405,6 +405,64 @@ public class TextField_Test
     }
 
     [Fact]
+    public void AccentColor_ChangedWhileFocused_ShouldRepaintFocusedVisuals()
+    {
+        var icon = new FontImageSource
+        {
+            FontFamily = "MaterialSharp",
+            Glyph = "A",
+            Color = Colors.Black,
+        };
+        var control = AnimationReadyHandler.Prepare(new TextField
+        {
+            AccentColor = Colors.Blue,
+            Icon = icon,
+        });
+        var border = control.FindByViewQueryIdInVisualTreeDescendants<Border>("Border");
+        var titleLabel = control.FindByViewQueryIdInVisualTreeDescendants<Label>("TitleLabel");
+
+        control.EntryView.SetValue(VisualElement.IsFocusedPropertyKey, true);
+        control.AccentColor = Colors.Green;
+
+        border.Stroke.ShouldBeOfType<SolidColorBrush>().Color.ShouldBe(Colors.Green);
+        titleLabel.TextColor.ShouldBe(Colors.Green);
+        icon.Color.ShouldBe(Colors.Green);
+    }
+
+    [Fact]
+    public void DefaultIconColor_ShouldResumeFollowingTheme_AfterUnfocus()
+    {
+        var originalTheme = Application.Current.UserAppTheme;
+
+        try
+        {
+            Application.Current.UserAppTheme = AppTheme.Light;
+            Application.Current.Resources["OnBackground"] = Colors.Purple;
+            Application.Current.Resources["OnBackgroundDark"] = Colors.White;
+            var icon = new FontImageSource { FontFamily = "MaterialSharp", Glyph = "A" };
+            var control = AnimationReadyHandler.Prepare(new TextField
+            {
+                AccentColor = Colors.Blue,
+                Icon = icon,
+            });
+
+            control.EntryView.SetValue(VisualElement.IsFocusedPropertyKey, true);
+            icon.Color.ShouldBe(Colors.Blue);
+
+            control.EntryView.SetValue(VisualElement.IsFocusedPropertyKey, false);
+            var colorBinding = GetBinding(icon, FontImageSource.ColorProperty);
+
+            colorBinding.GetType().Name.ShouldBe("AppThemeBinding");
+            GetAppThemeColor(colorBinding, "Light").ShouldBe(Colors.Purple);
+            GetAppThemeColor(colorBinding, "Dark").ShouldBe(Colors.White);
+        }
+        finally
+        {
+            Application.Current.UserAppTheme = originalTheme;
+        }
+    }
+
+    [Fact]
     public void TextChanges_ShouldShouldCorrectlyUpdateClearButtonVisibility()
     {
         var control = AnimationReadyHandler.Prepare(new TextField() { AllowClear = true });
@@ -846,6 +904,14 @@ public class TextField_Test
             .GetProperty(propertyName, BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic)
             .GetValue(appThemeBinding)
             .ShouldBeOfType<SolidColorBrush>();
+    }
+
+    private static Color GetAppThemeColor(object appThemeBinding, string propertyName)
+    {
+        return appThemeBinding.GetType()
+            .GetProperty(propertyName, BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic)
+            .GetValue(appThemeBinding)
+            .ShouldBeOfType<Color>();
     }
 
     private sealed class FailingValidation : IValidation

--- a/test/UraniumUI.Material.Tests/Controls/TextField_Test.cs
+++ b/test/UraniumUI.Material.Tests/Controls/TextField_Test.cs
@@ -463,6 +463,25 @@ public class TextField_Test
     }
 
     [Fact]
+    public void DefaultIcon_ReassignedWithExplicitColor_AfterReplacement_ShouldKeepExplicitColor()
+    {
+        var defaultIcon = new FontImageSource { FontFamily = "MaterialSharp", Glyph = "A" };
+        var replacementIcon = new FontImageSource
+        {
+            FontFamily = "MaterialSharp",
+            Glyph = "B",
+            Color = Colors.Green,
+        };
+        var control = AnimationReadyHandler.Prepare(new TextField { Icon = defaultIcon });
+
+        control.Icon = replacementIcon;
+        defaultIcon.Color = Colors.Red;
+        control.Icon = defaultIcon;
+
+        defaultIcon.Color.ShouldBe(Colors.Red);
+    }
+
+    [Fact]
     public void TextChanges_ShouldShouldCorrectlyUpdateClearButtonVisibility()
     {
         var control = AnimationReadyHandler.Prepare(new TextField() { AllowClear = true });

--- a/test/UraniumUI.Material.Tests/Controls/TextField_Test.cs
+++ b/test/UraniumUI.Material.Tests/Controls/TextField_Test.cs
@@ -411,7 +411,7 @@ public class TextField_Test
         {
             FontFamily = "MaterialSharp",
             Glyph = "A",
-            Color = Colors.Black,
+            Color = Colors.Blue,
         };
         var control = AnimationReadyHandler.Prepare(new TextField
         {
@@ -427,6 +427,60 @@ public class TextField_Test
         border.Stroke.ShouldBeOfType<SolidColorBrush>().Color.ShouldBe(Colors.Green);
         titleLabel.TextColor.ShouldBe(Colors.Green);
         icon.Color.ShouldBe(Colors.Green);
+
+        control.EntryView.SetValue(VisualElement.IsFocusedPropertyKey, false);
+        icon.Color.ShouldBe(Colors.Blue);
+    }
+
+    [Fact]
+    public void ExplicitIconColorMatchingAccent_ShouldRemainAfterFocusCycle()
+    {
+        var icon = new FontImageSource
+        {
+            FontFamily = "MaterialSharp",
+            Glyph = "A",
+            Color = Colors.Blue,
+        };
+        var control = AnimationReadyHandler.Prepare(new TextField
+        {
+            AccentColor = Colors.Blue,
+            Icon = icon,
+        });
+
+        control.EntryView.SetValue(VisualElement.IsFocusedPropertyKey, true);
+        control.EntryView.SetValue(VisualElement.IsFocusedPropertyKey, false);
+
+        icon.Color.ShouldBe(Colors.Blue);
+    }
+
+    [Fact]
+    public void Icon_ReplacedWhileFocused_ShouldRestorePreviousIconColor()
+    {
+        var originalIcon = new FontImageSource
+        {
+            FontFamily = "MaterialSharp",
+            Glyph = "A",
+            Color = Colors.Black,
+        };
+        var replacementIcon = new FontImageSource
+        {
+            FontFamily = "MaterialSharp",
+            Glyph = "B",
+            Color = Colors.Green,
+        };
+        var control = AnimationReadyHandler.Prepare(new TextField
+        {
+            AccentColor = Colors.Blue,
+            Icon = originalIcon,
+        });
+
+        control.EntryView.SetValue(VisualElement.IsFocusedPropertyKey, true);
+        control.Icon = replacementIcon;
+
+        originalIcon.Color.ShouldBe(Colors.Black);
+
+        control.EntryView.SetValue(VisualElement.IsFocusedPropertyKey, false);
+        replacementIcon.Color.ShouldBe(Colors.Green);
     }
 
     [Fact]

--- a/test/UraniumUI.Tests/Controls/AutoCompleteView_Test.cs
+++ b/test/UraniumUI.Tests/Controls/AutoCompleteView_Test.cs
@@ -1,0 +1,13 @@
+using UraniumUI.Controls;
+using UraniumUI.Handlers;
+
+namespace UraniumUI.Tests.Controls;
+
+public class AutoCompleteView_Test
+{
+    [Fact]
+    public void TextColor_ShouldBeRegisteredInPropertyMapper()
+    {
+        Assert.NotNull(AutoCompleteViewHandler.AutoCompleteViewMapper.GetProperty(nameof(AutoCompleteView.TextColor)));
+    }
+}


### PR DESCRIPTION
## Summary
- propagate `AutoCompleteView.TextColor` changes to Android, iOS/Mac Catalyst, and Windows platform views
- repaint focused `InputField` accents when the bound accent changes
- restore the app-theme binding for default font icon colors after focus changes
- release default-icon color ownership when the icon source changes, preserving later explicit colors
- restore explicit icon colors only when focus actually overrides that exact icon
- add regression coverage for mapper registration, focused accent updates, icon theme binding restoration, and icon replacement

## Automated Testing
- `dotnet test test/UraniumUI.Tests/UraniumUI.Tests.csproj --no-restore` (71 passed)
- `dotnet test test/UraniumUI.Material.Tests/UraniumUI.Material.Tests.csproj --no-restore` (211 passed)
- `dotnet build src/UraniumUI/UraniumUI.csproj -f net10.0-android --no-restore`
- `dotnet build src/UraniumUI/UraniumUI.csproj -f net10.0-windows10.0.19041.0 --no-restore`
- `dotnet build src/UraniumUI/UraniumUI.csproj -f net10.0-ios --no-restore`
- `dotnet build src/UraniumUI.Material/UraniumUI.Material.csproj -f net10.0-android --no-restore`

## Manual Testing
- Not run locally; this requires an Android device or emulator running a .NET MAUI 10 app.
- Display focused and unfocused Material input fields, including an `AutoCompleteTextField` and a field with a default font icon.
- Switch the Android system theme between light and dark while the autocomplete field is focused, then unfocus and refocus the fields.
- Verify that autocomplete text, focused border/title accents, and default icon colors update immediately and continue following later theme changes without rebuilding the controls.

Closes #1093