### PR TITLE
Add opened and closed events to BottomSheetView

### DIFF
--- a/docs/en/themes/material/components/BottomSheet.md
+++ b/docs/en/themes/material/components/BottomSheet.md
@@ -127,6 +127,15 @@ _It might be useful if you use bottom sheet for something like filtering the con
     </material:BottomSheetView>
 ```
 
+## Events
+
+| Event | Description |
+| --- | --- |
+| `Opened` | Raised when `IsPresented` changes to `true`. |
+| `Closed` | Raised when `IsPresented` changes to `false`, including when the sheet is dismissed by tapping outside it. |
+
+These events report the presentation state change; they do not wait for the open or close animation to finish.
+
 ## Accessibility
 
 Bottom sheets behave like temporary surfaces. Provide a visible heading inside the sheet, keep actions as buttons or focusable UraniumUI controls, and avoid using a passive layout with only `TapGestureRecognizer` for close, submit, or navigation actions.

--- a/src/UraniumUI.Material/Attachments/BottomSheetView.BindableProperties.cs
+++ b/src/UraniumUI.Material/Attachments/BottomSheetView.BindableProperties.cs
@@ -5,7 +5,7 @@ public partial class BottomSheetView
 
     public static readonly BindableProperty IsPresentedProperty =
         BindableProperty.Create(nameof(IsPresented), typeof(bool), typeof(BottomSheetView), defaultValue: false, defaultBindingMode: BindingMode.TwoWay,
-            propertyChanged: (bo, ov, nv) => (bo as BottomSheetView).AlignBottomSheet());
+            propertyChanged: (bo, ov, nv) => (bo as BottomSheetView).OnIsPresentedChanged((bool)ov, (bool)nv));
 
     public bool DisablePageWhenOpened { get => (bool)GetValue(DisablePageWhenOpenedProperty); set => SetValue(DisablePageWhenOpenedProperty, value); }
 

--- a/src/UraniumUI.Material/Attachments/BottomSheetView.cs
+++ b/src/UraniumUI.Material/Attachments/BottomSheetView.cs
@@ -16,6 +16,10 @@ public partial class BottomSheetView : Border, IPageAttachment
 
     public View Header { get; set; }
 
+    public event EventHandler Opened;
+
+    public event EventHandler Closed;
+
     private TapGestureRecognizer closeGestureRecognizer = new();
     private bool isGeneratedHeader;
 
@@ -86,6 +90,25 @@ public partial class BottomSheetView : Border, IPageAttachment
         IsPresented = !IsPresented;
     }
 
+    private void OnIsPresentedChanged(bool oldValue, bool newValue)
+    {
+        AlignBottomSheet();
+
+        if (oldValue == newValue)
+        {
+            return;
+        }
+
+        if (newValue)
+        {
+            OnOpened();
+        }
+        else
+        {
+            OnClosed();
+        }
+    }
+
     protected virtual View GenerateAnchor()
     {
         var anchor = new StatefulContentView
@@ -124,6 +147,8 @@ public partial class BottomSheetView : Border, IPageAttachment
         {
             AttachedPage?.ContentFrame?.GestureRecognizers.Add(closeGestureRecognizer);
         }
+
+        Opened?.Invoke(this, EventArgs.Empty);
     }
 
     protected virtual void OnClosed()
@@ -132,6 +157,8 @@ public partial class BottomSheetView : Border, IPageAttachment
         {
             AttachedPage?.ContentFrame?.GestureRecognizers.Remove(closeGestureRecognizer);
         }
+
+        Closed?.Invoke(this, EventArgs.Empty);
     }
 
     private void PanGestureRecognizer_PanUpdated(object sender, PanUpdatedEventArgs e)
@@ -167,11 +194,6 @@ public partial class BottomSheetView : Border, IPageAttachment
         if (IsPresented)
         {
             y = 0;
-            OnOpened();
-        }
-        else
-        {
-            OnClosed();
         }
 
         if (animate)

--- a/src/UraniumUI.Material/Attachments/BottomSheetView.cs
+++ b/src/UraniumUI.Material/Attachments/BottomSheetView.cs
@@ -33,6 +33,9 @@ public partial class BottomSheetView : Border, IPageAttachment
         {
             Body.SizeChanged += BottomSheetContent_SizeChanged;
         }
+
+        AlignBottomSheet(false);
+        UpdateTapOutsideGestureRecognizer();
     }
 
     private void BottomSheetContent_SizeChanged(object sender, EventArgs e)
@@ -92,7 +95,10 @@ public partial class BottomSheetView : Border, IPageAttachment
 
     private void OnIsPresentedChanged(bool oldValue, bool newValue)
     {
-        AlignBottomSheet();
+        if (Header is not null)
+        {
+            AlignBottomSheet();
+        }
 
         if (oldValue == newValue)
         {
@@ -143,22 +149,37 @@ public partial class BottomSheetView : Border, IPageAttachment
 
     protected virtual void OnOpened()
     {
-        if (CloseOnTapOutside)
-        {
-            AttachedPage?.ContentFrame?.GestureRecognizers.Add(closeGestureRecognizer);
-        }
+        UpdateTapOutsideGestureRecognizer();
 
         Opened?.Invoke(this, EventArgs.Empty);
     }
 
     protected virtual void OnClosed()
     {
-        if (CloseOnTapOutside)
-        {
-            AttachedPage?.ContentFrame?.GestureRecognizers.Remove(closeGestureRecognizer);
-        }
+        UpdateTapOutsideGestureRecognizer();
 
         Closed?.Invoke(this, EventArgs.Empty);
+    }
+
+    private void UpdateTapOutsideGestureRecognizer()
+    {
+        var gestureRecognizers = AttachedPage?.ContentFrame?.GestureRecognizers;
+        if (gestureRecognizers is null)
+        {
+            return;
+        }
+
+        if (IsPresented && CloseOnTapOutside)
+        {
+            if (!gestureRecognizers.Contains(closeGestureRecognizer))
+            {
+                gestureRecognizers.Add(closeGestureRecognizer);
+            }
+        }
+        else
+        {
+            gestureRecognizers.Remove(closeGestureRecognizer);
+        }
     }
 
     private void PanGestureRecognizer_PanUpdated(object sender, PanUpdatedEventArgs e)

--- a/test/UraniumUI.Material.Tests/Attachments/BottomSheetView_Test.cs
+++ b/test/UraniumUI.Material.Tests/Attachments/BottomSheetView_Test.cs
@@ -141,6 +141,31 @@ public class BottomSheetView_Test
         page.ContentFrame.GestureRecognizers.ShouldBeEmpty();
     }
 
+    [Fact]
+    public void InitiallyPresentedSheet_ShouldRegisterTapOutsideAfterAttachment()
+    {
+        var page = new UraniumContentPage { Body = new Label() };
+        var control = AnimationReadyHandler.Prepare(new BottomSheetView
+        {
+            Body = AnimationReadyHandler.Prepare(new BoxView()),
+            DisablePageWhenOpened = false,
+            IsPresented = true,
+        });
+        var closedCount = 0;
+        control.Closed += (_, _) => closedCount++;
+
+        page.Attachments.Add(control);
+
+        var closeGesture = page.ContentFrame.GestureRecognizers.ShouldHaveSingleItem().ShouldBeOfType<TapGestureRecognizer>();
+        var sendTapped = typeof(TapGestureRecognizer).GetMethod("SendTapped", BindingFlags.Instance | BindingFlags.NonPublic);
+        sendTapped.ShouldNotBeNull();
+        sendTapped.Invoke(closeGesture, new object[] { page.ContentFrame, null });
+
+        control.IsPresented.ShouldBeFalse();
+        closedCount.ShouldBe(1);
+        page.ContentFrame.GestureRecognizers.ShouldBeEmpty();
+    }
+
     private static void SetFrame(VisualElement element, double width, double height)
     {
         var frameProperty = typeof(VisualElement).GetProperty("Frame", BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic);

--- a/test/UraniumUI.Material.Tests/Attachments/BottomSheetView_Test.cs
+++ b/test/UraniumUI.Material.Tests/Attachments/BottomSheetView_Test.cs
@@ -72,6 +72,75 @@ public class BottomSheetView_Test
         control.TranslationY.ShouldBe(240);
     }
 
+    [Fact]
+    public void PresentationEvents_ShouldOnlyBeRaisedOnStateChanges()
+    {
+        var header = AnimationReadyHandler.Prepare(new Border());
+        var control = AnimationReadyHandler.Prepare(new BottomSheetView
+        {
+            Header = header,
+            Body = AnimationReadyHandler.Prepare(new BoxView()),
+            CloseOnTapOutside = false,
+            DisablePageWhenOpened = false,
+        });
+        control.OnAttached(new UraniumContentPage());
+        SetFrame(control, 100, 300);
+        var openedCount = 0;
+        var closedCount = 0;
+        control.Opened += (_, _) => openedCount++;
+        control.Closed += (_, _) => closedCount++;
+
+        control.IsPresented = true;
+
+        openedCount.ShouldBe(1);
+        closedCount.ShouldBe(0);
+
+#pragma warning disable CS0618
+        header.Layout(new Rect(0, 0, 100, 60));
+#pragma warning restore CS0618
+
+        openedCount.ShouldBe(1);
+        closedCount.ShouldBe(0);
+
+        control.IsPresented = false;
+
+        openedCount.ShouldBe(1);
+        closedCount.ShouldBe(1);
+
+#pragma warning disable CS0618
+        header.Layout(new Rect(0, 0, 100, 80));
+#pragma warning restore CS0618
+
+        openedCount.ShouldBe(1);
+        closedCount.ShouldBe(1);
+    }
+
+    [Fact]
+    public void TapOutside_ShouldRaiseClosed()
+    {
+        var page = new UraniumContentPage { Body = new Label() };
+        var control = AnimationReadyHandler.Prepare(new BottomSheetView
+        {
+            Header = AnimationReadyHandler.Prepare(new Border()),
+            Body = AnimationReadyHandler.Prepare(new BoxView()),
+            DisablePageWhenOpened = false,
+        });
+        page.Attachments.Add(control);
+        var closedCount = 0;
+        control.Closed += (_, _) => closedCount++;
+
+        control.IsPresented = true;
+
+        var closeGesture = page.ContentFrame.GestureRecognizers.ShouldHaveSingleItem().ShouldBeOfType<TapGestureRecognizer>();
+        var sendTapped = typeof(TapGestureRecognizer).GetMethod("SendTapped", BindingFlags.Instance | BindingFlags.NonPublic);
+        sendTapped.ShouldNotBeNull();
+        sendTapped.Invoke(closeGesture, new object[] { page.ContentFrame, null });
+
+        control.IsPresented.ShouldBeFalse();
+        closedCount.ShouldBe(1);
+        page.ContentFrame.GestureRecognizers.ShouldBeEmpty();
+    }
+
     private static void SetFrame(VisualElement element, double width, double height)
     {
         var frameProperty = typeof(VisualElement).GetProperty("Frame", BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic);


### PR DESCRIPTION
## Summary
- add `Opened` and `Closed` events that fire only when `IsPresented` changes
- keep tap-outside dismissal synchronized when a presented sheet is attached
- document event timing and dismissal behavior

## Automated Testing
- `dotnet test test/UraniumUI.Material.Tests/UraniumUI.Material.Tests.csproj --no-restore` (209 passed)

## Manual Testing
- Not run on a device in this environment.
- On Android or iOS, start with an open bottom sheet, tap outside it, and verify that the sheet closes and `Closed` fires once.
- Reopen and close the sheet through its header or drag gesture, and verify that `Opened` and `Closed` each fire once per state transition.

Closes #636.
