### PR TITLE
Make TimePickerField.Time nullable (TimeSpan?)

### DIFF
--- a/src/UraniumUI.Material/Controls/TimePickerField.cs
+++ b/src/UraniumUI.Material/Controls/TimePickerField.cs
@@ -1,4 +1,4 @@
-﻿using Plainer.Maui.Controls;
+using Plainer.Maui.Controls;
 using System.ComponentModel;
 using UraniumUI.Controls;
 using UraniumUI.Pages;
@@ -76,11 +76,7 @@ public class TimePickerField : InputField
     {
         if (IsEnabled)
         {
-            // Workaround for the selecting the same time again:
-            TimePickerView.Time += TimeSpan.FromSeconds(1);
-            // End of workaround
-
-            Time = (TimeSpan)TimePicker.TimeProperty.DefaultValue;
+            Time = null;
         }
     }
 
@@ -137,14 +133,15 @@ public class TimePickerField : InputField
 
     public override void ResetValidation()
     {
-        Time = (TimeSpan)TimePicker.TimeProperty.DefaultValue;
+        Time = null;
         base.ResetValidation();
     }
 
-    public TimeSpan Time { get => (TimeSpan)GetValue(TimeProperty); set => SetValue(TimeProperty, value); }
+    public TimeSpan? Time { get => (TimeSpan?)GetValue(TimeProperty); set => SetValue(TimeProperty, value); }
 
     public static readonly BindableProperty TimeProperty = BindableProperty.Create(
-        nameof(Time), typeof(TimeSpan), typeof(TimePickerField), TimePicker.TimeProperty.DefaultValue, defaultBindingMode: BindingMode.TwoWay,
+        nameof(Time), typeof(TimeSpan?), typeof(TimePickerField),
+        defaultValue: null, defaultBindingMode: BindingMode.TwoWay,
             propertyChanged: (bindable, oldValue, newValue) => (bindable as TimePickerField).OnTimeChanged());
 
     public string Format { get => (string)GetValue(FormatProperty); set => SetValue(FormatProperty, value); }

--- a/test/UraniumUI.Material.Tests/Controls/TimePickerField_Test.cs
+++ b/test/UraniumUI.Material.Tests/Controls/TimePickerField_Test.cs
@@ -1,4 +1,4 @@
-﻿using Shouldly;
+using Shouldly;
 using UraniumUI.Material.Controls;
 using UraniumUI.Tests.Core;
 using UraniumUI.Views;
@@ -194,9 +194,96 @@ public class TimePickerField_Test
         SemanticProperties.GetHint(clearIcon).ShouldBe("Clears the selected time.");
     }
 
-    public class TestViewModel : UraniumBindableObject
+    [Fact]
+    public void Time_Binding_ShouldSupportNonNullableTimeSpan()
+    {
+        var control = AnimationReadyHandler.Prepare(new TimePickerField());
+        var viewModel = new NonNullableTimeViewModel { Time = TimeSpan.FromHours(2) };
+        control.BindingContext = viewModel;
+        control.SetBinding(TimePickerField.TimeProperty, new Binding(nameof(NonNullableTimeViewModel.Time)));
+
+        // Assert source to control binding.
+        control.Time.ShouldBe(viewModel.Time);
+
+        // Act
+        control.Time = TimeSpan.Parse("09:05");
+
+        // Assert control to source binding.
+        viewModel.Time.ShouldBe(control.Time.Value);
+    }
+
+    [Fact]
+    public void Time_Binding_ShouldAcceptNull_FromSource()
+    {
+        var control = AnimationReadyHandler.Prepare(new TimePickerField());
+        var viewModel = new TestViewModel { Time = null };
+        control.BindingContext = viewModel;
+
+        // Act
+        control.SetBinding(TimePickerField.TimeProperty, new Binding(nameof(TestViewModel.Time)));
+
+        // Assert
+        control.Time.ShouldBeNull();
+        control.HasValue.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void Time_Binding_ShouldAcceptNull_ToSource()
+    {
+        var control = AnimationReadyHandler.Prepare(new TimePickerField());
+        var viewModel = new TestViewModel { Time = TimeSpan.FromHours(2) };
+        control.BindingContext = viewModel;
+        control.SetBinding(TimePickerField.TimeProperty, new Binding(nameof(TestViewModel.Time)));
+
+        // Act
+        control.Time = null;
+
+        // Assert
+        viewModel.Time.ShouldBeNull();
+        control.HasValue.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void Clear_ShouldSetTimeToNull()
+    {
+        var control = AnimationReadyHandler.Prepare(new TestTimePickerField());
+        control.Time = TimeSpan.FromHours(2);
+
+        // Act
+        control.Clear();
+
+        // Assert
+        control.Time.ShouldBeNull();
+        control.HasValue.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void TimePickerView_UserSelection_ShouldUpdateTime()
+    {
+        var control = AnimationReadyHandler.Prepare(new TimePickerField());
+
+        // Act
+        control.TimePickerView.Time = TimeSpan.FromHours(3);
+
+        // Assert
+        control.Time.ShouldBe(TimeSpan.FromHours(3));
+    }
+
+    private class TestTimePickerField : TimePickerField
+    {
+        public void Clear() => OnClearTapped(null);
+    }
+
+    private class NonNullableTimeViewModel : UraniumBindableObject
     {
         private TimeSpan time;
+
+        public TimeSpan Time { get => time; set => SetProperty(ref time, value); }
+    }
+
+    public class TestViewModel : UraniumBindableObject
+    {
+        private TimeSpan? time;
         private string format;
         private Color textColor;
         private double characterSpacing;
@@ -204,7 +291,7 @@ public class TimePickerField_Test
         private string fontFamily;
         private double fontSize;
 
-        public TimeSpan Time { get => time; set => SetProperty(ref time, value); }
+        public TimeSpan? Time { get => time; set => SetProperty(ref time, value); }
 
         public string Format { get => format; set => SetProperty(ref format, value); }
 


### PR DESCRIPTION
Closes #1108.

- `Time` bindable property → `TimeSpan?`, default `null` (was `TimeSpan.Zero`).
- The clear button sets `Time = null` (removes the reset-to-zero workaround); `ResetValidation` also clears to `null`.
- The inner `TimePicker` binding is unchanged — since .NET MAUI 10, `TimePicker.Time` is already `TimeSpan?`, so null flows through the existing two-way binding.
- Tests mirrored from the `DatePickerField` nullable tests: null round-trip both directions, clear → null, non-nullable source still binds. Full suite passes.

**Why default `null` and not `TimePicker.TimeProperty.DefaultValue`:** MAUI 10 made `TimePicker.Time` nullable but kept its default at `new TimeSpan(0)` — presumably backward compatibility, since `Time` was non-nullable before dotnet/maui#27921 — while `DatePicker.Date` defaults to `null`. That asymmetry lives in MAUI itself. This PR intentionally does not mirror it: the field defaults to `null` so an untouched optional field renders empty instead of claiming `00:00` was picked, and so `TimePickerField` matches `DatePickerField.Date`'s default within this library. The field's binding overwrites the inner picker's `TimeSpan.Zero` at attach, so field and inner picker never disagree.

Behavior when null: the field renders empty; opening the dialog preselects 00:00 (platform default); Cancel keeps null. Matches `DatePickerField`'s nullable `Date` semantics.

Breaking-change note: consumers binding a non-nullable `TimeSpan` keep working (value conversion is unchanged); only code reading `Time` as `TimeSpan` needs a null check — the same migration v3 already asked for on `DatePickerField.Date`.
