### PR TITLE
Add opt-in native picker mode to DatePickerField

### DIFF
--- a/docs/en/themes/material/components/DatePickerField.md
+++ b/docs/en/themes/material/components/DatePickerField.md
@@ -1,5 +1,5 @@
 # DatePickerField
-DatePickerField is a control that allows users to select a date. By default it embeds the platform date picker, matching `TimePickerField`'s dialog; setting `UseNativePicker` to `false` opens the UraniumUI date prompt backed by the custom `CalendarView` instead. Nullable dates, clear, and same-date reselection behave consistently in both modes.
+DatePickerField is a control that allows users to select a date. By default it opens the UraniumUI date prompt backed by the custom `CalendarView`. Set `UseNativePicker` to `true` to embed the platform date picker instead. Nullable dates, clear, and same-date reselection behave consistently in both modes.
 
 - [Material Design Date Pickers](https://material.io/components/date-pickers)
 
@@ -56,10 +56,10 @@ Clearing the field sets `Date` to `null`. `Date`, `MinimumDate`, and `MaximumDat
 | ![MAUI Material Input](../../../../images/datepickerfield-allowclear-dark-android.gif) | ![MAUI Material Input](../../../../images/datepickerfield-allowclear-light-android.gif) |
 
 ## UseNativePicker
-DatePickerField can either embed the platform date picker (default) or open the UraniumUI calendar prompt. Set `UseNativePicker` to `false` to use the calendar prompt backed by `CalendarView`.
+DatePickerField opens the UraniumUI calendar prompt by default. Set `UseNativePicker` to `true` to embed the platform date picker instead.
 
 ```xml
-<material:DatePickerField Title="Pick a Date" UseNativePicker="False" />
+<material:DatePickerField Title="Pick a Date" UseNativePicker="True" />
 ```
 
 The platform picker gives `DatePickerField` and `TimePickerField` the same look and feel on each platform. The calendar prompt renders the same UraniumUI calendar on every platform instead. `MinimumDate` and `MaximumDate` are honored in both modes.

--- a/docs/en/themes/material/components/DatePickerField.md
+++ b/docs/en/themes/material/components/DatePickerField.md
@@ -1,5 +1,5 @@
 # DatePickerField
-DatePickerField is a control that allows users to select a date. It opens the UraniumUI date prompt backed by the custom `CalendarView`, so nullable dates, clear, and same-date reselection behave consistently across platforms.
+DatePickerField is a control that allows users to select a date. By default it embeds the platform date picker, matching `TimePickerField`'s dialog; setting `UseNativePicker` to `false` opens the UraniumUI date prompt backed by the custom `CalendarView` instead. Nullable dates, clear, and same-date reselection behave consistently in both modes.
 
 - [Material Design Date Pickers](https://material.io/components/date-pickers)
 
@@ -54,6 +54,15 @@ Clearing the field sets `Date` to `null`. `Date`, `MinimumDate`, and `MaximumDat
 | Dark | Light|
 | --- | --- |
 | ![MAUI Material Input](../../../../images/datepickerfield-allowclear-dark-android.gif) | ![MAUI Material Input](../../../../images/datepickerfield-allowclear-light-android.gif) |
+
+## UseNativePicker
+DatePickerField can either embed the platform date picker (default) or open the UraniumUI calendar prompt. Set `UseNativePicker` to `false` to use the calendar prompt backed by `CalendarView`.
+
+```xml
+<material:DatePickerField Title="Pick a Date" UseNativePicker="False" />
+```
+
+The platform picker gives `DatePickerField` and `TimePickerField` the same look and feel on each platform. The calendar prompt renders the same UraniumUI calendar on every platform instead. `MinimumDate` and `MaximumDate` are honored in both modes.
 
 ## Accessibility
 

--- a/src/UraniumUI.Material/Controls/DatePickerField.cs
+++ b/src/UraniumUI.Material/Controls/DatePickerField.cs
@@ -14,6 +14,7 @@ namespace UraniumUI.Material.Controls;
 public class DatePickerField : InputField
 {
     private bool isDatePromptOpen;
+    private readonly Label promptLabel;
 
     public DatePickerView DatePickerView { get; } = new DatePickerView
     {
@@ -52,6 +53,7 @@ public class DatePickerField : InputField
     public DatePickerField()
     {
         base.RegisterForEvents();
+        promptLabel = (Label)Content;
         iconClear.TappedCommand = new Command(OnClearTapped);
         SetActionSemantics(iconClear, AccessibilityOptions.ClearDateDescription, AccessibilityOptions.ClearDateHint);
         SemanticProperties.SetHint(Content, AccessibilityOptions.OpenDatePickerHint);
@@ -63,6 +65,36 @@ public class DatePickerField : InputField
         });
 
         UpdateClearIconState();
+        ApplyPickerMode();
+    }
+
+    protected virtual void OnUseNativePickerChanged()
+    {
+        ApplyPickerMode();
+    }
+
+    private void ApplyPickerMode()
+    {
+        if (UseNativePicker)
+        {
+            DatePickerView.Opacity = 1;
+            DatePickerView.SetBinding(DatePicker.DateProperty, new Binding(nameof(Date), source: this, mode: BindingMode.TwoWay));
+            Content = DatePickerView;
+        }
+        else
+        {
+            DatePickerView.RemoveBinding(DatePicker.DateProperty);
+            DatePickerView.Opacity = 0;
+            Content = promptLabel;
+            UpdateDateText();
+            UpdateDatePickerViewDate();
+        }
+
+        // Binding refreshes ride on the dispatcher; without one (constructor in unit tests) the swap is picked up when the template binds.
+        if (Microsoft.Maui.Dispatching.Dispatcher.GetForCurrentThread() is not null)
+        {
+            OnPropertyChanged(nameof(Content));
+        }
     }
 
     protected Label DateLabel => Content as Label;
@@ -147,14 +179,20 @@ public class DatePickerField : InputField
 
     protected virtual void UpdateDateText()
     {
-        if (DateLabel is not null)
+        // Runs from the base ctor's template apply, before promptLabel is assigned.
+        if (promptLabel is not null)
         {
-            DateLabel.Text = Date?.ToString(Format, CultureInfo.CurrentCulture) ?? string.Empty;
+            promptLabel.Text = Date?.ToString(Format, CultureInfo.CurrentCulture) ?? string.Empty;
         }
     }
 
     protected virtual void UpdateDatePickerViewDate()
     {
+        if (UseNativePicker)
+        {
+            return; // The two-way binding owns the native picker's date; a fallback write would fight a pending null.
+        }
+
         var date = (Date ?? GetDatePickerViewFallbackDate()).Date;
 
         if (MinimumDate.HasValue && date < MinimumDate.Value.Date)
@@ -254,7 +292,7 @@ public class DatePickerField : InputField
         {
             var datePickerField = bindable as DatePickerField;
             datePickerField.DatePickerView.TextColor = (Color)newValue;
-            datePickerField.DateLabel?.SetValue(Label.TextColorProperty, newValue);
+            datePickerField.promptLabel?.SetValue(Label.TextColorProperty, newValue);
         });
 
     public double CharacterSpacing { get => (double)GetValue(CharacterSpacingProperty); set => SetValue(CharacterSpacingProperty, value); }
@@ -265,7 +303,7 @@ public class DatePickerField : InputField
         {
             var datePickerField = bindable as DatePickerField;
             datePickerField.DatePickerView.CharacterSpacing = (double)newValue;
-            datePickerField.DateLabel?.SetValue(Label.CharacterSpacingProperty, newValue);
+            datePickerField.promptLabel?.SetValue(Label.CharacterSpacingProperty, newValue);
         });
 
     public FontAttributes FontAttributes { get => (FontAttributes)GetValue(FontAttributesProperty); set => SetValue(FontAttributesProperty, value); }
@@ -276,7 +314,7 @@ public class DatePickerField : InputField
         {
             var datePickerField = bindable as DatePickerField;
             datePickerField.DatePickerView.FontAttributes = (FontAttributes)newValue;
-            datePickerField.DateLabel?.SetValue(Label.FontAttributesProperty, newValue);
+            datePickerField.promptLabel?.SetValue(Label.FontAttributesProperty, newValue);
         });
 
     public string FontFamily { get => (string)GetValue(FontFamilyProperty); set => SetValue(FontFamilyProperty, value); }
@@ -287,7 +325,7 @@ public class DatePickerField : InputField
         {
             var datePickerField = bindable as DatePickerField;
             datePickerField.DatePickerView.FontFamily = (string)newValue;
-            datePickerField.DateLabel?.SetValue(Label.FontFamilyProperty, newValue);
+            datePickerField.promptLabel?.SetValue(Label.FontFamilyProperty, newValue);
         });
 
     [TypeConverter(typeof(FontSizeConverter))]
@@ -299,7 +337,7 @@ public class DatePickerField : InputField
         {
             var datePickerField = bindable as DatePickerField;
             datePickerField.DatePickerView.FontSize = (double)newValue;
-            datePickerField.DateLabel?.SetValue(Label.FontSizeProperty, newValue);
+            datePickerField.promptLabel?.SetValue(Label.FontSizeProperty, newValue);
         });
 
     public bool FontAutoScalingEnabled { get => (bool)GetValue(FontAutoScalingEnabledProperty); set => SetValue(FontAutoScalingEnabledProperty, value); }
@@ -310,7 +348,7 @@ public class DatePickerField : InputField
         {
             var datePickerField = bindable as DatePickerField;
             datePickerField.DatePickerView.FontAutoScalingEnabled = (bool)newValue;
-            datePickerField.DateLabel?.SetValue(Label.FontAutoScalingEnabledProperty, newValue);
+            datePickerField.promptLabel?.SetValue(Label.FontAutoScalingEnabledProperty, newValue);
         });
     public bool AllowClear { get => (bool)GetValue(AllowClearProperty); set => SetValue(AllowClearProperty, value); }
 
@@ -319,4 +357,16 @@ public class DatePickerField : InputField
         typeof(bool), typeof(DatePickerField),
         true,
         propertyChanged: (bindable, oldValue, newValue) => (bindable as DatePickerField).OnAllowClearChanged());
+
+    /// <summary>
+    /// Whether the field embeds the platform date picker (matching TimePickerField's dialog) or
+    /// shows a label that opens the calendar prompt via <see cref="IDialogService"/>.
+    /// </summary>
+    public bool UseNativePicker { get => (bool)GetValue(UseNativePickerProperty); set => SetValue(UseNativePickerProperty, value); }
+
+    public static readonly BindableProperty UseNativePickerProperty = BindableProperty.Create(
+        nameof(UseNativePicker),
+        typeof(bool), typeof(DatePickerField),
+        true,
+        propertyChanged: (bindable, oldValue, newValue) => (bindable as DatePickerField).OnUseNativePickerChanged());
 }

--- a/src/UraniumUI.Material/Controls/DatePickerField.cs
+++ b/src/UraniumUI.Material/Controls/DatePickerField.cs
@@ -81,19 +81,18 @@ public class DatePickerField : InputField
 
         if (UseNativePicker)
         {
-            DatePickerView.Opacity = 1;
             DatePickerView.SetBinding(DatePicker.DateProperty, new Binding(nameof(Date), source: this, mode: BindingMode.TwoWay));
             Content = DatePickerView;
         }
         else
         {
             DatePickerView.RemoveBinding(DatePicker.DateProperty);
-            DatePickerView.Opacity = 0;
             Content = promptLabel;
             UpdateDateText();
             UpdateDatePickerViewDate();
         }
 
+        UpdateDatePickerOpacity();
         RegisterForEvents();
         UpdateContentSemantics();
 
@@ -150,6 +149,7 @@ public class DatePickerField : InputField
         CheckAndShowValidations();
         UpdateDateText();
         UpdateDatePickerViewDate();
+        UpdateDatePickerOpacity();
 
         if (AllowClear)
         {
@@ -157,6 +157,11 @@ public class DatePickerField : InputField
         }
 
         UpdateState();
+    }
+
+    private void UpdateDatePickerOpacity()
+    {
+        DatePickerView.Opacity = UseNativePicker && Date is not null ? 1 : 0;
     }
 
     protected override void OnIconChanged()

--- a/src/UraniumUI.Material/Controls/DatePickerField.cs
+++ b/src/UraniumUI.Material/Controls/DatePickerField.cs
@@ -379,6 +379,6 @@ public class DatePickerField : InputField
     public static readonly BindableProperty UseNativePickerProperty = BindableProperty.Create(
         nameof(UseNativePicker),
         typeof(bool), typeof(DatePickerField),
-        true,
+        false,
         propertyChanged: (bindable, oldValue, newValue) => (bindable as DatePickerField).OnUseNativePickerChanged());
 }

--- a/src/UraniumUI.Material/Controls/DatePickerField.cs
+++ b/src/UraniumUI.Material/Controls/DatePickerField.cs
@@ -56,10 +56,11 @@ public class DatePickerField : InputField
         promptLabel = (Label)Content;
         iconClear.TappedCommand = new Command(OnClearTapped);
         SetActionSemantics(iconClear, AccessibilityOptions.ClearDateDescription, AccessibilityOptions.ClearDateHint);
-        SemanticProperties.SetHint(Content, AccessibilityOptions.OpenDatePickerHint);
+        SemanticProperties.SetHint(promptLabel, AccessibilityOptions.OpenDatePickerHint);
+        SemanticProperties.SetHint(DatePickerView, AccessibilityOptions.OpenDatePickerHint);
         DialogService = UraniumServiceProvider.Current.GetRequiredService<IDialogService>();
 
-        Content.GestureRecognizers.Add(new TapGestureRecognizer
+        promptLabel.GestureRecognizers.Add(new TapGestureRecognizer
         {
             Command = new Command(async () => await OpenDatePromptAsync())
         });
@@ -73,9 +74,9 @@ public class DatePickerField : InputField
         ApplyPickerMode();
     }
 
-    private void ApplyPickerMode
+    private void ApplyPickerMode()
     {
-        // Ensure InputField hooks (focus visuals, semantics) are attached to the currently active content.
+        // Content is an auto-property override here, so InputField's bindable-property hooks never see the swap.
         ReleaseEvents();
 
         if (UseNativePicker)
@@ -93,7 +94,6 @@ public class DatePickerField : InputField
             UpdateDatePickerViewDate();
         }
 
-        // Re-attach focus events and re-generate semantic description/hint for the new Content instance.
         RegisterForEvents();
         UpdateContentSemantics();
 

--- a/src/UraniumUI.Material/Controls/DatePickerField.cs
+++ b/src/UraniumUI.Material/Controls/DatePickerField.cs
@@ -73,8 +73,11 @@ public class DatePickerField : InputField
         ApplyPickerMode();
     }
 
-    private void ApplyPickerMode()
+    private void ApplyPickerMode
     {
+        // Ensure InputField hooks (focus visuals, semantics) are attached to the currently active content.
+        ReleaseEvents();
+
         if (UseNativePicker)
         {
             DatePickerView.Opacity = 1;
@@ -89,6 +92,10 @@ public class DatePickerField : InputField
             UpdateDateText();
             UpdateDatePickerViewDate();
         }
+
+        // Re-attach focus events and re-generate semantic description/hint for the new Content instance.
+        RegisterForEvents();
+        UpdateContentSemantics();
 
         // Binding refreshes ride on the dispatcher; without one (constructor in unit tests) the swap is picked up when the template binds.
         if (Microsoft.Maui.Dispatching.Dispatcher.GetForCurrentThread() is not null)

--- a/test/UraniumUI.Material.Tests/Controls/DatePickerField_Test.cs
+++ b/test/UraniumUI.Material.Tests/Controls/DatePickerField_Test.cs
@@ -205,7 +205,7 @@ public class DatePickerField_Test
     [Fact]
     public void NativePicker_ShouldCarrySemanticsOfActiveContent()
     {
-        var control = AnimationReadyHandler.Prepare(new DatePickerField());
+        var control = AnimationReadyHandler.Prepare(new DatePickerField { UseNativePicker = true });
 
         control.Title = "Birth date";
 
@@ -503,11 +503,20 @@ public class DatePickerField_Test
     }
 
     [Fact]
-    public void UseNativePicker_IsDefault_AndHidesNativePicker_WhenDateIsNull()
+    public void UseNativePicker_IsFalseByDefault_AndUsesPromptLabel()
     {
         var control = AnimationReadyHandler.Prepare(new DatePickerField());
 
-        control.UseNativePicker.ShouldBeTrue();
+        control.UseNativePicker.ShouldBeFalse();
+        control.Content.ShouldBeOfType<Label>();
+        control.DatePickerView.Opacity.ShouldBe(0);
+    }
+
+    [Fact]
+    public void UseNativePicker_True_EmbedsHiddenNativePicker_WhenDateIsNull()
+    {
+        var control = AnimationReadyHandler.Prepare(new DatePickerField { UseNativePicker = true });
+
         control.Content.ShouldBeSameAs(control.DatePickerView);
         control.Date.ShouldBeNull();
         control.DatePickerView.Opacity.ShouldBe(0);
@@ -529,7 +538,7 @@ public class DatePickerField_Test
     [Fact]
     public void UseNativePicker_Date_FlowsBothWays()
     {
-        var control = AnimationReadyHandler.Prepare(new DatePickerField());
+        var control = AnimationReadyHandler.Prepare(new DatePickerField { UseNativePicker = true });
         AnimationReadyHandler.Prepare(control.DatePickerView);
 
         control.DatePickerView.Opacity.ShouldBe(0);
@@ -551,7 +560,7 @@ public class DatePickerField_Test
     [Fact]
     public void UseNativePicker_Clear_ClearsNativePickerDate()
     {
-        var control = AnimationReadyHandler.Prepare(new TestDatePickerField());
+        var control = AnimationReadyHandler.Prepare(new TestDatePickerField { UseNativePicker = true });
         AnimationReadyHandler.Prepare(control.DatePickerView);
         control.Date = DateTime.Today;
 

--- a/test/UraniumUI.Material.Tests/Controls/DatePickerField_Test.cs
+++ b/test/UraniumUI.Material.Tests/Controls/DatePickerField_Test.cs
@@ -203,6 +203,35 @@ public class DatePickerField_Test
     }
 
     [Fact]
+    public void NativePicker_ShouldCarrySemanticsOfActiveContent()
+    {
+        var control = AnimationReadyHandler.Prepare(new DatePickerField());
+
+        control.Title = "Birth date";
+
+        control.Content.ShouldBe(control.DatePickerView);
+        SemanticProperties.GetHint(control.Content).ShouldBe("Opens the date picker.");
+        SemanticProperties.GetDescription(control.Content).ShouldBe("Birth date");
+    }
+
+    [Fact]
+    public void UseNativePicker_Toggled_ShouldMoveSemanticsToActiveContent()
+    {
+        var control = AnimationReadyHandler.Prepare(new DatePickerField());
+
+        control.Title = "Birth date";
+        control.UseNativePicker = false;
+
+        control.Content.ShouldBeOfType<Label>();
+        SemanticProperties.GetDescription(control.Content).ShouldBe("Birth date");
+
+        control.UseNativePicker = true;
+
+        control.Content.ShouldBe(control.DatePickerView);
+        SemanticProperties.GetDescription(control.Content).ShouldBe("Birth date");
+    }
+
+    [Fact]
     public void Icon_ShouldPreserveDateLabelLeadingMargin()
     {
         var control = AnimationReadyHandler.Prepare(new DatePickerField

--- a/test/UraniumUI.Material.Tests/Controls/DatePickerField_Test.cs
+++ b/test/UraniumUI.Material.Tests/Controls/DatePickerField_Test.cs
@@ -503,13 +503,14 @@ public class DatePickerField_Test
     }
 
     [Fact]
-    public void UseNativePicker_IsDefault_AndEmbedsNativePickerAsContent()
+    public void UseNativePicker_IsDefault_AndHidesNativePicker_WhenDateIsNull()
     {
         var control = AnimationReadyHandler.Prepare(new DatePickerField());
 
         control.UseNativePicker.ShouldBeTrue();
         control.Content.ShouldBeSameAs(control.DatePickerView);
-        control.DatePickerView.Opacity.ShouldBe(1);
+        control.Date.ShouldBeNull();
+        control.DatePickerView.Opacity.ShouldBe(0);
     }
 
     [Fact]
@@ -531,13 +532,20 @@ public class DatePickerField_Test
         var control = AnimationReadyHandler.Prepare(new DatePickerField());
         AnimationReadyHandler.Prepare(control.DatePickerView);
 
+        control.DatePickerView.Opacity.ShouldBe(0);
+
         var picked = DateTime.Today.AddDays(3);
         control.Date = picked;
         control.DatePickerView.Date.ShouldBe(picked);
+        control.DatePickerView.Opacity.ShouldBe(1);
 
         var pickedInView = DateTime.Today.AddDays(5);
         control.DatePickerView.Date = pickedInView;
         control.Date.ShouldBe(pickedInView);
+
+        control.Date = null;
+        control.DatePickerView.Date.ShouldBeNull();
+        control.DatePickerView.Opacity.ShouldBe(0);
     }
 
     [Fact]
@@ -551,6 +559,7 @@ public class DatePickerField_Test
 
         control.Date.ShouldBeNull();
         control.DatePickerView.Date.ShouldBeNull();
+        control.DatePickerView.Opacity.ShouldBe(0);
     }
 
     public class TestViewModel : UraniumBindableObject

--- a/test/UraniumUI.Material.Tests/Controls/DatePickerField_Test.cs
+++ b/test/UraniumUI.Material.Tests/Controls/DatePickerField_Test.cs
@@ -108,7 +108,9 @@ public class DatePickerField_Test
     [Fact]
     public void Clear_ShouldSetDateToNull()
     {
-        var control = AnimationReadyHandler.Prepare(new TestDatePickerField { Date = DateTime.Today });
+        var control = AnimationReadyHandler.Prepare(new TestDatePickerField());
+        AnimationReadyHandler.Prepare(control.DatePickerView);
+        control.Date = DateTime.Today;
 
         // Act
         control.Clear();
@@ -122,7 +124,7 @@ public class DatePickerField_Test
     public void Clear_ShouldResetDatePickerViewDate()
     {
         var fallbackDate = DateTime.Today;
-        var control = AnimationReadyHandler.Prepare(new TestDatePickerField { Date = fallbackDate.AddDays(7) });
+        var control = AnimationReadyHandler.Prepare(new TestDatePickerField { UseNativePicker = false, Date = fallbackDate.AddDays(7) });
 
         // Act
         control.Clear();
@@ -134,7 +136,7 @@ public class DatePickerField_Test
     [Fact]
     public void Date_ShouldUpdateDisplayText()
     {
-        var control = AnimationReadyHandler.Prepare(new DatePickerField());
+        var control = AnimationReadyHandler.Prepare(new DatePickerField { UseNativePicker = false });
         var date = DateTime.Today.AddDays(2);
 
         // Act
@@ -149,6 +151,7 @@ public class DatePickerField_Test
     public void Date_ShouldUpdateDatePickerViewDate()
     {
         var control = AnimationReadyHandler.Prepare(new DatePickerField());
+        AnimationReadyHandler.Prepare(control.DatePickerView);
         var date = DateTime.Today.AddDays(2);
 
         // Act
@@ -161,7 +164,7 @@ public class DatePickerField_Test
     [Fact]
     public void DateLabel_ShouldCenterTextVertically()
     {
-        var control = AnimationReadyHandler.Prepare(new DatePickerField());
+        var control = AnimationReadyHandler.Prepare(new DatePickerField { UseNativePicker = false });
 
         // Assert
         ((Label)control.Content).VerticalTextAlignment.ShouldBe(TextAlignment.Center);
@@ -170,7 +173,7 @@ public class DatePickerField_Test
     [Fact]
     public void DateLabel_ShouldOwnPromptTapGesture()
     {
-        var control = AnimationReadyHandler.Prepare(new DatePickerField());
+        var control = AnimationReadyHandler.Prepare(new DatePickerField { UseNativePicker = false });
         var dateLabel = (Label)control.Content;
 
         // Assert
@@ -194,7 +197,7 @@ public class DatePickerField_Test
     [Fact]
     public void DateLabel_ShouldExposePromptSemanticHint()
     {
-        var control = AnimationReadyHandler.Prepare(new DatePickerField());
+        var control = AnimationReadyHandler.Prepare(new DatePickerField { UseNativePicker = false });
 
         SemanticProperties.GetHint(control.Content).ShouldBe("Opens the date picker.");
     }
@@ -204,6 +207,7 @@ public class DatePickerField_Test
     {
         var control = AnimationReadyHandler.Prepare(new DatePickerField
         {
+            UseNativePicker = false,
             Icon = new FontImageSource
             {
                 FontFamily = "MaterialSharp",
@@ -221,7 +225,7 @@ public class DatePickerField_Test
         var selectedDate = new DateTime(2026, 6, 2);
         dialogService.UseDatePromptResult = true;
         dialogService.DatePromptResult = selectedDate;
-        var control = AnimationReadyHandler.Prepare(new TestDatePickerField());
+        var control = AnimationReadyHandler.Prepare(new TestDatePickerField { UseNativePicker = false });
         control.Title = "Birth Date";
 
         // Act
@@ -241,6 +245,7 @@ public class DatePickerField_Test
         var maximumDate = new DateTime(2026, 12, 31);
         var control = AnimationReadyHandler.Prepare(new TestDatePickerField
         {
+            UseNativePicker = false,
             Date = selectedDate,
             MinimumDate = minimumDate,
             MaximumDate = maximumDate,
@@ -265,7 +270,7 @@ public class DatePickerField_Test
         var dialogService = UseMockDialogService();
         dialogService.UseDatePromptResult = true;
         dialogService.DatePromptResult = null;
-        var control = AnimationReadyHandler.Prepare(new TestDatePickerField { Date = DateTime.Today });
+        var control = AnimationReadyHandler.Prepare(new TestDatePickerField { UseNativePicker = false, Date = DateTime.Today });
 
         // Act
         await control.OpenPromptAsync();
@@ -282,6 +287,7 @@ public class DatePickerField_Test
         var originalDate = DateTime.Today;
         var control = AnimationReadyHandler.Prepare(new TestDatePickerField
         {
+            UseNativePicker = false,
             Date = originalDate,
             IsEnabled = false,
         });
@@ -301,7 +307,7 @@ public class DatePickerField_Test
         var selectedDate = DateTime.Today;
         dialogService.UseDatePromptResult = true;
         dialogService.DatePromptResult = selectedDate;
-        var control = AnimationReadyHandler.Prepare(new TestDatePickerField { Date = selectedDate });
+        var control = AnimationReadyHandler.Prepare(new TestDatePickerField { UseNativePicker = false, Date = selectedDate });
 
         // Act
         control.Clear();
@@ -465,6 +471,58 @@ public class DatePickerField_Test
 
         // Assert
         control.DatePickerView.FontSize.ShouldBe(fontSize);
+    }
+
+
+    [Fact]
+    public void UseNativePicker_IsDefault_AndEmbedsNativePickerAsContent()
+    {
+        var control = AnimationReadyHandler.Prepare(new DatePickerField());
+
+        control.UseNativePicker.ShouldBeTrue();
+        control.Content.ShouldBeSameAs(control.DatePickerView);
+        control.DatePickerView.Opacity.ShouldBe(1);
+    }
+
+    [Fact]
+    public void UseNativePicker_False_RestoresPromptLabel()
+    {
+        var control = AnimationReadyHandler.Prepare(new DatePickerField { UseNativePicker = false });
+        var date = DateTime.Today.AddDays(2);
+
+        control.Date = date;
+
+        control.Content.ShouldBeOfType<Label>();
+        ((Label)control.Content).Text.ShouldBe(date.ToString(control.Format, CultureInfo.CurrentCulture));
+        control.Content.GestureRecognizers.Count.ShouldBe(1);
+    }
+
+    [Fact]
+    public void UseNativePicker_Date_FlowsBothWays()
+    {
+        var control = AnimationReadyHandler.Prepare(new DatePickerField());
+        AnimationReadyHandler.Prepare(control.DatePickerView);
+
+        var picked = DateTime.Today.AddDays(3);
+        control.Date = picked;
+        control.DatePickerView.Date.ShouldBe(picked);
+
+        var pickedInView = DateTime.Today.AddDays(5);
+        control.DatePickerView.Date = pickedInView;
+        control.Date.ShouldBe(pickedInView);
+    }
+
+    [Fact]
+    public void UseNativePicker_Clear_ClearsNativePickerDate()
+    {
+        var control = AnimationReadyHandler.Prepare(new TestDatePickerField());
+        AnimationReadyHandler.Prepare(control.DatePickerView);
+        control.Date = DateTime.Today;
+
+        control.Clear();
+
+        control.Date.ShouldBeNull();
+        control.DatePickerView.Date.ShouldBeNull();
     }
 
     public class TestViewModel : UraniumBindableObject

--- a/test/UraniumUI.Material.Tests/Controls/DatePickerField_Test.cs
+++ b/test/UraniumUI.Material.Tests/Controls/DatePickerField_Test.cs
@@ -1,4 +1,4 @@
-﻿using Shouldly;
+using Shouldly;
 using UraniumUI.Material.Controls;
 using UraniumUI.Material.Tests.Mocks;
 using UraniumUI.Dialogs;
@@ -472,7 +472,6 @@ public class DatePickerField_Test
         // Assert
         control.DatePickerView.FontSize.ShouldBe(fontSize);
     }
-
 
     [Fact]
     public void UseNativePicker_IsDefault_AndEmbedsNativePickerAsContent()


### PR DESCRIPTION
Closes #1109.

Adds UseNativePicker to DatePickerField while preserving the existing CalendarView prompt as the default behavior.

- Prompt mode (default; UseNativePicker=False): keeps the v3 label and calendar prompt behavior.
- Native mode (UseNativePicker=True): DatePickerView becomes the field content with a two-way Date binding.
- The native picker is visually hidden while Date is null so it does not overlap the centered title; it becomes visible after a date is selected and hides again when cleared.
- DatePickerView fallback writes are skipped in native mode so they cannot fight a pending null value.
- Label formatting targets the prompt label directly, so changes made while native mode is active are retained when switching back.
- Content focus hooks and semantics are refreshed when the picker mode changes.
- Documentation and tests cover the default prompt mode, native opt-in, two-way date flow, and clear-to-null behavior.